### PR TITLE
fix: query now includes leading `?` when passed to Cloud API

### DIFF
--- a/src/arcjet/context.py
+++ b/src/arcjet/context.py
@@ -290,7 +290,10 @@ def request_details_from_context(ctx: RequestContext) -> decide_pb2.RequestDetai
     if ctx.cookies:
         d.cookies = ctx.cookies
     if ctx.query:
-        d.query = ctx.query
+        # Decide API expects leading "?" on query string while RequestContext
+        # explicitly excludes it. We add it here if missing in an abundance of
+        # caution.
+        d.query = f"?{ctx.query}" if not ctx.query.startswith("?") else ctx.query
     if ctx.body is not None:
         d.body = ctx.body
     if ctx.email:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -63,3 +63,21 @@ def test_request_details_from_context_normalizes_headers_and_extra():
     assert d.ip == "203.0.113.6"
     assert d.headers["x-foo"] == "Bar"
     assert d.extra["k"] == "v"
+
+def test_request_details_from_context_normalizes_query_string():
+    """
+    Decide server expects query string to include the leading '?' while
+    RequestContext explicitly excludes it from the `query` field.
+    """
+
+    ctx = RequestContext(
+        ip="203.0.113.6",
+        method="GET",
+        protocol="https",
+        host="ex",
+        path="/p",
+        query="a=1&b=2",
+    )
+    d = request_details_from_context(ctx)
+    assert d.ip == "203.0.113.6"
+    assert d.query == "?a=1&b=2"


### PR DESCRIPTION
Fixes #4. Added a test that was previously failing. This also resolves the observed error in both the Flask & FastAPI examples when a query parameter was included in the url.

I don't have any authoritative source (yet) that the server expects the leading `?` to be included, but I'll see if I can track one down.