### PR TITLE
chore: bump to v0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcjet"
-version = "0.2.1"
+version = "0.2.2"
 description = "Arcjet Python SDK. Bot detection, rate limiting, email validation, attack protection for Python applications."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "arcjet"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "connect-python" },


### PR DESCRIPTION
Bump version and workflow configured with required reviewers so we can add the same protection to the release workflow that we just added to the JS SDK in https://github.com/arcjet/arcjet-js/pull/5578