### PR TITLE
chore(tests): expand IP parsing test coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ uvx griffe check arcjet -s src --against main
 2. Bump the version using `uv version --bump` e.g. `uv version --bump patch`.
 3. Commit and push the changes to GitHub, then open a PR.
 4. Once merged to `main`, create a new Git tag with the new version e.g. `git tag -a v0.1.0 -m v0.1.0`
-4. Push the tag to GitHub e.g. `git push --tags`
-5. The release workflow will be triggered automatically and must be approved by another member of the team.
-6. Once approved, the package will be pushed to PyPI
-7. Create a new release in GitHub and link the release to the newly created tag.
+5. Push the tag to GitHub e.g. `git push --tags`
+6. The release workflow will be triggered automatically and must be approved by another member of the team.
+7. Once approved, the package will be pushed to PyPI
+8. Create a new release in GitHub and link the release to the newly created tag.

--- a/tests/mocked/test_context.py
+++ b/tests/mocked/test_context.py
@@ -8,18 +8,88 @@ from arcjet.context import (
 )
 
 
-def test_extract_ip_various_headers_and_dev_override(monkeypatch):
-    # In development, X-Arcjet-Ip override wins
-    headers = {"X-Arcjet-Ip": "10.0.0.1"}
-    ip = extract_ip_from_headers(headers)
-    assert ip == "10.0.0.1"
+import pytest
 
-    # Global/public IP selection from x-forwarded-for (last trusted non-proxy)
-    headers = {
-        "x-forwarded-for": "10.0.0.2, 192.168.0.1, 8.8.8.8",
-    }
-    ip = extract_ip_from_headers(headers, proxies=["10.0.0.0/8", "192.168.0.0/16"])
-    assert ip == "8.8.8.8"
+
+def test_extract_ip_xff_skips_trusted_proxy_literal():
+    headers = {"x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3"}
+    assert extract_ip_from_headers(headers, proxies=["3.3.3.3"]) == "2.2.2.2"
+
+
+def test_extract_ip_xff_skips_trusted_proxy_cidr():
+    headers = {"x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3"}
+    assert extract_ip_from_headers(headers, proxies=["3.3.3.3/32"]) == "2.2.2.2"
+
+
+def test_extract_ip_xff_skips_multiple_trusted_proxies():
+    headers = {"x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3"}
+    assert extract_ip_from_headers(headers, proxies=["3.3.3.3", "2.2.2.2"]) == "1.1.1.1"
+
+
+def test_extract_ip_xff_ignores_invalid_proxy_entries():
+    headers = {"x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3"}
+    assert extract_ip_from_headers(headers, proxies=[1234]) == "3.3.3.3"  # type: ignore
+
+
+def test_extract_ip_dev_override_wins(monkeypatch):
+    headers = {"X-Arcjet-Ip": "10.0.0.1"}
+    assert extract_ip_from_headers(headers) == "10.0.0.1"
+
+
+def test_extract_ip_xff_picks_rightmost_global_ip():
+    headers = {"x-forwarded-for": "9.9.9.9, 8.8.8.8"}
+    assert extract_ip_from_headers(headers) == "8.8.8.8"
+
+
+def test_extract_ip_xff_picks_rightmost_global_minus_trusted_proxies():
+    headers = {"x-forwarded-for": "8.8.8.8, 192.168.0.1, 10.0.0.2"}
+    # No trusted proxies => rightmost global is 8.8.8.8 (since others are private anyway)
+    assert extract_ip_from_headers(headers) == "8.8.8.8"
+
+
+def test_extract_ip_xff_skips_trailing_private_then_uses_previous_global():
+    headers = {"x-forwarded-for": "1.1.1.1, 2.2.2.2, 127.0.0.1"}
+    assert extract_ip_from_headers(headers) == "2.2.2.2"
+
+
+def test_extract_ip_xff_all_trusted_returns_none():
+    headers = {"x-forwarded-for": "192.168.0.1, 10.0.0.2"}
+    ip = extract_ip_from_headers(
+        headers,
+        proxies=["10.0.0.0/8", "192.168.0.0/16"],
+    )
+    assert ip is None
+
+
+def test_extract_ip_xff_ipv4_with_port_is_returned_without_port():
+    headers = {"x-forwarded-for": "1.1.1.1:443"}
+    assert extract_ip_from_headers(headers) == "1.1.1.1"
+
+
+def test_extract_ip_xff_ported_ipv4_is_matched_by_cidr_proxy():
+    headers = {"x-forwarded-for": "9.9.9.9, 1.1.1.1:443"}
+    assert extract_ip_from_headers(headers, proxies=["1.1.1.1/32"]) == "9.9.9.9"
+
+
+def test_extract_ip_xff_ignores_junk_and_whitespace():
+    headers = {"x-forwarded-for": "  , 8.8.8.8 , garbage , 192.168.0.1 "}
+    assert (
+        extract_ip_from_headers(
+            headers,
+            proxies=["192.168.0.0/16"],
+        )
+        == "8.8.8.8"
+    )
+
+
+def test_extract_ip_rejects_shared_address_space_100_64_0_0_10():
+    headers = {"x-forwarded-for": "1.1.1.1, 100.64.0.1"}
+    assert extract_ip_from_headers(headers) == "1.1.1.1"
+
+
+def test_extract_ip_rejects_benchmarking_198_18_0_0_15():
+    headers = {"x-forwarded-for": "1.1.1.1, 198.18.0.1"}
+    assert extract_ip_from_headers(headers) == "1.1.1.1"
 
 
 def test_coerce_asgi_scope_and_plain_mapping(monkeypatch):
@@ -63,6 +133,7 @@ def test_request_details_from_context_normalizes_headers_and_extra():
     assert d.ip == "203.0.113.6"
     assert d.headers["x-foo"] == "Bar"
     assert d.extra["k"] == "v"
+
 
 def test_request_details_from_context_normalizes_query_string():
     """


### PR DESCRIPTION
Increase test cases around IP parsing to improve reliability and parity with JS SDK + [ADR](https://github.com/arcjet/arcjet/pull/6780).