### PR TITLE
chore: Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,6 @@ __marimo__/
 
 # Internal planning documents
 docs/plans/
+
+# local Claude settings (permissions, etc. per user)
+.claude/


### PR DESCRIPTION
## Summary
- Adds `.claude/` directory to `.gitignore` so local Claude Code settings (permissions, configuration) are not committed per-user.

## Test plan
- [x] Verify `.claude/` directory is ignored by git after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)