### PR TITLE
docs: Refresh READMEs and code comments for guards release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,55 @@
 
 [Arcjet](https://arcjet.com) is the runtime security platform that ships with your AI code. Stop bots and automated attacks from burning your AI budget, leaking data, or misusing tools with Arcjet's AI security building blocks.
 
-This is the Python SDK for [Arcjet](https://arcjet.com).
+This is the Python SDK for [Arcjet](https://arcjet.com) — use `arcjet` /
+`arcjet_sync` for **request protection** (FastAPI, Flask, Django route handlers)
+and `arcjet.guard` for **guard protection** (AI agent tool calls, MCP servers,
+background jobs).
 
 ## Getting started
 
-1. **Get your API key** — [sign up at `app.arcjet.com`](https://app.arcjet.com).
-2. **Install the SDK:**
+### Install the Arcjet CLI
 
-```shell
-pip install arcjet
-# or with uv
-uv add arcjet
-```
+The CLI is used to log in, manage site keys, and install protection skills.
 
-3. **Set your environment variable:**
+**Homebrew (macOS and Linux):**
 
 ```sh
-# .env or .env.local
-ARCJET_KEY=ajkey_yourkey
+brew install arcjet/tap/arcjet
 ```
 
-4. **Protect a route** — see the [AI protection example](#quick-start) or
+**npx (Node.js):**
+
+```sh
+npx @arcjet/cli
+```
+
+**Or [download a binary](https://github.com/arcjet/arcjet-cli/releases)** for
+macOS (Apple Silicon, Intel), Linux (x86_64, arm64), and Windows (x86_64,
+arm64).
+
+### Quick setup with an AI agent
+
+1. Log in with the CLI:
+   ```sh
+   arcjet auth login
+   ```
+2. Install the protection skill:
+   ```sh
+   npx skills add arcjet/skills --skill add-request-protection
+   ```
+   For guard protection: `--skill add-guard-protection`
+3. Tell your agent what to protect — it handles the rest.
+
+### Manual setup
+
+1. **Log in** with the CLI (or at [`app.arcjet.com`](https://app.arcjet.com)):
+   ```sh
+   arcjet auth login
+   ```
+2. `pip install arcjet` (or `uv add arcjet`)
+3. Set `ARCJET_KEY=ajkey_yourkey` in `.env`
+4. Protect a route — see the [AI protection example](#quick-start) or
    individual [feature examples](#features) below.
 
 ### Get help
@@ -81,7 +109,7 @@ app = FastAPI()
 arcjet_key = os.getenv("ARCJET_KEY")
 if not arcjet_key:
     raise RuntimeError(
-        "ARCJET_KEY is required. Get one at https://app.arcjet.com"
+        "ARCJET_KEY is required. Get one with: arcjet sites get-key"
     )
 
 # Create a single Arcjet instance and reuse it across requests.
@@ -144,6 +172,18 @@ async def chat(request: Request, body: ChatRequest):
 ```
 
 ## Features
+
+| Feature | Request (`arcjet`) | Guard (`arcjet.guard`) |
+| --- | :---: | :---: |
+| Rate Limiting | ✅ | ✅ |
+| Prompt Injection Detection | ✅ | ✅ |
+| Sensitive Information Detection | ✅ | ✅ |
+| Bot Protection | ✅ | — |
+| Shield WAF | ✅ | — |
+| Email Validation | ✅ | — |
+| Request Filters | ✅ | — |
+| IP Analysis | ✅ | — |
+| Custom Rules | — | ✅ |
 
 - 🔒 [Prompt Injection Detection](#prompt-injection-detection) — detect and block
   prompt injection attacks before they reach your LLM.

--- a/examples/fastapi-langchain/main.py
+++ b/examples/fastapi-langchain/main.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 arcjet_key = os.getenv("ARCJET_KEY")
 if not arcjet_key:
-    raise RuntimeError("ARCJET_KEY is required. Get one at https://app.arcjet.com")
+    raise RuntimeError("ARCJET_KEY is required. Get one with: arcjet sites get-key")
 
 openai_api_key = os.getenv("OPENAI_API_KEY")
 if not openai_api_key:
@@ -50,7 +50,7 @@ class ChatRequest(BaseModel):
 
 
 aj = arcjet(
-    key=arcjet_key,  # Get your key from https://app.arcjet.com
+    key=arcjet_key,  # Get your key with: arcjet sites get-key
     rules=[
         # Shield protects your app from common attacks e.g. SQL injection
         shield(mode=Mode.LIVE),

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -22,10 +22,10 @@ logger = logging.getLogger(__name__)
 
 arcjet_key = os.getenv("ARCJET_KEY")
 if not arcjet_key:
-    raise RuntimeError("ARCJET_KEY is required. Get one at https://app.arcjet.com")
+    raise RuntimeError("ARCJET_KEY is required. Get one with: arcjet sites get-key")
 
 aj = arcjet(
-    key=arcjet_key,  # Get your key from https://app.arcjet.com
+    key=arcjet_key,  # Get your key with: arcjet sites get-key
     rules=[
         # Shield protects your app from common attacks e.g. SQL injection
         shield(mode=Mode.LIVE),

--- a/examples/flask-langchain/main.py
+++ b/examples/flask-langchain/main.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 arcjet_key = os.getenv("ARCJET_KEY")
 if not arcjet_key:
-    raise RuntimeError("ARCJET_KEY is required. Get one at https://app.arcjet.com")
+    raise RuntimeError("ARCJET_KEY is required. Get one with: arcjet sites get-key")
 
 openai_api_key = os.getenv("OPENAI_API_KEY")
 if not openai_api_key:
@@ -43,7 +43,7 @@ prompt = ChatPromptTemplate.from_messages(
 chain = prompt | llm | StrOutputParser()
 
 aj = arcjet_sync(
-    key=arcjet_key,  # Get your key from https://app.arcjet.com
+    key=arcjet_key,  # Get your key with: arcjet sites get-key
     rules=[
         # Shield protects your app from common attacks e.g. SQL injection
         shield(mode=Mode.LIVE),

--- a/examples/flask/main.py
+++ b/examples/flask/main.py
@@ -19,10 +19,10 @@ app = Flask(__name__)
 
 arcjet_key = os.getenv("ARCJET_KEY")
 if not arcjet_key:
-    raise RuntimeError("ARCJET_KEY is required. Get one at https://app.arcjet.com")
+    raise RuntimeError("ARCJET_KEY is required. Get one with: arcjet sites get-key")
 
 aj = arcjet_sync(
-    key=arcjet_key,  # Get your key from https://app.arcjet.com
+    key=arcjet_key,  # Get your key with: arcjet sites get-key
     rules=[
         # Shield protects your app from common attacks e.g. SQL injection
         shield(mode=Mode.LIVE),

--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -356,10 +356,10 @@ class Arcjet:
         arcjet_key = os.getenv("ARCJET_KEY")
         if not arcjet_key:
             raise RuntimeError(
-                "ARCJET_KEY is required. Get one at https://app.arcjet.com")
+                "ARCJET_KEY is required. Get one with: arcjet sites get-key")
 
         aj = arcjet(
-            key=arcjet_key,  # Get your key from https://app.arcjet.com
+            key=arcjet_key,  # Get your key with: arcjet sites get-key
             rules=[
                 # Shield protects your app from common attacks e.g. SQL injection
                 shield(mode=Mode.LIVE),
@@ -874,10 +874,10 @@ class ArcjetSync:
         arcjet_key = os.getenv("ARCJET_KEY")
         if not arcjet_key:
             raise RuntimeError(
-                "ARCJET_KEY is required. Get one at https://app.arcjet.com")
+                "ARCJET_KEY is required. Get one with: arcjet sites get-key")
 
         aj = arcjet_sync(
-            key=arcjet_key,  # Get your key from https://app.arcjet.com
+            key=arcjet_key,  # Get your key with: arcjet sites get-key
             rules=[
                 # Shield protects your app from common attacks e.g. SQL injection
                 shield(mode=Mode.LIVE),
@@ -1321,8 +1321,9 @@ def arcjet(
     """Create an async Arcjet client.
 
     Args:
-        key: Your Arcjet site key from https://app.arcjet.com. Keep this
-            secret — store it in an environment variable, never in source code.
+        key: Your Arcjet site key. Get one with ``arcjet sites get-key``
+            or at https://app.arcjet.com. Keep this secret — store it in an
+            environment variable, never in source code.
         rules: One or more rule specs created by ``shield()``, ``detect_bot()``,
             ``token_bucket()``, ``fixed_window()``, ``sliding_window()``, or
             ``validate_email()``.
@@ -1371,10 +1372,10 @@ def arcjet(
         arcjet_key = os.getenv("ARCJET_KEY")
         if not arcjet_key:
             raise RuntimeError(
-                "ARCJET_KEY is required. Get one at https://app.arcjet.com")
+                "ARCJET_KEY is required. Get one with: arcjet sites get-key")
 
         aj = arcjet(
-            key=arcjet_key,  # Get your key from https://app.arcjet.com
+            key=arcjet_key,  # Get your key with: arcjet sites get-key
             rules=[
                 # Shield protects your app from common attacks e.g. SQL injection
                 shield(mode=Mode.LIVE),
@@ -1444,8 +1445,9 @@ def arcjet_sync(
     not support ``async/await`` such as Flask or Django.
 
     Args:
-        key: Your Arcjet site key from https://app.arcjet.com. Keep this
-            secret — store it in an environment variable, never in source code.
+        key: Your Arcjet site key. Get one with ``arcjet sites get-key``
+            or at https://app.arcjet.com. Keep this secret — store it in an
+            environment variable, never in source code.
         rules: One or more rule specs created by ``shield()``, ``detect_bot()``,
             ``token_bucket()``, ``fixed_window()``, ``sliding_window()``, or
             ``validate_email()``.
@@ -1494,10 +1496,10 @@ def arcjet_sync(
         arcjet_key = os.getenv("ARCJET_KEY")
         if not arcjet_key:
             raise RuntimeError(
-                "ARCJET_KEY is required. Get one at https://app.arcjet.com")
+                "ARCJET_KEY is required. Get one with: arcjet sites get-key")
 
         aj = arcjet_sync(
-            key=arcjet_key,  # Get your key from https://app.arcjet.com
+            key=arcjet_key,  # Get your key with: arcjet sites get-key
             rules=[
                 # Shield protects your app from common attacks e.g. SQL injection
                 shield(mode=Mode.LIVE),


### PR DESCRIPTION
- Update intro to describe request protection (arcjet/arcjet_sync) vs guard protection (arcjet.guard)
- Add CLI install section with Homebrew, npx, and binary download paths
- Restructure getting started into AI agent and manual setup flows
- Add feature availability table (request vs guard)
- Update all 'Get one at app.arcjet.com' references to use 'arcjet sites get-key' CLI command across README, _client.py, and all example apps

Closes ENG-733