### PR TITLE
chore(ci): add workflow lint gate (actionlint + zizmor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Fetch base branch for griffe comparison
         if: github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch origin "$BASE_REF"
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - name: Ruff lint
         run: uv run ruff check . --output-format github
@@ -38,7 +42,9 @@ jobs:
         # Only run on PRs and allow breaking changes to be merged with a label
         if: github.event_name == 'pull_request'
         continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'breaking') }}
-        run: uv run griffe check arcjet --search src --format github --against origin/${{ github.event.pull_request.base.ref }}
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: uv run griffe check arcjet --search src --format github --against "origin/${BASE_REF}"
 
 
   test:
@@ -49,6 +55,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - name: Tests
         run: uv run pytest

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,48 @@
+name: Lint workflows
+
+on:
+  pull_request:
+    # Recommended by Graphite: https://graphite.dev/docs/github-configuration-guidelines#github-actions
+    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/**
+  merge_group:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: actionlint + zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # actionlint runs from the upstream image pinned by tag. The container
+      # only reads workflow YAML, so it never sees repo credentials.
+      - name: actionlint
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: false
+
+      # Gates on medium-and-above findings (all confidence levels).
+      # Drop --min-severity entirely once low-severity findings are triaged.
+      - name: zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uvx zizmor==1.24.1 --min-severity=medium .github/workflows/

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -29,16 +29,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # actionlint runs from the upstream image pinned by tag. The container
-      # only reads workflow YAML, so it never sees repo credentials.
       - name: actionlint
-        uses: docker://rhysd/actionlint:1.7.12
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # 1.7.12
         with:
           args: -color
 
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-        with:
-          enable-cache: false
 
       # Gates on medium-and-above findings (all confidence levels).
       # Drop --min-severity entirely once low-severity findings are triaged.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: false
       - name: Install Python 3.10
         run: uv python install 3.10
       - name: Build


### PR DESCRIPTION
## Summary

- Add a static-analysis gate over `.github/workflows/` so future workflow changes get validated before they hit GitHub. New `lint-workflows.yml` runs `actionlint` (pinned `rhysd/actionlint:1.7.12`) and `zizmor` (`uvx zizmor==1.24.1`) on workflow-path changes, gating on actionlint failures and medium-and-above zizmor findings.
- Clear the pre-existing zizmor findings so the gate can land green:
  - **artipacked (3)** — added `persist-credentials: false` to every `actions/checkout` (both jobs in `ci.yml`, the publish job in `release.yml`).
  - **template-injection (2)** — env-mapped `${{ github.event.pull_request.base.ref }}` to `BASE_REF` in the `git fetch` and `griffe check` `run` blocks.
  - **cache-poisoning (1)** — set `enable-cache: false` on `setup-uv` in `release.yml` since that workflow only runs on `v*` tags and publishes to PyPI.

## Approach notes

This mirrors arcjet/arcjet#7978, scaled down for this repo. Differences worth flagging:

- No `dev/mise.toml` here. actionlint is pinned via Docker image tag; zizmor is pinned via `uvx zizmor==1.24.1`. Swapping to mise (or pinning the actionlint image by `sha256:` digest) is a one-line follow-up.
- No `reusable-path-checker.yml` exists here, so the workflow uses `paths:` filters directly. `merge_group` runs unfiltered so the required check still reports through the merge queue. If you want a stable required-check name on PRs that don't touch workflow files, we'd add the path-checker + coordinator pattern from the parent PR.
- Below-medium findings (4 suppressed, low/informational) are not gated and remain in the report. Tightening to `--min-severity=low` is a follow-up once those are triaged.

## Risk notes

- `enable-cache: false` on `setup-uv` in `release.yml` means the release-only build no longer reuses uv's cache. Trade-off is intentional (cache-poisoning surface on a tag-publish workflow > a few seconds of build time).
- First lint-workflow run after merge is the one to watch — if any workflow change reintroduces a finding, the gate will block.

## Test plan

- [ ] `Lint workflows` job is green on this PR
- [ ] `Test` workflow (ci.yml) still passes after the `persist-credentials: false` / `BASE_REF` changes
- [ ] Verify `release.yml` works on the next tag (release-only, can't dry-run in PR CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)