### PR TITLE
feat: accept `environment=` kwarg on `arcjet()` / `arcjet_sync()`

### DIFF
--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -39,6 +39,7 @@ from arcjet.proto.decide.v1alpha1.decide_connect import (
 from ._cache import DecisionCache, make_cache_key
 from ._context import (
     RequestContext,
+    _is_development,
     coerce_request_context,
     request_details_from_context,
 )
@@ -151,10 +152,11 @@ class ProtectOptions(TypedDict, total=False):
     """Arbitrary key/value pairs forwarded verbatim to the Arcjet Decide API."""
 
 
-def _default_timeout_ms(rules: Sequence[RuleSpec] = ()) -> int:
+def _default_timeout_ms(
+    rules: Sequence[RuleSpec] = (), environment: str | None = None
+) -> int:
     # 1000ms in development, 500ms otherwise.
-    env = (os.getenv("ARCJET_ENV") or "production").lower()
-    default = 1000 if env == "development" else 500
+    default = 1000 if _is_development(environment=environment) else 500
     # detect_prompt_injection defines its latency guarantees individually
     # rather than as part of the protect call, so enforce a 1 second minimum.
     if any(isinstance(r, PromptInjectionDetection) for r in rules):
@@ -427,6 +429,7 @@ class Arcjet:
     _proxies: tuple[str, ...] = ()
     _disable_automatic_ip_detection: bool = False
     _cache: DecisionCache = field(default_factory=DecisionCache)
+    _environment: str | None = None
 
     async def protect(
         self,
@@ -509,7 +512,12 @@ class Arcjet:
             raise ArcjetMisconfiguration(
                 "ip_src cannot be set when disable_automatic_ip_detection=False."
             )
-        ctx = coerce_request_context(request, proxies=self._proxies, ip_src=ip_src)
+        ctx = coerce_request_context(
+            request,
+            proxies=self._proxies,
+            ip_src=ip_src,
+            environment=self._environment,
+        )
 
         if email:
             ctx = replace(ctx, email=email)
@@ -946,6 +954,7 @@ class ArcjetSync:
     _proxies: tuple[str, ...] = ()
     _disable_automatic_ip_detection: bool = False
     _cache: DecisionCache = field(default_factory=DecisionCache)
+    _environment: str | None = None
 
     def protect(
         self,
@@ -985,7 +994,12 @@ class ArcjetSync:
             raise ArcjetMisconfiguration(
                 "ip_src cannot be set when disable_automatic_ip_detection=False."
             )
-        ctx = coerce_request_context(request, proxies=self._proxies, ip_src=ip_src)
+        ctx = coerce_request_context(
+            request,
+            proxies=self._proxies,
+            ip_src=ip_src,
+            environment=self._environment,
+        )
 
         if email:
             ctx = replace(ctx, email=email)
@@ -1339,6 +1353,7 @@ def arcjet(
     fail_open: bool = True,
     proxies: Sequence[str] = (),
     disable_automatic_ip_detection: bool = False,
+    environment: str | None = None,
 ) -> Arcjet:
     """Create an async Arcjet client.
 
@@ -1372,6 +1387,14 @@ def arcjet(
             yourself via ``ip_src`` on each ``protect()`` call. Only use this
             when you have your own validated IP-extraction logic. See
             https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For.
+        environment: Environment mode (``"development"`` or ``"production"``).
+            When ``None`` (default), falls back to the ``ARCJET_ENV``
+            environment variable. Set this explicitly when using a config
+            library such as ``pydantic-settings`` that loads ``.env`` files
+            into a typed settings object without propagating values to
+            ``os.environ``::
+
+                aj = arcjet(environment=settings.ARCJET_ENV, key=..., rules=[...])
 
     Returns:
         An ``Arcjet`` async client instance.
@@ -1439,13 +1462,18 @@ def arcjet(
         _client=client,
         _sdk_stack=stack,
         _sdk_version=_sdk_version() if sdk_version is None else sdk_version,
-        _timeout_ms=_default_timeout_ms(rules) if timeout_ms is None else timeout_ms,
+        _timeout_ms=(
+            _default_timeout_ms(rules, environment=environment)
+            if timeout_ms is None
+            else timeout_ms
+        ),
         _fail_open=fail_open,
         _needs_email=any(isinstance(r, EmailValidation) for r in rules),
         _needs_message=any(isinstance(r, PromptInjectionDetection) for r in rules),
         _has_token_bucket=any(isinstance(r, TokenBucket) for r in rules),
         _proxies=tuple(proxies),
         _disable_automatic_ip_detection=disable_automatic_ip_detection,
+        _environment=environment,
     )
 
 
@@ -1461,6 +1489,7 @@ def arcjet_sync(
     fail_open: bool = True,
     proxies: Sequence[str] = (),
     disable_automatic_ip_detection: bool = False,
+    environment: str | None = None,
 ) -> ArcjetSync:
     """Create a sync Arcjet client.
 
@@ -1497,6 +1526,14 @@ def arcjet_sync(
             yourself via ``ip_src`` on each ``protect()`` call. Only use this
             when you have your own validated IP-extraction logic. See
             https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For.
+        environment: Environment mode (``"development"`` or ``"production"``).
+            When ``None`` (default), falls back to the ``ARCJET_ENV``
+            environment variable. Set this explicitly when using a config
+            library such as ``pydantic-settings`` that loads ``.env`` files
+            into a typed settings object without propagating values to
+            ``os.environ``::
+
+                aj = arcjet_sync(environment=settings.ARCJET_ENV, key=..., rules=[...])
 
     Returns:
         An ``ArcjetSync`` sync client instance.
@@ -1565,11 +1602,16 @@ def arcjet_sync(
         _client=client,
         _sdk_stack=stack,
         _sdk_version=_sdk_version() if sdk_version is None else sdk_version,
-        _timeout_ms=_default_timeout_ms(rules) if timeout_ms is None else timeout_ms,
+        _timeout_ms=(
+            _default_timeout_ms(rules, environment=environment)
+            if timeout_ms is None
+            else timeout_ms
+        ),
         _fail_open=fail_open,
         _needs_email=any(isinstance(r, EmailValidation) for r in rules),
         _needs_message=any(isinstance(r, PromptInjectionDetection) for r in rules),
         _has_token_bucket=any(isinstance(r, TokenBucket) for r in rules),
         _proxies=tuple(proxies),
         _disable_automatic_ip_detection=disable_automatic_ip_detection,
+        _environment=environment,
     )

--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -1394,7 +1394,7 @@ def arcjet(
             into a typed settings object without propagating values to
             ``os.environ``::
 
-                aj = arcjet(environment=settings.ARCJET_ENV, key=..., rules=[...])
+                aj = arcjet(key=..., rules=[...], environment=settings.ARCJET_ENV)
 
     Returns:
         An ``Arcjet`` async client instance.
@@ -1463,7 +1463,7 @@ def arcjet(
         _sdk_stack=stack,
         _sdk_version=_sdk_version() if sdk_version is None else sdk_version,
         _timeout_ms=(
-            _default_timeout_ms(rules, environment=environment)
+            _default_timeout_ms(rules=rules, environment=environment)
             if timeout_ms is None
             else timeout_ms
         ),
@@ -1533,7 +1533,7 @@ def arcjet_sync(
             into a typed settings object without propagating values to
             ``os.environ``::
 
-                aj = arcjet_sync(environment=settings.ARCJET_ENV, key=..., rules=[...])
+                aj = arcjet_sync(key=..., rules=[...], environment=settings.ARCJET_ENV)
 
     Returns:
         An ``ArcjetSync`` sync client instance.
@@ -1603,7 +1603,7 @@ def arcjet_sync(
         _sdk_stack=stack,
         _sdk_version=_sdk_version() if sdk_version is None else sdk_version,
         _timeout_ms=(
-            _default_timeout_ms(rules, environment=environment)
+            _default_timeout_ms(rules=rules, environment=environment)
             if timeout_ms is None
             else timeout_ms
         ),

--- a/src/arcjet/_context.py
+++ b/src/arcjet/_context.py
@@ -20,7 +20,9 @@ Environment behavior:
 - For frameworks whose config library does not propagate `.env` values into
     `os.environ` (e.g. `pydantic-settings`), pass `environment=` explicitly to
     `coerce_request_context` / `extract_ip_from_headers` to override the
-    env-var read.
+    env-var read. End users typically set this once via the
+    `arcjet(environment=...)` / `arcjet_sync(environment=...)` factory kwarg,
+    which threads the value through to these helpers automatically.
 """
 
 from __future__ import annotations

--- a/src/arcjet/_context.py
+++ b/src/arcjet/_context.py
@@ -17,6 +17,10 @@ Key pieces:
 Environment behavior:
 - If `ARCJET_ENV=development`, a missing IP is defaulted to `127.0.0.1` and the
     header `X-Arcjet-Ip` may be used to force an IP for local testing.
+- For frameworks whose config library does not propagate `.env` values into
+    `os.environ` (e.g. `pydantic-settings`), pass `environment=` explicitly to
+    `coerce_request_context` / `extract_ip_from_headers` to override the
+    env-var read.
 """
 
 from __future__ import annotations
@@ -31,14 +35,19 @@ from arcjet.proto.decide.v1alpha1 import decide_pb2
 HeaderValue = str | Sequence[str]
 
 
-def _is_development() -> bool:
+def _is_development(environment: str | None = None) -> bool:
     """Return True when running in development mode.
 
-    We consider the environment to be development when `ARCJET_ENV` is set to
-    "development" (case-insensitive). Defaults to production otherwise.
+    Args:
+        environment: Explicit environment string, e.g. from a framework
+            Settings object. When ``None`` (default), falls back to the
+            ``ARCJET_ENV`` environment variable. Matching is case-insensitive;
+            anything other than "development" (or unset/empty) is treated as
+            production.
     """
-    env = (os.getenv("ARCJET_ENV") or "production").lower()
-    return env == "development"
+    if environment is None:
+        environment = os.getenv("ARCJET_ENV")
+    return (environment or "production").lower() == "development"
 
 
 @dataclass(frozen=True, slots=True)
@@ -239,14 +248,20 @@ def extract_ip_from_headers(
     headers: Mapping[str, HeaderValue],
     *,
     proxies: Sequence[str] | None = None,
+    environment: str | None = None,
 ) -> str | None:
     """
     Extract a likely client IP from headers with validation and trusted proxies.
+
+    When ``environment`` is supplied, it overrides ``ARCJET_ENV`` for the
+    development-mode gating of the ``X-Arcjet-Ip`` override. Pass this when
+    using a config library that does not propagate ``.env`` values into
+    ``os.environ`` (e.g. ``pydantic-settings``).
     """
     proxy_nets = _parse_proxies(proxies)
 
     # In development only, allow override for testing.
-    if _is_development():
+    if _is_development(environment=environment):
         xaj = _first_header(headers, "x-arcjet-ip")
         if xaj:
             # In development, accept any override to ease local testing.
@@ -319,6 +334,7 @@ def coerce_request_context(
     *,
     proxies: Sequence[str] | None = None,
     ip_src: str | None = None,
+    environment: str | None = None,
 ) -> RequestContext:
     """Best-effort coercion from common request objects.
 
@@ -333,6 +349,9 @@ def coerce_request_context(
         cookies, query string, and body.
 
     In development, if no IP can be determined, defaults to `127.0.0.1`.
+    When ``environment`` is supplied, it overrides ``ARCJET_ENV`` for the
+    development-mode check; pass this when using a config library that does
+    not propagate ``.env`` values into ``os.environ`` (e.g. ``pydantic-settings``).
     Raises `TypeError` for unsupported shapes.
     """
     if isinstance(req, RequestContext):
@@ -361,8 +380,10 @@ def coerce_request_context(
                     # Prefer the direct remote address when it's global and not a trusted proxy.
                     if _is_global_public_ip(client[0], _parse_proxies(proxies)):
                         ip = client[0]
-                ip = ip or extract_ip_from_headers(headers, proxies=proxies)
-                if not ip and _is_development():
+                ip = ip or extract_ip_from_headers(
+                    headers, proxies=proxies, environment=environment
+                )
+                if not ip and _is_development(environment=environment):
                     ip = "127.0.0.1"
             else:
                 ip = ip_src
@@ -407,8 +428,10 @@ def coerce_request_context(
         if not ip_src:
             if _is_global_public_ip(remote, _parse_proxies(proxies)):
                 ip = remote
-            ip = ip or extract_ip_from_headers(headers, proxies=proxies)
-            if not ip and _is_development():
+            ip = ip or extract_ip_from_headers(
+                headers, proxies=proxies, environment=environment
+            )
+            if not ip and _is_development(environment=environment):
                 ip = "127.0.0.1"
         else:
             ip = ip_src
@@ -449,8 +472,10 @@ def coerce_request_context(
         if not ip_src:
             if _is_global_public_ip(remote, _parse_proxies(proxies)):
                 ip = remote
-            ip = ip or extract_ip_from_headers(headers, proxies=proxies)
-            if not ip and _is_development():
+            ip = ip or extract_ip_from_headers(
+                headers, proxies=proxies, environment=environment
+            )
+            if not ip and _is_development(environment=environment):
                 ip = "127.0.0.1"
         else:
             ip = ip_src

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -655,3 +655,148 @@ def test_cache_hit_report_redacts_prompt_injection_message(
 
     assert "details" in captured, "_redact_report_details was not called on cache hit"
     assert captured["details"].extra.get("detectPromptInjectionMessage") == "<redacted>"
+
+
+class TestDefaultTimeoutMsEnvironmentKwarg:
+    """`_default_timeout_ms` honors the `environment` kwarg.
+
+    The 1000 vs 500 ms split is keyed off dev/prod, so it has the same
+    pydantic-settings bug as `coerce_request_context` and must accept the
+    same kwarg.
+    """
+
+    def test_kwarg_development_returns_1000(self, monkeypatch: pytest.MonkeyPatch):
+        from arcjet._client import _default_timeout_ms
+
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        assert _default_timeout_ms((), environment="development") == 1000
+
+    def test_kwarg_production_returns_500(self, monkeypatch: pytest.MonkeyPatch):
+        from arcjet._client import _default_timeout_ms
+
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        assert _default_timeout_ms((), environment="production") == 500
+
+    def test_prompt_injection_min_clamp_still_applies_in_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from arcjet._client import _default_timeout_ms
+        from arcjet._rules import detect_prompt_injection
+
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        # detect_prompt_injection enforces a 1000ms minimum even in production.
+        assert (
+            _default_timeout_ms([detect_prompt_injection()], environment="production")
+            == 1000
+        )
+
+    def test_env_var_fallback_when_kwarg_none(self, monkeypatch: pytest.MonkeyPatch):
+        from arcjet._client import _default_timeout_ms
+
+        monkeypatch.setenv("ARCJET_ENV", "development")
+        assert _default_timeout_ms((), environment=None) == 1000
+
+
+class TestArcjetFactoryEnvironmentKwarg:
+    """End-to-end wiring: `environment=` flows from the factory into the
+    dataclass and through `_default_timeout_ms`.
+    """
+
+    def test_kwarg_reaches_dataclass(self, monkeypatch: pytest.MonkeyPatch):
+        from arcjet import arcjet
+        from arcjet._enums import Mode
+        from arcjet._rules import shield
+
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        aj = arcjet(
+            key="ajkey_x",
+            rules=[shield(mode=Mode.LIVE)],
+            environment="development",
+        )
+        assert aj._environment == "development"
+        # 1000 ms dev timeout proves _default_timeout_ms saw the kwarg.
+        assert aj._timeout_ms == 1000
+
+    def test_kwarg_production_sets_short_timeout(self, monkeypatch: pytest.MonkeyPatch):
+        from arcjet import arcjet
+        from arcjet._enums import Mode
+        from arcjet._rules import shield
+
+        monkeypatch.setenv("ARCJET_ENV", "development")
+        aj = arcjet(
+            key="ajkey_x",
+            rules=[shield(mode=Mode.LIVE)],
+            environment="production",
+        )
+        assert aj._environment == "production"
+        # Explicit kwarg beats env var: 500 ms prod timeout.
+        assert aj._timeout_ms == 500
+
+    def test_no_kwarg_falls_back_to_env_var(self, monkeypatch: pytest.MonkeyPatch):
+        """Pre-existing behavior: no kwarg + ARCJET_ENV=development -> dev mode.
+        Pins backward compatibility so the refactor of `_is_development()`
+        doesn't silently regress users relying on the env var today.
+        """
+        from arcjet import arcjet
+        from arcjet._enums import Mode
+        from arcjet._rules import shield
+
+        monkeypatch.setenv("ARCJET_ENV", "development")
+        aj = arcjet(key="ajkey_x", rules=[shield(mode=Mode.LIVE)])
+        assert aj._environment is None
+        assert aj._timeout_ms == 1000
+
+    def test_explicit_timeout_overrides_kwarg_inference(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from arcjet import arcjet
+        from arcjet._enums import Mode
+        from arcjet._rules import shield
+
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        aj = arcjet(
+            key="ajkey_x",
+            rules=[shield(mode=Mode.LIVE)],
+            environment="development",
+            timeout_ms=42,
+        )
+        assert aj._timeout_ms == 42
+
+    def test_protect_uses_environment_for_loopback_fallback(
+        self,
+        mock_protobuf_modules,
+        make_allow_decision,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """End-to-end proof the bug is fixed: with ARCJET_ENV unset and
+        environment="development" on the client, a loopback request fingerprints
+        with 127.0.0.1 instead of being dropped.
+        """
+        import asyncio
+
+        from arcjet import arcjet
+        from arcjet._enums import Mode
+        from arcjet._rules import shield
+        from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
+
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+
+        captured: dict[str, str] = {}
+
+        def capture_decide(req):
+            captured["ip"] = req.details.ip
+            decision = make_allow_decision()
+            return mock_protobuf_modules["DecideResponse"](decision)
+
+        monkeypatch.setattr(
+            DecideServiceClient, "decide_behavior", capture_decide, raising=False
+        )
+
+        aj = arcjet(
+            key="ajkey_x",
+            rules=[shield(mode=Mode.LIVE)],
+            environment="development",
+        )
+        scope = {"type": "http", "headers": [], "client": ("127.0.0.1", 0)}
+        asyncio.run(aj.protect(scope))
+        assert captured["ip"] == "127.0.0.1"

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -690,6 +690,20 @@ class TestDefaultTimeoutMsEnvironmentKwarg:
             == 1000
         )
 
+    def test_prompt_injection_in_development_keeps_1000(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from arcjet._client import _default_timeout_ms
+        from arcjet._rules import detect_prompt_injection
+
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        # Dev default (1000) already meets the prompt-injection min (1000);
+        # the max() should be a no-op rather than incorrectly clamping higher.
+        assert (
+            _default_timeout_ms([detect_prompt_injection()], environment="development")
+            == 1000
+        )
+
     def test_env_var_fallback_when_kwarg_none(self, monkeypatch: pytest.MonkeyPatch):
         from arcjet._client import _default_timeout_ms
 

--- a/tests/unit/test_client_sync.py
+++ b/tests/unit/test_client_sync.py
@@ -627,3 +627,80 @@ def test_cache_hit_report_redacts_prompt_injection_message(
 
     assert "details" in captured, "_redact_report_details was not called on cache hit"
     assert captured["details"].extra.get("detectPromptInjectionMessage") == "<redacted>"
+
+
+class TestArcjetSyncFactoryEnvironmentKwarg:
+    """Sync counterpart to `TestArcjetFactoryEnvironmentKwarg` — `environment=`
+    flows from `arcjet_sync()` into the dataclass and through
+    `_default_timeout_ms`.
+    """
+
+    def test_kwarg_reaches_dataclass(self, monkeypatch: pytest.MonkeyPatch):
+        from arcjet import arcjet_sync
+        from arcjet._enums import Mode
+        from arcjet._rules import shield
+
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        aj = arcjet_sync(
+            key="ajkey_x",
+            rules=[shield(mode=Mode.LIVE)],
+            environment="development",
+        )
+        assert aj._environment == "development"
+        assert aj._timeout_ms == 1000
+
+    def test_kwarg_production_beats_env_var(self, monkeypatch: pytest.MonkeyPatch):
+        from arcjet import arcjet_sync
+        from arcjet._enums import Mode
+        from arcjet._rules import shield
+
+        monkeypatch.setenv("ARCJET_ENV", "development")
+        aj = arcjet_sync(
+            key="ajkey_x",
+            rules=[shield(mode=Mode.LIVE)],
+            environment="production",
+        )
+        assert aj._environment == "production"
+        assert aj._timeout_ms == 500
+
+    def test_protect_uses_environment_for_loopback_fallback(
+        self,
+        mock_protobuf_modules,
+        make_allow_decision,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """End-to-end proof for the sync path: with ARCJET_ENV unset and
+        environment="development" on the client, a loopback request fingerprints
+        with 127.0.0.1.
+        """
+        from arcjet import arcjet_sync
+        from arcjet._enums import Mode
+        from arcjet._rules import shield
+        from arcjet.proto.decide.v1alpha1.decide_connect import (
+            DecideServiceClientSync,
+        )
+
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+
+        captured: dict[str, str] = {}
+
+        def capture_decide(req):
+            captured["ip"] = req.details.ip
+            decision = make_allow_decision()
+            return mock_protobuf_modules["DecideResponse"](decision)
+
+        monkeypatch.setattr(
+            DecideServiceClientSync,
+            "decide_behavior",
+            capture_decide,
+            raising=False,
+        )
+
+        aj = arcjet_sync(
+            key="ajkey_x",
+            rules=[shield(mode=Mode.LIVE)],
+            environment="development",
+        )
+        scope = {"type": "http", "headers": [], "client": ("127.0.0.1", 0)}
+        aj.protect(scope)
+        assert captured["ip"] == "127.0.0.1"

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -6,8 +6,11 @@ frameworks, and protobuf conversion utilities.
 
 from __future__ import annotations
 
+import pytest
+
 from arcjet._context import (
     RequestContext,
+    _is_development,
     coerce_request_context,
     extract_ip_from_headers,
     request_details_from_context,
@@ -222,6 +225,186 @@ def test_request_details_from_context_omits_redacted_keys_when_absent():
     d = request_details_from_context(ctx)
     assert "filterLocal" not in d.extra
     assert "sensitiveInfoValue" not in d.extra
+
+
+class TestIsDevelopment:
+    """`_is_development()` resolves from the kwarg first, env var second.
+
+    The kwarg is what pydantic-settings users pass; this matrix locks in the
+    promise that an explicit value always wins over `ARCJET_ENV`.
+    """
+
+    def test_no_kwarg_no_env_returns_false(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        assert _is_development() is False
+
+    def test_no_kwarg_env_development_returns_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("ARCJET_ENV", "development")
+        assert _is_development() is True
+
+    def test_kwarg_development_returns_true(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        assert _is_development(environment="development") is True
+
+    def test_kwarg_production_beats_env_development(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("ARCJET_ENV", "development")
+        assert _is_development(environment="production") is False
+
+    def test_kwarg_is_case_insensitive(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        assert _is_development(environment="Development") is True
+        assert _is_development(environment="DEVELOPMENT") is True
+
+    def test_kwarg_empty_string_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch):
+        # Empty string falls through `(environment or "production")`, matching
+        # existing `or "production"` semantics for the env var.
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        assert _is_development(environment="") is False
+
+    def test_kwarg_unrecognized_values_are_not_dev(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Only the exact (case-insensitive) string "development" is dev; this
+        # matches the pre-existing env-var contract — typos and aliases like
+        # "dev" or "staging" silently mean production.
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        assert _is_development(environment="staging") is False
+        assert _is_development(environment="dev") is False
+
+
+class TestExtractIpFromHeadersEnvironmentKwarg:
+    """`extract_ip_from_headers` honors the `environment` kwarg for the
+    `X-Arcjet-Ip` dev override, independent of `ARCJET_ENV`.
+    """
+
+    def test_kwarg_development_enables_override(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        headers = {"X-Arcjet-Ip": "10.0.0.1"}
+        assert extract_ip_from_headers(headers, environment="development") == "10.0.0.1"
+
+    def test_kwarg_production_disables_override_even_when_env_says_dev(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("ARCJET_ENV", "development")
+        # X-Arcjet-Ip should be ignored — kwarg explicitly says production.
+        # With no XFF and no global IP, result is None.
+        headers = {"X-Arcjet-Ip": "10.0.0.1"}
+        assert extract_ip_from_headers(headers, environment="production") is None
+
+
+class TestCoerceRequestContextEnvironmentKwarg:
+    """The loopback fallback honors the `environment` kwarg across all three
+    framework adapter paths (ASGI, Flask, Django). Each path duplicates the
+    same fallback block, so we cover each path explicitly.
+    """
+
+    def test_asgi_loopback_fallback_with_kwarg(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/",
+            "headers": [],
+            "client": ("127.0.0.1", 0),
+        }
+        ctx = coerce_request_context(scope, environment="development")
+        assert ctx.ip == "127.0.0.1"
+
+    def test_asgi_loopback_dropped_when_kwarg_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("ARCJET_ENV", "development")
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/",
+            "headers": [],
+            "client": ("127.0.0.1", 0),
+        }
+        ctx = coerce_request_context(scope, environment="production")
+        assert ctx.ip is None
+
+    def test_flask_loopback_fallback_with_kwarg(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+
+        class FakeFlaskRequest:
+            headers: dict[str, str] = {}
+            method = "GET"
+            path = "/"
+            host = "localhost"
+            remote_addr = "127.0.0.1"
+            is_secure = False
+            query_string = b""
+
+            def get_data(self):
+                return b""
+
+        ctx = coerce_request_context(FakeFlaskRequest(), environment="development")
+        assert ctx.ip == "127.0.0.1"
+
+    def test_flask_loopback_dropped_when_kwarg_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("ARCJET_ENV", "development")
+
+        class FakeFlaskRequest:
+            headers: dict[str, str] = {}
+            method = "GET"
+            path = "/"
+            host = "localhost"
+            remote_addr = "127.0.0.1"
+            is_secure = False
+            query_string = b""
+
+            def get_data(self):
+                return b""
+
+        ctx = coerce_request_context(FakeFlaskRequest(), environment="production")
+        assert ctx.ip is None
+
+    def test_django_loopback_fallback_with_kwarg(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ARCJET_ENV", raising=False)
+
+        class FakeDjangoRequest:
+            META = {
+                "REMOTE_ADDR": "127.0.0.1",
+                "wsgi.url_scheme": "http",
+                "HTTP_HOST": "localhost",
+                "QUERY_STRING": "",
+            }
+            method = "GET"
+            path = "/"
+            headers: dict[str, str] = {}
+            body = b""
+
+        ctx = coerce_request_context(FakeDjangoRequest(), environment="development")
+        assert ctx.ip == "127.0.0.1"
+
+    def test_django_loopback_dropped_when_kwarg_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("ARCJET_ENV", "development")
+
+        class FakeDjangoRequest:
+            META = {
+                "REMOTE_ADDR": "127.0.0.1",
+                "wsgi.url_scheme": "http",
+                "HTTP_HOST": "localhost",
+                "QUERY_STRING": "",
+            }
+            method = "GET"
+            path = "/"
+            headers: dict[str, str] = {}
+            body = b""
+
+        ctx = coerce_request_context(FakeDjangoRequest(), environment="production")
+        assert ctx.ip is None
 
 
 def test_request_details_from_context_normalizes_query_string():


### PR DESCRIPTION
## Summary

- Adds `environment=` kwarg to `arcjet()` and `arcjet_sync()` so users on `pydantic-settings` (or any config library that doesn't propagate `.env` into `os.environ`) can pass dev mode explicitly: `arcjet(environment=settings.ARCJET_ENV, ...)`.
- Threads `environment` through `_default_timeout_ms`, `coerce_request_context`, and `extract_ip_from_headers` so dev-mode gating is consistent end-to-end (loopback fallback, `X-Arcjet-Ip` override, timeout default).
- Fully additive — `environment=None` (default) falls back to `os.getenv("ARCJET_ENV")`, so existing callers are unaffected. Griffe API check passes.

Resolves ENG-760 / arcjet/arcjet#8079.

## Why

The SDK reads `ARCJET_ENV` via `os.getenv`, but `pydantic-settings` — the de-facto FastAPI config pattern — intentionally does not push `.env` values into `os.environ`. The combination silently defaulted users to production mode, dropped loopback IPs, and (with `fail_open=True`) returned ALLOW with no dashboard visibility. The new kwarg is the escape hatch.

## Test plan

- [x] `make check` (ruff lint + format, ty, pyright, griffe API check) — all pass
- [x] `uv run pytest` — 651 passed, coverage 91.44%
- [x] 27 new tests covering: `_is_development()` matrix (kwarg vs env var, explicit-beats-env-var, case-insensitivity, empty/unknown values), `extract_ip_from_headers()` honoring `X-Arcjet-Ip` based on kwarg, `coerce_request_context()` loopback fallback for all three framework paths (ASGI, Flask, Django), `_default_timeout_ms()` honoring kwarg + prompt-injection min-clamp, factory wiring for both `arcjet()` and `arcjet_sync()`, end-to-end loopback-fingerprint proof, and a backward-compat regression test pinning the existing `ARCJET_ENV` behavior
- [x] Manual repro from the issue against a FastAPI + pydantic-settings app: confirm `arcjet(environment=settings.ARCJET_ENV, ...)` fingerprints loopback traffic and shows it in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)