### PR TITLE
docs: document label/bucket slug validation in arcjet.guard docstrings

### DIFF
--- a/src/arcjet/guard/_client.py
+++ b/src/arcjet/guard/_client.py
@@ -192,6 +192,9 @@ class ArcjetGuard:
         Args:
             rules: Bound rule inputs (e.g. ``TokenBucket(...)(key="u")``)
             label: Label identifying this guard call (required by the server).
+                Validated server-side as a slug: lowercase letters, digits,
+                dash (``-``), and dot (``.``) only; must start and end with
+                a lowercase letter or digit; max 256 bytes.
             metadata: Optional key/value metadata.
 
         Returns:
@@ -241,6 +244,9 @@ class ArcjetGuardSync:
         Args:
             rules: Bound rule inputs (e.g. ``TokenBucket(...)(key="u")``)
             label: Label identifying this guard call (required by the server).
+                Validated server-side as a slug: lowercase letters, digits,
+                dash (``-``), and dot (``.``) only; must start and end with
+                a lowercase letter or digit; max 256 bytes.
             metadata: Optional key/value metadata.
 
         Returns:

--- a/src/arcjet/guard/_rules/_custom.py
+++ b/src/arcjet/guard/_rules/_custom.py
@@ -138,7 +138,10 @@ class LocalCustomRule(Generic[TConfig, TInput, TData]):
     Args:
         config: Config data passed to ``evaluate`` on each call.
         mode: ``"LIVE"`` or ``"DRY_RUN"``.
-        label: Optional observability label.
+        label: Optional observability label. Validated server-side as a
+            slug: lowercase letters, digits, dash (``-``), and dot (``.``)
+            only; must start and end with a lowercase letter or digit;
+            max 256 bytes.
         metadata: Config-level key-value metadata.
 
     Example::

--- a/src/arcjet/guard/_rules/_prompt_injection.py
+++ b/src/arcjet/guard/_rules/_prompt_injection.py
@@ -53,7 +53,10 @@ class DetectPromptInjection:
 
     Args:
         mode: ``"LIVE"`` or ``"DRY_RUN"``.
-        label: Optional observability label.
+        label: Optional observability label. Validated server-side as a
+            slug: lowercase letters, digits, dash (``-``), and dot (``.``)
+            only; must start and end with a lowercase letter or digit;
+            max 256 bytes.
         metadata: Config-level key-value metadata.  Merged with
             per-input metadata on each call — input keys replace
             config keys on conflict.

--- a/src/arcjet/guard/_rules/_rate_limit.py
+++ b/src/arcjet/guard/_rules/_rate_limit.py
@@ -248,9 +248,14 @@ class TokenBucket:
         refill_rate: Tokens added per interval.
         interval_seconds: Seconds between refills.
         max_tokens: Maximum bucket capacity.
-        bucket: Bucket name for counter grouping (default ``"default"``).
+        bucket: Bucket name for counter grouping (default
+            ``"default-token-bucket"``). Validated server-side as a slug:
+            lowercase letters, digits, dash (``-``), and dot (``.``) only;
+            must start and end with a lowercase letter or digit;
+            max 256 bytes.
         mode: ``"LIVE"`` or ``"DRY_RUN"``.
-        label: Optional observability label.
+        label: Optional observability label. Validated server-side with
+            the same slug rules as ``bucket``.
         metadata: Config-level key-value metadata.  Merged with
             per-input metadata on each call — input keys replace
             config keys on conflict.
@@ -344,9 +349,14 @@ class FixedWindow:
     Args:
         max_requests: Maximum requests per window.
         window_seconds: Window duration in seconds.
-        bucket: Bucket name for counter grouping (default ``"default"``).
+        bucket: Bucket name for counter grouping (default
+            ``"default-fixed-window"``). Validated server-side as a slug:
+            lowercase letters, digits, dash (``-``), and dot (``.``) only;
+            must start and end with a lowercase letter or digit;
+            max 256 bytes.
         mode: ``"LIVE"`` or ``"DRY_RUN"``.
-        label: Optional observability label.
+        label: Optional observability label. Validated server-side with
+            the same slug rules as ``bucket``.
         metadata: Config-level key-value metadata.  Merged with
             per-input metadata on each call — input keys replace
             config keys on conflict.
@@ -433,9 +443,14 @@ class SlidingWindow:
     Args:
         max_requests: Maximum requests per interval.
         interval_seconds: Sliding interval in seconds.
-        bucket: Bucket name for counter grouping (default ``"default"``).
+        bucket: Bucket name for counter grouping (default
+            ``"default-sliding-window"``). Validated server-side as a slug:
+            lowercase letters, digits, dash (``-``), and dot (``.``) only;
+            must start and end with a lowercase letter or digit;
+            max 256 bytes.
         mode: ``"LIVE"`` or ``"DRY_RUN"``.
-        label: Optional observability label.
+        label: Optional observability label. Validated server-side with
+            the same slug rules as ``bucket``.
         metadata: Config-level key-value metadata.  Merged with
             per-input metadata on each call — input keys replace
             config keys on conflict.

--- a/src/arcjet/guard/_rules/_sensitive_info.py
+++ b/src/arcjet/guard/_rules/_sensitive_info.py
@@ -88,6 +88,9 @@ class LocalDetectSensitiveInfo:
         deny: Entity types to detect and block on.
         mode: ``"LIVE"`` (default) enforces; ``"DRY_RUN"`` evaluates only.
         label: Optional human-readable label for observability.
+            Validated server-side as a slug: lowercase letters, digits,
+            dash (``-``), and dot (``.``) only; must start and end with a
+            lowercase letter or digit; max 256 bytes.
         metadata: Optional key-value metadata for analytics.
 
     Raises:


### PR DESCRIPTION
The label and bucket fields on arcjet.guard rules and on the .guard() method are validated server-side as slugs:

  // validateSlug: only letters/digits/dash/dot, starting and ending
  // with a letter or digit. Used for labels, bucket names, and similar
  // human-readable identifiers.

And the proto comment is more specific: "Only lowercase letters, digits, dash, and dot."

Python docstrings previously said only "Optional observability label" or "Bucket name for counter grouping" without naming the allowed character set. Users following the docstrings can pass underscores or uppercase letters and get back an "invalid label" / "invalid bucket" error from the server with no upfront indication that those characters weren't allowed.

Adds the slug rule explicitly to every label and bucket docstring across:

- ArcjetGuard.guard() / ArcjetGuardSync.guard() (label)
- TokenBucket / FixedWindow / SlidingWindow (label + bucket)
- DetectPromptInjection (label)
- LocalDetectSensitiveInfo (label)
- LocalCustomRule (label)

Also tightened the documented `bucket` defaults to match the real constants (default-token-bucket, default-fixed-window, default-sliding-window) instead of the inaccurate "default".

No runtime behavior change — docstrings only.