### PR TITLE
feat(guard): error/warning decision model with has_failed_open() gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,8 +1053,10 @@ decision = await aj.guard(label="tools.weather", rules=[...])
 decision.conclusion   # "ALLOW" or "DENY"
 decision.reason       # "RATE_LIMIT", "PROMPT_INJECTION", "SENSITIVE_INFO", "CUSTOM", "ERROR", etc.
 
-# Layer 2: error detection
-decision.has_error()  # True if any rule errored or the server reported diagnostics
+# Layer 2: error/warning detection
+decision.has_failed_open()  # True if ALLOW only because a rule/decision could not be processed (fail-closed gate)
+decision.error_results()    # Results that errored (rules or the decision that could not be processed)
+decision.warnings           # Decision-level diagnostics (e.g. an invalid metadata key that was stripped)
 
 # Layer 3: per-rule results (see "Per-rule results" above)
 for result in decision.results:

--- a/README.md
+++ b/README.md
@@ -1055,7 +1055,7 @@ decision.reason       # "RATE_LIMIT", "PROMPT_INJECTION", "SENSITIVE_INFO", "CUS
 
 # Layer 2: error/warning detection
 decision.has_failed_open()  # True if ALLOW only because a rule/decision could not be processed (fail-closed gate)
-decision.error_results()    # Results that errored (rules or the decision that could not be processed)
+decision.error_results()  # Results that errored (rules or the decision that could not be processed)
 decision.warnings           # Decision-level diagnostics (e.g. an invalid metadata key that was stripped)
 
 # Layer 3: per-rule results (see "Per-rule results" above)

--- a/src/arcjet/guard/__init__.py
+++ b/src/arcjet/guard/__init__.py
@@ -83,6 +83,7 @@ from ._types import (
     RuleResultSlidingWindow,
     RuleResultTokenBucket,
     RuleResultUnknown,
+    Warning,
 )
 
 __all__ = [
@@ -104,6 +105,7 @@ __all__ = [
     "RuleResultTokenBucket",
     "RuleResultUnknown",
     "SENSITIVE_INFO_ENTITY_TYPES",
+    "Warning",
     # Rule classes
     "DetectPromptInjection",
     "FixedWindow",

--- a/src/arcjet/guard/__init__.py
+++ b/src/arcjet/guard/__init__.py
@@ -67,6 +67,7 @@ from ._rules import (
 experimental_ModerateContent = ModerateContent
 from ._types import (
     SENSITIVE_INFO_ENTITY_TYPES,
+    ArcjetWarning,
     Conclusion,
     CustomEvaluateResult,
     Decision,
@@ -83,7 +84,6 @@ from ._types import (
     RuleResultSlidingWindow,
     RuleResultTokenBucket,
     RuleResultUnknown,
-    Warning,
 )
 
 __all__ = [
@@ -105,7 +105,7 @@ __all__ = [
     "RuleResultTokenBucket",
     "RuleResultUnknown",
     "SENSITIVE_INFO_ENTITY_TYPES",
-    "Warning",
+    "ArcjetWarning",
     # Rule classes
     "DetectPromptInjection",
     "FixedWindow",

--- a/src/arcjet/guard/_convert.py
+++ b/src/arcjet/guard/_convert.py
@@ -28,6 +28,7 @@ from ._rules import (
     TokenBucketWithInput,
 )
 from ._types import (
+    ArcjetWarning,
     Conclusion,
     Decision,
     InternalResult,
@@ -43,7 +44,6 @@ from ._types import (
     RuleResultSlidingWindow,
     RuleResultTokenBucket,
     RuleResultUnknown,
-    Warning,
 )
 
 _CONCLUSION_MAP: dict[int, Conclusion] = {
@@ -349,17 +349,17 @@ def _rule_body_to_proto(
     raise ValueError(f"Unknown rule type: {type(rule).__name__}")
 
 
-def _warnings_from_proto(errors: Iterable[pb.ResultError]) -> tuple[Warning, ...]:
+def _warnings_from_proto(errors: Iterable[pb.ResultError]) -> tuple[ArcjetWarning, ...]:
     """Convert the proto ``GuardResponse.errors`` payload (non-fatal request
-    validation diagnostics) into decision-level :class:`Warning` entries,
+    validation diagnostics) into decision-level :class:`ArcjetWarning` entries,
     coercing each field to ``str`` at the SDK boundary. Network data is
     untrusted — a malformed response can put a non-string where a string is
     expected."""
-    warnings: list[Warning] = []
+    warnings: list[ArcjetWarning] = []
     for err in errors:
         code = err.code if isinstance(err.code, str) else "UNKNOWN"
         message = err.message if isinstance(err.message, str) else "Unknown warning"
-        warnings.append(Warning(code=code, message=message))
+        warnings.append(ArcjetWarning(code=code, message=message))
     return tuple(warnings)
 
 

--- a/src/arcjet/guard/_convert.py
+++ b/src/arcjet/guard/_convert.py
@@ -387,7 +387,7 @@ def decision_from_proto(
     proto = response.decision
     if not proto or not proto.id:
         # No usable decision — synthesize a fail-open ALLOW carrying an error
-        # result so error_results() / has_failed_open() see the failure.
+        # result so error_results / has_failed_open() see the failure.
         error = RuleResultError(
             message="No decision in response",
             code="NO_DECISION",

--- a/src/arcjet/guard/_convert.py
+++ b/src/arcjet/guard/_convert.py
@@ -7,8 +7,9 @@ directly.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from arcjet._errors import ArcjetError
-from arcjet._logging import logger
 from arcjet.guard.proto.decide.v2 import decide_pb2 as pb
 
 from ._local import (
@@ -42,6 +43,7 @@ from ._types import (
     RuleResultSlidingWindow,
     RuleResultTokenBucket,
     RuleResultUnknown,
+    Warning,
 )
 
 _CONCLUSION_MAP: dict[int, Conclusion] = {
@@ -347,6 +349,20 @@ def _rule_body_to_proto(
     raise ValueError(f"Unknown rule type: {type(rule).__name__}")
 
 
+def _warnings_from_proto(errors: Iterable[pb.ResultError]) -> tuple[Warning, ...]:
+    """Convert the proto ``GuardResponse.errors`` payload (non-fatal request
+    validation diagnostics) into decision-level :class:`Warning` entries,
+    coercing each field to ``str`` at the SDK boundary. Network data is
+    untrusted — a malformed response can put a non-string where a string is
+    expected."""
+    warnings: list[Warning] = []
+    for err in errors:
+        code = err.code if isinstance(err.code, str) else "UNKNOWN"
+        message = err.message if isinstance(err.message, str) else "Unknown warning"
+        warnings.append(Warning(code=code, message=message))
+    return tuple(warnings)
+
+
 def decision_from_proto(
     response: pb.GuardResponse,
 ) -> Decision:
@@ -362,21 +378,16 @@ def decision_from_proto(
     falls back to deriving the reason from the first DENY result.
 
     Response-level ``errors`` (recoverable validation diagnostics) are
-    logged but do not affect the decision.
+    surfaced as ``decision.warnings``; they never change the conclusion.
     """
-    # Log recoverable server-side validation errors if present.
-    has_response_errors = len(response.errors) > 0
-    for err in response.errors:
-        logger.warning(
-            "arcjet guard server diagnostic: [%s] %s",
-            err.code,
-            err.message,
-            extra={"event": "guard_server_diagnostic"},
-        )
+    # Top-level diagnostics are decision-level warnings; present whether or not
+    # a decision came back. The decision remains valid when they are populated.
+    warnings = _warnings_from_proto(response.errors)
 
     proto = response.decision
     if not proto or not proto.id:
-        # No decision in response — synthesize an ALLOW with error.
+        # No usable decision — synthesize a fail-open ALLOW carrying an error
+        # result so error_results() / has_failed_open() see the failure.
         error = RuleResultError(
             message="No decision in response",
             code="NO_DECISION",
@@ -386,6 +397,7 @@ def decision_from_proto(
             id="",
             results=(error,),
             reason="ERROR",
+            warnings=warnings,
             _internal_results=(
                 InternalResult(result=error, config_id="", input_id=""),
             ),
@@ -424,6 +436,6 @@ def decision_from_proto(
         id=proto.id,
         results=results,
         reason=reason,
+        warnings=warnings,
         _internal_results=tuple(internal_results),
-        _has_response_errors=has_response_errors,
     )

--- a/src/arcjet/guard/_types.py
+++ b/src/arcjet/guard/_types.py
@@ -7,12 +7,14 @@ These are independent of protobuf — the SDK exposes plain frozen dataclasses,
 not proto messages.  The type system is designed for progressive disclosure:
 
 - **Layer 1:** ``decision.conclusion`` (``"ALLOW"`` | ``"DENY"``) and ``decision.reason``.
-- **Layer 2:** ``decision.has_error()`` — out-of-band signal helpers.
+- **Layer 2:** ``decision.warnings``, ``decision.error_results()``, and
+  ``decision.has_failed_open()`` — out-of-band signal helpers.
 - **Layer 3:** ``rule.results(decision)`` — typed per-rule results.
 """
 
 from __future__ import annotations
 
+import warnings as _stdlib_warnings
 from dataclasses import dataclass, field
 from typing import (
     Literal,
@@ -34,6 +36,24 @@ Reason = Literal[
     "UNKNOWN",
 ]
 """Broad reason category for a decision or rule result."""
+
+
+@dataclass(frozen=True, slots=True)
+class Warning:
+    """A warning means the decision (or a single rule result) was processed
+    correctly — the result is trustworthy — but something should be fixed,
+    e.g. an invalid metadata key that was stripped or an invalid label.
+
+    Contrast with :class:`RuleResultError`, which means a rule or the
+    decision *could not* be processed and the security signal is degraded.
+    """
+
+    code: str = ""
+    """Machine-readable code (e.g. ``"AJ1100"``)."""
+
+    message: str = ""
+    """Human-readable description."""
+
 
 Mode = Literal["LIVE", "DRY_RUN"]
 """Rule evaluation mode.  ``"LIVE"`` enforces the rule; ``"DRY_RUN"``
@@ -82,6 +102,12 @@ class RuleResultTokenBucket:
     type: Literal["TOKEN_BUCKET"] = "TOKEN_BUCKET"
     """Discriminant — always ``"TOKEN_BUCKET"``."""
 
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
+
     remaining_tokens: int = 0
     """Number of tokens remaining in the bucket after this evaluation."""
 
@@ -111,6 +137,12 @@ class RuleResultFixedWindow:
     type: Literal["FIXED_WINDOW"] = "FIXED_WINDOW"
     """Discriminant — always ``"FIXED_WINDOW"``."""
 
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
+
     remaining_requests: int = 0
     """Number of requests remaining in the current window."""
 
@@ -136,6 +168,12 @@ class RuleResultSlidingWindow:
 
     type: Literal["SLIDING_WINDOW"] = "SLIDING_WINDOW"
     """Discriminant — always ``"SLIDING_WINDOW"``."""
+
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
 
     remaining_requests: int = 0
     """Number of requests remaining in the current sliding interval."""
@@ -163,6 +201,12 @@ class RuleResultPromptInjection:
     type: Literal["PROMPT_INJECTION"] = "PROMPT_INJECTION"
     """Discriminant — always ``"PROMPT_INJECTION"``."""
 
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
+
 
 @dataclass(frozen=True, slots=True)
 class RuleResultModerateContent:
@@ -180,6 +224,12 @@ class RuleResultModerateContent:
     type: Literal["MODERATE_CONTENT"] = "MODERATE_CONTENT"
     """Discriminant — always ``"MODERATE_CONTENT"``."""
 
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
+
 
 @dataclass(frozen=True, slots=True)
 class RuleResultSensitiveInfo:
@@ -193,6 +243,12 @@ class RuleResultSensitiveInfo:
 
     type: Literal["SENSITIVE_INFO"] = "SENSITIVE_INFO"
     """Discriminant — always ``"SENSITIVE_INFO"``."""
+
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
 
     detected_entity_types: tuple[str, ...] = ()
     """Entity types detected in the input (e.g. ``"EMAIL"``, ``"PHONE_NUMBER"``)."""
@@ -211,6 +267,12 @@ class RuleResultCustom:
     type: Literal["CUSTOM"] = "CUSTOM"
     """Discriminant — always ``"CUSTOM"``."""
 
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
+
     data: Mapping[str, str] = field(default_factory=dict)
     """Arbitrary key-value data returned by the custom rule's evaluate function."""
 
@@ -227,6 +289,12 @@ class RuleResultNotRun:
 
     type: Literal["NOT_RUN"] = "NOT_RUN"
     """Discriminant — always ``"NOT_RUN"``."""
+
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -245,6 +313,12 @@ class RuleResultError:
     type: Literal["RULE_ERROR"] = "RULE_ERROR"
     """Discriminant — ``"RULE_ERROR"`` (distinct from the ``"ERROR"`` reason
     to avoid ambiguity with the :class:`Reason` value)."""
+
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
 
     message: str = ""
     """Human-readable error description."""
@@ -265,6 +339,12 @@ class RuleResultUnknown:
 
     type: Literal["UNKNOWN"] = "UNKNOWN"
     """Discriminant — always ``"UNKNOWN"``."""
+
+    warnings: tuple[Warning, ...] = ()
+    """Per-rule warnings — this rule was processed correctly (the result is
+    trustworthy) but something about it should be fixed. Informational; never
+    changes the rule's conclusion. Empty until the Decide service emits
+    per-rule diagnostics."""
 
 
 RuleResult = Union[
@@ -296,7 +376,8 @@ class Decision:
     """A guard decision — either ``"ALLOW"`` or ``"DENY"``.
 
     **Layer 1**: ``decision.conclusion`` and ``decision.reason``.
-    **Layer 2**: ``decision.has_error()``.
+    **Layer 2**: ``decision.warnings``, ``decision.error_results()``, and
+    ``decision.has_failed_open()`` (the fail-closed gate).
     **Layer 3**: Use ``rule.results(decision)`` or ``rule_input.result(decision)``.
     """
 
@@ -318,15 +399,48 @@ class Decision:
     reason: Reason = "UNKNOWN"
     """Broad reason category (only meaningful for DENY decisions)."""
 
+    warnings: tuple[Warning, ...] = ()
+    """Decision-level warnings — diagnostics from request validation (e.g. an
+    invalid metadata key that was stripped). The decision is still valid; these
+    are informational and never change the conclusion."""
+
     _internal_results: tuple[InternalResult, ...] = field(
         default=(), repr=False, compare=False
     )
 
-    _has_response_errors: bool = field(default=False, repr=False, compare=False)
-    """True when the server response included non-fatal validation errors."""
+    def error_results(self) -> tuple[RuleResultError, ...]:
+        """The results that errored — rules (or the decision itself) that could
+        not be processed. Empty when nothing errored. Each entry carries a
+        ``code`` and ``message``; correlate one to a rule with
+        ``rule.result(decision)``."""
+        return tuple(r for r in self.results if isinstance(r, RuleResultError))
+
+    def has_failed_open(self) -> bool:
+        """True when this decision returned ``"ALLOW"`` only because a rule or
+        the decision could not be processed — i.e. it failed open. Gate a
+        fail-closed policy on this::
+
+            if decision.has_failed_open():
+                return deny()
+
+        "Failed open" describes an outcome of *this decision*, not the policy
+        configuration.
+        """
+        return self.conclusion == "ALLOW" and bool(self.error_results())
 
     def has_error(self) -> bool:
-        """True if any rule errored or the server reported diagnostics."""
-        return self._has_response_errors or any(
-            r.type == "RULE_ERROR" for r in self.results
+        """True if there is any warning or any errored rule.
+
+        .. deprecated::
+            Use :attr:`warnings` for request diagnostics and
+            :meth:`error_results` / :meth:`has_failed_open` for errors.
+            Removed in the next major.
+        """
+        _stdlib_warnings.warn(
+            "Decision.has_error() is deprecated: use decision.warnings for "
+            "request diagnostics and error_results() / has_failed_open() for "
+            "errors. It will be removed in the next major release.",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        return bool(self.warnings) or bool(self.error_results())

--- a/src/arcjet/guard/_types.py
+++ b/src/arcjet/guard/_types.py
@@ -408,12 +408,12 @@ class Decision:
         default=(), repr=False, compare=False
     )
 
-    def error_results(self) -> tuple[RuleResultError, ...]:
+    def error_results(self) -> list[RuleResultError]:
         """The results that errored — rules (or the decision itself) that could
         not be processed. Empty when nothing errored. Each entry carries a
         ``code`` and ``message``; correlate one to a rule with
         ``rule.result(decision)``."""
-        return tuple(r for r in self.results if isinstance(r, RuleResultError))
+        return [r for r in self.results if isinstance(r, RuleResultError)]
 
     def has_failed_open(self) -> bool:
         """True when this decision returned ``"ALLOW"`` only because a rule or
@@ -438,7 +438,7 @@ class Decision:
         """
         _stdlib_warnings.warn(
             "Decision.has_error() is deprecated: use decision.warnings for "
-            "request diagnostics and error_results() / has_failed_open() for "
+            "request diagnostics and error_results / has_failed_open() for "
             "errors. It will be removed in the next major release.",
             DeprecationWarning,
             stacklevel=2,

--- a/src/arcjet/guard/_types.py
+++ b/src/arcjet/guard/_types.py
@@ -39,7 +39,7 @@ Reason = Literal[
 
 
 @dataclass(frozen=True, slots=True)
-class Warning:
+class ArcjetWarning:
     """A warning means the decision (or a single rule result) was processed
     correctly — the result is trustworthy — but something should be fixed,
     e.g. an invalid metadata key that was stripped or an invalid label.
@@ -102,7 +102,7 @@ class RuleResultTokenBucket:
     type: Literal["TOKEN_BUCKET"] = "TOKEN_BUCKET"
     """Discriminant — always ``"TOKEN_BUCKET"``."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -137,7 +137,7 @@ class RuleResultFixedWindow:
     type: Literal["FIXED_WINDOW"] = "FIXED_WINDOW"
     """Discriminant — always ``"FIXED_WINDOW"``."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -169,7 +169,7 @@ class RuleResultSlidingWindow:
     type: Literal["SLIDING_WINDOW"] = "SLIDING_WINDOW"
     """Discriminant — always ``"SLIDING_WINDOW"``."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -201,7 +201,7 @@ class RuleResultPromptInjection:
     type: Literal["PROMPT_INJECTION"] = "PROMPT_INJECTION"
     """Discriminant — always ``"PROMPT_INJECTION"``."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -224,7 +224,7 @@ class RuleResultModerateContent:
     type: Literal["MODERATE_CONTENT"] = "MODERATE_CONTENT"
     """Discriminant — always ``"MODERATE_CONTENT"``."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -244,7 +244,7 @@ class RuleResultSensitiveInfo:
     type: Literal["SENSITIVE_INFO"] = "SENSITIVE_INFO"
     """Discriminant — always ``"SENSITIVE_INFO"``."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -267,7 +267,7 @@ class RuleResultCustom:
     type: Literal["CUSTOM"] = "CUSTOM"
     """Discriminant — always ``"CUSTOM"``."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -290,7 +290,7 @@ class RuleResultNotRun:
     type: Literal["NOT_RUN"] = "NOT_RUN"
     """Discriminant — always ``"NOT_RUN"``."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -314,7 +314,7 @@ class RuleResultError:
     """Discriminant — ``"RULE_ERROR"`` (distinct from the ``"ERROR"`` reason
     to avoid ambiguity with the :class:`Reason` value)."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -340,7 +340,7 @@ class RuleResultUnknown:
     type: Literal["UNKNOWN"] = "UNKNOWN"
     """Discriminant — always ``"UNKNOWN"``."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Per-rule warnings — this rule was processed correctly (the result is
     trustworthy) but something about it should be fixed. Informational; never
     changes the rule's conclusion. Empty until the Decide service emits
@@ -399,7 +399,7 @@ class Decision:
     reason: Reason = "UNKNOWN"
     """Broad reason category (only meaningful for DENY decisions)."""
 
-    warnings: tuple[Warning, ...] = ()
+    warnings: tuple[ArcjetWarning, ...] = ()
     """Decision-level warnings — diagnostics from request validation (e.g. an
     invalid metadata key that was stripped). The decision is still valid; these
     are informational and never change the conclusion."""

--- a/tests/integration/guard/test_client.py
+++ b/tests/integration/guard/test_client.py
@@ -320,6 +320,13 @@ class TestArcjetGuardSync:
         assert decision.conclusion == "ALLOW"
         assert decision.reason == "ERROR"
         assert decision.has_error()
+        # A transport failure fails open: ALLOW with a synthetic error result.
+        assert decision.has_failed_open()
+        errs = decision.error_results()
+        assert len(errs) == 1
+        assert errs[0].code == "TRANSPORT_ERROR"
+        # No server response, so no decision-level warnings.
+        assert decision.warnings == ()
 
     def test_sensitive_info_with_mock_wasm(self) -> None:
         from unittest.mock import patch
@@ -346,6 +353,9 @@ class TestArcjetGuardSync:
         assert decision.id == ""
         assert decision.reason == "ERROR"
         assert decision.has_error()
+        assert decision.has_failed_open()
+        assert len(decision.error_results()) == 1
+        assert decision.warnings == ()
         assert len(decision.results) == 1
         r = decision.results[0]
         assert isinstance(r, RuleResultError)
@@ -406,6 +416,11 @@ class TestArcjetGuardAsync:
         assert decision.conclusion == "ALLOW"
         assert decision.reason == "ERROR"
         assert decision.has_error()
+        assert decision.has_failed_open()
+        errs = decision.error_results()
+        assert len(errs) == 1
+        assert errs[0].code == "TRANSPORT_ERROR"
+        assert decision.warnings == ()
 
     def test_empty_rules_returns_validation_error(self) -> None:
         client = FakeAsyncClient()
@@ -415,6 +430,9 @@ class TestArcjetGuardAsync:
         assert decision.id == ""
         assert decision.reason == "ERROR"
         assert decision.has_error()
+        assert decision.has_failed_open()
+        assert len(decision.error_results()) == 1
+        assert decision.warnings == ()
         assert len(decision.results) == 1
         r = decision.results[0]
         assert isinstance(r, RuleResultError)

--- a/tests/unit/guard/test_convert.py
+++ b/tests/unit/guard/test_convert.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from arcjet.guard import (
+    ArcjetWarning,
     DetectPromptInjection,
     FixedWindow,
     LocalDetectSensitiveInfo,
     RuleResultError,
     SlidingWindow,
     TokenBucket,
-    Warning,
     experimental_ModerateContent,
 )
 from arcjet.guard._convert import decision_from_proto, rule_to_proto
@@ -518,8 +518,8 @@ class TestWarningsAndFailedOpen:
         )
         decision = decision_from_proto(response)
         assert decision.warnings == (
-            Warning(code="AJ1001", message="invalid metadata key"),
-            Warning(code="AJ1002", message="invalid label"),
+            ArcjetWarning(code="AJ1001", message="invalid metadata key"),
+            ArcjetWarning(code="AJ1002", message="invalid label"),
         )
         # A warning alone never makes a decision fail open.
         assert not decision.has_failed_open()
@@ -623,7 +623,7 @@ class TestWarningsAndFailedOpen:
             message = None  # type: ignore[assignment]
 
         warnings = _warnings_from_proto(cast("list[pb.ResultError]", [_BadError()]))
-        assert warnings == (Warning(code="UNKNOWN", message="Unknown warning"),)
+        assert warnings == (ArcjetWarning(code="UNKNOWN", message="Unknown warning"),)
 
     def test_warnings_empty_when_no_response_errors(self) -> None:
         decision = decision_from_proto(make_response(pb.GUARD_CONCLUSION_ALLOW, []))

--- a/tests/unit/guard/test_convert.py
+++ b/tests/unit/guard/test_convert.py
@@ -502,7 +502,7 @@ class TestEdgeCases:
 
 
 class TestWarningsAndFailedOpen:
-    """Decision-level warnings, error_results(), and has_failed_open()."""
+    """Decision-level warnings, error_results, and has_failed_open()."""
 
     def test_response_errors_surface_as_warnings(self) -> None:
         response = pb.GuardResponse(
@@ -523,7 +523,7 @@ class TestWarningsAndFailedOpen:
         )
         # A warning alone never makes a decision fail open.
         assert not decision.has_failed_open()
-        assert decision.error_results() == ()
+        assert decision.error_results() == []
 
     def test_allow_with_error_result_is_failed_open(self) -> None:
         rl = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
@@ -568,7 +568,7 @@ class TestWarningsAndFailedOpen:
         decision = decision_from_proto(response)
         assert decision.conclusion == "DENY"
         assert not decision.has_failed_open()
-        # error_results() still surfaces the errored rule regardless of conclusion.
+        # error_results still surfaces the errored rule regardless of conclusion.
         assert len(decision.error_results()) == 1
 
     def test_warning_and_error_are_distinct_severity_axes(self) -> None:

--- a/tests/unit/guard/test_convert.py
+++ b/tests/unit/guard/test_convert.py
@@ -8,8 +8,10 @@ from arcjet.guard import (
     DetectPromptInjection,
     FixedWindow,
     LocalDetectSensitiveInfo,
+    RuleResultError,
     SlidingWindow,
     TokenBucket,
+    Warning,
     experimental_ModerateContent,
 )
 from arcjet.guard._convert import decision_from_proto, rule_to_proto
@@ -497,6 +499,136 @@ class TestEdgeCases:
         decision = decision_from_proto(response)
         assert decision.conclusion == "DENY"
         assert decision.has_error()
+
+
+class TestWarningsAndFailedOpen:
+    """Decision-level warnings, error_results(), and has_failed_open()."""
+
+    def test_response_errors_surface_as_warnings(self) -> None:
+        response = pb.GuardResponse(
+            decision=pb.GuardDecision(
+                id="gdec_test",
+                conclusion=pb.GUARD_CONCLUSION_ALLOW,
+                rule_results=[],
+            ),
+            errors=[
+                pb.ResultError(message="invalid metadata key", code="AJ1001"),
+                pb.ResultError(message="invalid label", code="AJ1002"),
+            ],
+        )
+        decision = decision_from_proto(response)
+        assert decision.warnings == (
+            Warning(code="AJ1001", message="invalid metadata key"),
+            Warning(code="AJ1002", message="invalid label"),
+        )
+        # A warning alone never makes a decision fail open.
+        assert not decision.has_failed_open()
+        assert decision.error_results() == ()
+
+    def test_allow_with_error_result_is_failed_open(self) -> None:
+        rl = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        inp = rl(key="user_1")
+        response = make_response(
+            pb.GUARD_CONCLUSION_ALLOW,
+            [
+                pb.GuardRuleResult(
+                    result_id="gres_1",
+                    config_id=inp._config_id,
+                    input_id=inp._input_id,
+                    type=pb.GUARD_RULE_TYPE_TOKEN_BUCKET,
+                    error=pb.ResultError(message="boom", code="INTERNAL"),
+                ),
+            ],
+        )
+        decision = decision_from_proto(response)
+        assert decision.conclusion == "ALLOW"
+        assert decision.has_failed_open()
+        errs = decision.error_results()
+        assert len(errs) == 1
+        assert isinstance(errs[0], RuleResultError)
+        assert errs[0].code == "INTERNAL"
+
+    def test_deny_with_error_is_not_failed_open(self) -> None:
+        # A DENY conclusion was reached despite an errored rule — the decision
+        # did not fail open (it denied on purpose).
+        rl = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        inp = rl(key="user_1")
+        response = make_response(
+            pb.GUARD_CONCLUSION_DENY,
+            [
+                pb.GuardRuleResult(
+                    result_id="gres_1",
+                    config_id=inp._config_id,
+                    input_id=inp._input_id,
+                    type=pb.GUARD_RULE_TYPE_TOKEN_BUCKET,
+                    error=pb.ResultError(message="boom", code="INTERNAL"),
+                ),
+            ],
+        )
+        decision = decision_from_proto(response)
+        assert decision.conclusion == "DENY"
+        assert not decision.has_failed_open()
+        # error_results() still surfaces the errored rule regardless of conclusion.
+        assert len(decision.error_results()) == 1
+
+    def test_warning_and_error_are_distinct_severity_axes(self) -> None:
+        # A warning (processed correctly, fix it) and an error (could not
+        # process) are independent: a warning does not make the decision fail
+        # open, but an errored rule does.
+        rl = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        inp = rl(key="user_1")
+        response = pb.GuardResponse(
+            decision=pb.GuardDecision(
+                id="gdec_test",
+                conclusion=pb.GUARD_CONCLUSION_ALLOW,
+                rule_results=[
+                    pb.GuardRuleResult(
+                        result_id="gres_1",
+                        config_id=inp._config_id,
+                        input_id=inp._input_id,
+                        type=pb.GUARD_RULE_TYPE_TOKEN_BUCKET,
+                        error=pb.ResultError(message="boom", code="INTERNAL"),
+                    ),
+                ],
+            ),
+            errors=[pb.ResultError(message="stripped key", code="AJ1002")],
+        )
+        decision = decision_from_proto(response)
+        assert decision.conclusion == "ALLOW"
+        assert len(decision.warnings) == 1
+        assert len(decision.error_results()) == 1
+        # Failed open is driven by the error, not the warning.
+        assert decision.has_failed_open()
+
+    def test_missing_decision_synthesizes_failed_open(self) -> None:
+        # No decision in the response — the SDK synthesizes a fail-open ALLOW
+        # carrying a synthetic error result.
+        decision = decision_from_proto(pb.GuardResponse())
+        assert decision.conclusion == "ALLOW"
+        assert decision.has_failed_open()
+        assert len(decision.error_results()) == 1
+        assert decision.error_results()[0].code == "NO_DECISION"
+
+    def test_warnings_coerce_non_string_fields(self) -> None:
+        # A malformed response can put a non-string where code/message is
+        # expected; the SDK boundary coerces to safe fallbacks rather than
+        # propagating the bad value.
+        from typing import cast
+
+        from arcjet.guard._convert import _warnings_from_proto
+
+        class _BadError:
+            # Intentionally non-string to simulate malformed wire data.
+            code = 42  # type: ignore[assignment]
+            message = None  # type: ignore[assignment]
+
+        warnings = _warnings_from_proto(cast("list[pb.ResultError]", [_BadError()]))
+        assert warnings == (Warning(code="UNKNOWN", message="Unknown warning"),)
+
+    def test_warnings_empty_when_no_response_errors(self) -> None:
+        decision = decision_from_proto(make_response(pb.GUARD_CONCLUSION_ALLOW, []))
+        assert decision.warnings == ()
+        assert not decision.has_failed_open()
 
 
 class TestRuleToProtoLocalSensitiveInfo:

--- a/tests/unit/guard/test_rules.py
+++ b/tests/unit/guard/test_rules.py
@@ -1419,6 +1419,11 @@ class TestHasErrorWithResponseErrors:
         decision = decision_from_proto(response)
         assert decision.has_error()
 
+    def test_has_error_emits_deprecation_warning(self) -> None:
+        decision = decision_from_proto(make_response(pb.GUARD_CONCLUSION_ALLOW, []))
+        with pytest.warns(DeprecationWarning, match="has_error\\(\\) is deprecated"):
+            decision.has_error()
+
 
 class TestThreadSafety:
     """Verify concurrent rule invocation from multiple threads."""


### PR DESCRIPTION
Surface a two-axis error/warning model on Decision: severity (error vs warning) carried by channel, not inferred from placement. Matches the JS/Go SDKs.

* Decision.warnings: decision-level diagnostics from request validation (proto GuardResponse.errors), surfaced publicly instead of only logged. Coerced to str at the SDK boundary (non-string code/message fall back to "UNKNOWN"/"Unknown warning") since the wire is untrusted.
* Decision.error_results(): the RuleResultError entries (rules or the decision that could not be processed).
* Decision.has_failed_open(): conclusion == ALLOW AND error_results() is non-empty — the fail-closed gate.
* Decision.has_error(): deprecated (DeprecationWarning); now the conflated union of warnings + error_results. Kept working for one major cycle.
* Per-rule result variants carry an empty `warnings` tuple for forward-compat (the Decide service does not yet emit per-rule diagnostics; no proto change is required to ship).
* Warning exported from arcjet.guard.

Behavior unchanged for runtime degradation: transport failures already return a fail-open ALLOW decision carrying a synthetic TRANSPORT_ERROR result, so has_failed_open()/error_results() see them. Encode/misconfig errors still raise ArcjetError (programmer errors surface, not fail open). The dropped _has_response_errors internal field is replaced by the public warnings tuple; the server-diagnostic logger.warning is removed since diagnostics are now a structured public surface.

Tests: new TestWarningsAndFailedOpen covers warnings surfacing, allow+error is failed-open, deny+error is not, the warning/error severity independence, the missing-decision synthetic, non-string field coercion, and the empty case. Extended the transport-error and empty-rules client tests (sync + async) with has_failed_open()/ error_results()/warnings assertions. Pinned the has_error() DeprecationWarning.