### PR TITLE
feat: expose correlation_id on protect() and guard()

### DIFF
--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -151,6 +151,16 @@ class ProtectOptions(TypedDict, total=False):
     extra: Mapping[str, str]
     """Arbitrary key/value pairs forwarded verbatim to the Arcjet Decide API."""
 
+    correlation_id: str
+    """Optional, caller-supplied opaque identifier used to correlate this
+    request with other ``protect()`` and ``guard()`` calls that belong to the
+    same workflow, agent run, or multi-step task.
+
+    It does not affect the decision and is excluded from fingerprinting (and the
+    decision cache key), so two requests that differ only by correlation ID
+    still share rate-limit state. Bounded server-side to 256 bytes of printable
+    ASCII; invalid values are dropped, not truncated."""
+
 
 def _default_timeout_ms(
     rules: Sequence[RuleSpec] = (), environment: str | None = None
@@ -442,6 +452,7 @@ class Arcjet:
         detect_prompt_injection_message: str | None = None,
         extra: Mapping[str, str] | None = None,
         filter_local: Mapping[str, str] | None = None,
+        correlation_id: str | None = None,
         ip_src: str | None = None,
     ) -> Decision:
         """Evaluate the configured security rules against an incoming request.
@@ -470,6 +481,10 @@ class Arcjet:
             filter_local: Additional key/value pairs available as ``local.<key>``
                 in ``filter_request()`` expressions. Only used when a
                 ``filter_request()`` rule is configured.
+            correlation_id: Optional opaque identifier used to correlate this
+                request with other ``protect()``/``guard()`` calls in the same
+                workflow or agent run. Does not affect the decision and is
+                excluded from fingerprinting (and the decision cache key).
             ip_src: Override the detected client IP. Only valid when
                 ``disable_automatic_ip_detection=True`` was set on the client.
                 **Caution:** only pass IPs from sources you trust. See
@@ -529,6 +544,8 @@ class Arcjet:
             )
         if filter_local:
             ctx = replace(ctx, filter_local=filter_local)
+        if correlation_id:
+            ctx = replace(ctx, correlation_id=correlation_id)
         # Enforce required per-request context based on configured rules.
         if self._needs_email and not (email or ctx.email):
             raise ArcjetMisconfiguration(
@@ -967,6 +984,7 @@ class ArcjetSync:
         detect_prompt_injection_message: str | None = None,
         extra: Mapping[str, str] | None = None,
         filter_local: Mapping[str, str] | None = None,
+        correlation_id: str | None = None,
         ip_src: str | None = None,
     ) -> Decision:
         """Evaluate the configured security rules against an incoming request (sync).
@@ -1011,6 +1029,8 @@ class ArcjetSync:
             )
         if filter_local:
             ctx = replace(ctx, filter_local=filter_local)
+        if correlation_id:
+            ctx = replace(ctx, correlation_id=correlation_id)
         # Enforce required per-request context based on configured rules.
         if self._needs_email and not (email or ctx.email):
             raise ArcjetMisconfiguration(

--- a/src/arcjet/_context.py
+++ b/src/arcjet/_context.py
@@ -77,6 +77,13 @@ class RequestContext:
     - detect_prompt_injection_message: User message for prompt injection
         detection rule.
     - extra: Additional key/value metadata to be forwarded to the Decide API.
+    - correlation_id: Optional, caller-supplied opaque identifier used to
+        correlate this request with other `protect()` and `guard()` calls that
+        belong to the same workflow, agent run, or multi-step task. It does not
+        affect the decision and is excluded from fingerprinting; it is stored
+        alongside the recorded decision so a chain of actions can be
+        reconstructed. Bounded server-side to 256 bytes of printable ASCII;
+        invalid values are dropped, not truncated.
     """
 
     ip: str | None = None
@@ -93,6 +100,7 @@ class RequestContext:
     detect_prompt_injection_message: str | None = None
     filter_local: Mapping[str, str] | None = None
     extra: Mapping[str, str] | None = None
+    correlation_id: str | None = None
 
 
 class SupportsRequestContext(Protocol):
@@ -306,6 +314,10 @@ def request_details_from_context(ctx: RequestContext) -> decide_pb2.RequestDetai
         d.body = ctx.body
     if ctx.email:
         d.email = ctx.email
+    if ctx.correlation_id:
+        # Dedicated top-level field (not `extra`). Excluded from the cache key;
+        # see `make_cache_key`, which only hashes rule characteristics.
+        d.correlation_id = ctx.correlation_id
 
     if ctx.headers:
         for k, v in ctx.headers.items():

--- a/src/arcjet/guard/_client.py
+++ b/src/arcjet/guard/_client.py
@@ -57,6 +57,7 @@ def _build_request(
     label: str,
     metadata: dict[str, str] | None,
     local_eval_duration_ms: int,
+    correlation_id: str | None = None,
 ) -> pb.GuardRequest:
     req = pb.GuardRequest(
         user_agent=user_agent,
@@ -67,6 +68,8 @@ def _build_request(
     if metadata:
         for k, v in metadata.items():
             req.metadata[k] = v
+    if correlation_id:
+        req.correlation_id = correlation_id
     req.rule_submissions.extend(submissions)
     return req
 
@@ -111,6 +114,7 @@ def _prepare_guard(
     user_agent: str,
     label: str,
     metadata: dict[str, str] | None,
+    correlation_id: str | None = None,
 ) -> Decision | pb.GuardRequest:
     """Validate rules, run local evaluations, and build the proto request.
 
@@ -148,6 +152,7 @@ def _prepare_guard(
         label=label,
         metadata=metadata,
         local_eval_duration_ms=local_eval_duration_ms,
+        correlation_id=correlation_id,
     )
 
 
@@ -186,6 +191,7 @@ class ArcjetGuard:
         *,
         label: str,
         metadata: dict[str, str] | None = None,
+        correlation_id: str | None = None,
     ) -> Decision:
         """Evaluate *rules* via the Arcjet Guard v2 API (async).
 
@@ -196,12 +202,21 @@ class ArcjetGuard:
                 dash (``-``), and dot (``.``) only; must start and end with
                 a lowercase letter or digit; max 256 bytes.
             metadata: Optional key/value metadata.
+            correlation_id: Optional opaque identifier used to correlate this
+                guard call with other ``guard()``/``protect()`` calls in the
+                same workflow or agent run. A dedicated, indexable field (unlike
+                ``metadata``); does not affect the decision. Bounded server-side
+                to 256 bytes of printable ASCII; invalid values are dropped.
 
         Returns:
             A :class:`Decision` with conclusion, reason, and per-rule results.
         """
         result = _prepare_guard(
-            rules, user_agent=self._user_agent, label=label, metadata=metadata
+            rules,
+            user_agent=self._user_agent,
+            label=label,
+            metadata=metadata,
+            correlation_id=correlation_id,
         )
         if isinstance(result, Decision):
             return result
@@ -238,6 +253,7 @@ class ArcjetGuardSync:
         *,
         label: str,
         metadata: dict[str, str] | None = None,
+        correlation_id: str | None = None,
     ) -> Decision:
         """Evaluate *rules* via the Arcjet Guard v2 API (sync).
 
@@ -248,12 +264,21 @@ class ArcjetGuardSync:
                 dash (``-``), and dot (``.``) only; must start and end with
                 a lowercase letter or digit; max 256 bytes.
             metadata: Optional key/value metadata.
+            correlation_id: Optional opaque identifier used to correlate this
+                guard call with other ``guard()``/``protect()`` calls in the
+                same workflow or agent run. A dedicated, indexable field (unlike
+                ``metadata``); does not affect the decision. Bounded server-side
+                to 256 bytes of printable ASCII; invalid values are dropped.
 
         Returns:
             A :class:`Decision` with conclusion, reason, and per-rule results.
         """
         result = _prepare_guard(
-            rules, user_agent=self._user_agent, label=label, metadata=metadata
+            rules,
+            user_agent=self._user_agent,
+            label=label,
+            metadata=metadata,
+            correlation_id=correlation_id,
         )
         if isinstance(result, Decision):
             return result

--- a/tests/integration/guard/test_client.py
+++ b/tests/integration/guard/test_client.py
@@ -245,12 +245,14 @@ class TestHelpers:
             label="my-label",
             metadata={"env": "test"},
             local_eval_duration_ms=5,
+            correlation_id="wf_abcdef",
         )
         assert req.user_agent == "test/1.0"
         assert req.label == "my-label"
         assert dict(req.metadata) == {"env": "test"}
         assert req.local_eval_duration_ms == 5
         assert req.sent_at_unix_ms > 0
+        assert req.correlation_id == "wf_abcdef"
         assert len(req.rule_submissions) == 1
 
     def test_build_request_no_metadata(self) -> None:

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -152,6 +152,39 @@ def test_ip_override_with_ip_src(
     assert d.is_allowed()
 
 
+def test_correlation_id_sent_in_decide_request(
+    mock_protobuf_modules,
+    make_allow_decision,
+    dev_environment,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """correlation_id is forwarded on RequestDetails, not placed in extra."""
+    from arcjet import arcjet
+    from arcjet._rules import token_bucket
+    from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
+
+    captured = {}
+
+    def capture_decide(req):
+        captured["correlation_id"] = req.details.correlation_id
+        captured["extra"] = dict(req.details.extra)
+        decision = make_allow_decision()
+        return mock_protobuf_modules["DecideResponse"](decision)
+
+    monkeypatch.setattr(
+        DecideServiceClient, "decide_behavior", capture_decide, raising=False
+    )
+    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    aj = arcjet(key="ajkey_x", rules=rules)
+    import asyncio
+
+    asyncio.run(aj.protect({"headers": [], "type": "http"}, correlation_id="wf_abcdef"))
+    assert captured["correlation_id"] == "wf_abcdef"
+    # It is a dedicated field, never funneled into the `extra` map.
+    assert "correlation_id" not in captured["extra"]
+    assert "correlationId" not in captured["extra"]
+
+
 def test_disable_automatic_ip_detection_requires_ip_src(mock_protobuf_modules):
     """Test that ip_src is required when automatic IP detection is disabled."""
     from arcjet import arcjet


### PR DESCRIPTION
Expose an optional, caller-supplied `correlation_id` on the public entry points and map it to the protocol fields from the proto regen (#147):

- `protect()` (async + sync): a new `correlation_id` keyword and a matching `RequestContext.correlation_id` field, mapped to `RequestDetails.correlation_id` (v1alpha1) on both decide and report.
- `guard()` (async + sync): a new `correlation_id` keyword, mapped to `GuardRequest.correlation_id` (v2).

It is a dedicated field (not placed in the `extra` map) and is excluded from the decision cache key — `make_cache_key` only hashes rule characteristics — so two calls that differ only by correlation ID still share rate-limit state.

Server-side sanitization (max 256 bytes, printable ASCII; invalid values dropped, not truncated) remains authoritative; SDK-side validation can follow.