### PR TITLE
fix(guard): add error_result() so errored rules aren't silently dropped

### DIFF
--- a/src/arcjet/guard/_rules/_base.py
+++ b/src/arcjet/guard/_rules/_base.py
@@ -5,12 +5,48 @@ from __future__ import annotations
 import hashlib
 from typing import Mapping, Optional
 
-from .._types import Decision, InternalResult
+from .._types import Decision, InternalResult, RuleResultError
 
 
 def _get_internal_results(decision: Decision) -> tuple[InternalResult, ...]:
     """Extract internal results from a decision (empty tuple if absent)."""
     return decision._internal_results
+
+
+def _error_result_for_input(
+    decision: Decision, config_id: str, input_id: str
+) -> RuleResultError | None:
+    """Get the errored result for one specific rule invocation, or ``None``.
+
+    Matched by both ``config_id`` and ``input_id`` so two invocations of the
+    same rule resolve to distinct errors. Returns only :class:`RuleResultError`
+    — the non-error accessors (``result``/``results``/``denied_result``)
+    exclude it.
+    """
+    for ir in _get_internal_results(decision):
+        if (
+            ir.config_id == config_id
+            and ir.input_id == input_id
+            and isinstance(ir.result, RuleResultError)
+        ):
+            return ir.result
+    return None
+
+
+def _error_result_for_config(
+    decision: Decision, config_id: str
+) -> RuleResultError | None:
+    """Get the first errored result for a configured rule, or ``None``.
+
+    Matched by ``config_id`` only. If multiple invocations of the same rule
+    errored, returns one arbitrarily — mirroring ``denied_result``. There is
+    deliberately no plural ``error_results``: retrieve per-invocation via the
+    bound input's ``error_result`` instead.
+    """
+    for ir in _get_internal_results(decision):
+        if ir.config_id == config_id and isinstance(ir.result, RuleResultError):
+            return ir.result
+    return None
 
 
 def _hash_key(key: str) -> str:

--- a/src/arcjet/guard/_rules/_custom.py
+++ b/src/arcjet/guard/_rules/_custom.py
@@ -16,8 +16,19 @@ from typing import Any, Generic, Literal, Mapping, Optional, TypeVar, cast
 
 from arcjet._logging import logger
 
-from .._types import CustomEvaluateResult, Decision, Mode, RuleResultCustom
-from ._base import _get_internal_results, _merge_metadata
+from .._types import (
+    CustomEvaluateResult,
+    Decision,
+    Mode,
+    RuleResultCustom,
+    RuleResultError,
+)
+from ._base import (
+    _error_result_for_config,
+    _error_result_for_input,
+    _get_internal_results,
+    _merge_metadata,
+)
 
 TConfig = TypeVar("TConfig")
 TInput = TypeVar("TInput")
@@ -119,6 +130,16 @@ class LocalCustomWithInput(Generic[TData]):
         if r is not None and r.conclusion == "DENY":
             return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get this invocation's errored result, or ``None`` if it didn't error.
+
+        Returns the :class:`RuleResultError` only — an errored rule has no
+        custom result data, so this is not wrapped in
+        :class:`TypedCustomResult`. The non-error accessors
+        (``result``/``results``/``denied_result``) exclude it.
+        """
+        return _error_result_for_input(decision, self._config_id, self._input_id)
 
 
 class LocalCustomRule(Generic[TConfig, TInput, TData]):
@@ -311,3 +332,11 @@ class LocalCustomRule(Generic[TConfig, TInput, TData]):
             if r.conclusion == "DENY":
                 return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get the first errored result for this rule, or ``None``.
+
+        Returns the raw :class:`RuleResultError` — an errored rule has no
+        custom result data to wrap.
+        """
+        return _error_result_for_config(decision, self._config_id)

--- a/src/arcjet/guard/_rules/_moderate_content.py
+++ b/src/arcjet/guard/_rules/_moderate_content.py
@@ -11,8 +11,13 @@ import uuid
 from dataclasses import dataclass
 from typing import Mapping, Optional
 
-from .._types import Decision, Mode, RuleResultModerateContent
-from ._base import _get_internal_results, _merge_metadata
+from .._types import Decision, Mode, RuleResultError, RuleResultModerateContent
+from ._base import (
+    _error_result_for_config,
+    _error_result_for_input,
+    _get_internal_results,
+    _merge_metadata,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,6 +52,15 @@ class ModerateContentWithInput:
         if r is not None and r.conclusion == "DENY":
             return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get this invocation's errored result, or ``None`` if it didn't error.
+
+        Returns the :class:`RuleResultError` only — never the non-error
+        result. The non-error accessors (``result``/``results``/
+        ``denied_result``) exclude it.
+        """
+        return _error_result_for_input(decision, self._config_id, self._input_id)
 
 
 class ModerateContent:
@@ -135,3 +149,7 @@ class ModerateContent:
             if r.conclusion == "DENY":
                 return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get the first errored result for this rule, or ``None``."""
+        return _error_result_for_config(decision, self._config_id)

--- a/src/arcjet/guard/_rules/_prompt_injection.py
+++ b/src/arcjet/guard/_rules/_prompt_injection.py
@@ -6,8 +6,13 @@ import uuid
 from dataclasses import dataclass
 from typing import Mapping, Optional
 
-from .._types import Decision, Mode, RuleResultPromptInjection
-from ._base import _get_internal_results, _merge_metadata
+from .._types import Decision, Mode, RuleResultError, RuleResultPromptInjection
+from ._base import (
+    _error_result_for_config,
+    _error_result_for_input,
+    _get_internal_results,
+    _merge_metadata,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,6 +47,15 @@ class PromptInjectionWithInput:
         if r is not None and r.conclusion == "DENY":
             return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get this invocation's errored result, or ``None`` if it didn't error.
+
+        Returns the :class:`RuleResultError` only — never the non-error
+        result. The non-error accessors (``result``/``results``/
+        ``denied_result``) exclude it.
+        """
+        return _error_result_for_input(decision, self._config_id, self._input_id)
 
 
 class DetectPromptInjection:
@@ -122,3 +136,7 @@ class DetectPromptInjection:
             if r.conclusion == "DENY":
                 return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get the first errored result for this rule, or ``None``."""
+        return _error_result_for_config(decision, self._config_id)

--- a/src/arcjet/guard/_rules/_rate_limit.py
+++ b/src/arcjet/guard/_rules/_rate_limit.py
@@ -9,11 +9,14 @@ from typing import Mapping, Optional
 from .._types import (
     Decision,
     Mode,
+    RuleResultError,
     RuleResultFixedWindow,
     RuleResultSlidingWindow,
     RuleResultTokenBucket,
 )
 from ._base import (
+    _error_result_for_config,
+    _error_result_for_input,
     _get_internal_results,
     _hash_key,
     _merge_metadata,
@@ -137,6 +140,15 @@ class TokenBucketWithInput:
             return r
         return None
 
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get this invocation's errored result, or ``None`` if it didn't error.
+
+        Returns the :class:`RuleResultError` only — never the non-error
+        result. The non-error accessors (``result``/``results``/
+        ``denied_result``) exclude it.
+        """
+        return _error_result_for_input(decision, self._config_id, self._input_id)
+
 
 @dataclass(frozen=True, slots=True)
 class FixedWindowWithInput:
@@ -187,6 +199,15 @@ class FixedWindowWithInput:
             return r
         return None
 
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get this invocation's errored result, or ``None`` if it didn't error.
+
+        Returns the :class:`RuleResultError` only — never the non-error
+        result. The non-error accessors (``result``/``results``/
+        ``denied_result``) exclude it.
+        """
+        return _error_result_for_input(decision, self._config_id, self._input_id)
+
 
 @dataclass(frozen=True, slots=True)
 class SlidingWindowWithInput:
@@ -236,6 +257,15 @@ class SlidingWindowWithInput:
         if r is not None and r.conclusion == "DENY":
             return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get this invocation's errored result, or ``None`` if it didn't error.
+
+        Returns the :class:`RuleResultError` only — never the non-error
+        result. The non-error accessors (``result``/``results``/
+        ``denied_result``) exclude it.
+        """
+        return _error_result_for_input(decision, self._config_id, self._input_id)
 
 
 class TokenBucket:
@@ -339,6 +369,10 @@ class TokenBucket:
                 return r
         return None
 
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get the first errored result for this rule, or ``None``."""
+        return _error_result_for_config(decision, self._config_id)
+
 
 class FixedWindow:
     """Fixed window rate limiting rule.
@@ -433,6 +467,10 @@ class FixedWindow:
                 return r
         return None
 
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get the first errored result for this rule, or ``None``."""
+        return _error_result_for_config(decision, self._config_id)
+
 
 class SlidingWindow:
     """Sliding window rate limiting rule.
@@ -526,3 +564,7 @@ class SlidingWindow:
             if r.conclusion == "DENY":
                 return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get the first errored result for this rule, or ``None``."""
+        return _error_result_for_config(decision, self._config_id)

--- a/src/arcjet/guard/_rules/_sensitive_info.py
+++ b/src/arcjet/guard/_rules/_sensitive_info.py
@@ -12,9 +12,15 @@ from .._types import (
     SENSITIVE_INFO_ENTITY_TYPES,
     Decision,
     Mode,
+    RuleResultError,
     RuleResultSensitiveInfo,
 )
-from ._base import _get_internal_results, _merge_metadata
+from ._base import (
+    _error_result_for_config,
+    _error_result_for_input,
+    _get_internal_results,
+    _merge_metadata,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,6 +76,15 @@ class SensitiveInfoWithInput:
         if r is not None and r.conclusion == "DENY":
             return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get this invocation's errored result, or ``None`` if it didn't error.
+
+        Returns the :class:`RuleResultError` only — never the non-error
+        result. The non-error accessors (``result``/``results``/
+        ``denied_result``) exclude it.
+        """
+        return _error_result_for_input(decision, self._config_id, self._input_id)
 
 
 class LocalDetectSensitiveInfo:
@@ -206,3 +221,7 @@ class LocalDetectSensitiveInfo:
             if r.conclusion == "DENY":
                 return r
         return None
+
+    def error_result(self, decision: Decision) -> RuleResultError | None:
+        """Get the first errored result for this rule, or ``None``."""
+        return _error_result_for_config(decision, self._config_id)

--- a/tests/unit/guard/test_rules.py
+++ b/tests/unit/guard/test_rules.py
@@ -1450,3 +1450,179 @@ class TestThreadSafety:
         input_ids = {r._input_id for r in results}
         assert len(config_ids) == 1
         assert len(input_ids) == 10
+
+
+def _errored_result(inp, *, code: str = "AJ1100", message: str = "boom"):
+    """Build a GuardRuleResult carrying an error, matched to ``inp``."""
+    return pb.GuardRuleResult(
+        result_id="gres_err",
+        config_id=inp._config_id,
+        input_id=inp._input_id,
+        type=pb.GUARD_RULE_TYPE_TOKEN_BUCKET,
+        error=pb.ResultError(message=message, code=code),
+    )
+
+
+class TestErrorResultAccessor:
+    """``error_result()`` surfaces errored rule results without ever leaking
+    them into the non-error accessors.
+
+    The error/non-error split is the entire point: ``result``/``results``/
+    ``denied_result`` return only ALLOW/DENY (non-error) results, while
+    ``error_result`` returns only :class:`RuleResultError`.
+    """
+
+    def test_input_error_result_returns_error(self) -> None:
+        rule = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        inp = rule(key="user_1")
+        response = make_response(
+            pb.GUARD_CONCLUSION_ALLOW, [_errored_result(inp, code="AJ1100")]
+        )
+        decision = decision_from_proto(response)
+
+        err = inp.error_result(decision)
+        assert err is not None
+        assert err.type == "RULE_ERROR"
+        assert err.reason == "ERROR"
+        assert err.conclusion == "ALLOW"  # errors fail open
+        assert err.code == "AJ1100"
+        assert err.message == "boom"
+
+    def test_config_error_result_returns_error(self) -> None:
+        rule = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        inp = rule(key="user_1")
+        response = make_response(
+            pb.GUARD_CONCLUSION_ALLOW, [_errored_result(inp, code="AJ1200")]
+        )
+        decision = decision_from_proto(response)
+
+        err = rule.error_result(decision)
+        assert err is not None
+        assert err.code == "AJ1200"
+
+    def test_result_accessors_exclude_error(self) -> None:
+        # An errored rule must NOT surface through result/results/denied_result.
+        rule = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        inp = rule(key="user_1")
+        response = make_response(pb.GUARD_CONCLUSION_ALLOW, [_errored_result(inp)])
+        decision = decision_from_proto(response)
+
+        assert inp.result(decision) is None
+        assert inp.results(decision) == []
+        assert inp.denied_result(decision) is None
+        assert rule.result(decision) is None
+        assert rule.results(decision) == []
+        assert rule.denied_result(decision) is None
+        # ...but it IS retrievable via error_result.
+        assert inp.error_result(decision) is not None
+
+    def test_error_result_none_when_no_error(self) -> None:
+        # A normal (non-error) result must not be reported as an error.
+        rule = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        inp = rule(key="user_1")
+        response = make_response(
+            pb.GUARD_CONCLUSION_ALLOW,
+            [
+                pb.GuardRuleResult(
+                    result_id="gres_1",
+                    config_id=inp._config_id,
+                    input_id=inp._input_id,
+                    type=pb.GUARD_RULE_TYPE_TOKEN_BUCKET,
+                    token_bucket=pb.ResultTokenBucket(
+                        conclusion=pb.GUARD_CONCLUSION_ALLOW,
+                        remaining_tokens=99,
+                        max_tokens=100,
+                    ),
+                ),
+            ],
+        )
+        decision = decision_from_proto(response)
+
+        assert inp.error_result(decision) is None
+        assert rule.error_result(decision) is None
+        assert inp.result(decision) is not None
+
+    def test_deny_result_not_dropped_alongside_error_axis(self) -> None:
+        # The trap: removing the error must not drop denials. A DENY is a
+        # trustworthy non-error result and must still flow through result().
+        rule = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        inp = rule(key="user_1")
+        response = make_response(
+            pb.GUARD_CONCLUSION_DENY,
+            [
+                pb.GuardRuleResult(
+                    result_id="gres_1",
+                    config_id=inp._config_id,
+                    input_id=inp._input_id,
+                    type=pb.GUARD_RULE_TYPE_TOKEN_BUCKET,
+                    token_bucket=pb.ResultTokenBucket(
+                        conclusion=pb.GUARD_CONCLUSION_DENY,
+                        remaining_tokens=0,
+                        max_tokens=100,
+                    ),
+                ),
+            ],
+        )
+        decision = decision_from_proto(response)
+
+        denied = inp.denied_result(decision)
+        assert denied is not None
+        assert denied.conclusion == "DENY"
+        assert inp.error_result(decision) is None  # a DENY is not an error
+
+    def test_two_invocations_resolve_distinct_errors(self) -> None:
+        # Same rule type, two calls: each instance resolves its own error by
+        # identifier (config_id + input_id), never the other's.
+        rule = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        call1 = rule(key="first")
+        call2 = rule(key="second")
+        response = make_response(
+            pb.GUARD_CONCLUSION_ALLOW,
+            [
+                _errored_result(call1, code="AJ1001", message="first failed"),
+                pb.GuardRuleResult(
+                    result_id="gres_2",
+                    config_id=call2._config_id,
+                    input_id=call2._input_id,
+                    type=pb.GUARD_RULE_TYPE_TOKEN_BUCKET,
+                    token_bucket=pb.ResultTokenBucket(
+                        conclusion=pb.GUARD_CONCLUSION_ALLOW,
+                        remaining_tokens=42,
+                        max_tokens=100,
+                    ),
+                ),
+            ],
+        )
+        decision = decision_from_proto(response)
+
+        err1 = call1.error_result(decision)
+        assert err1 is not None
+        assert err1.code == "AJ1001"
+        assert err1.message == "first failed"
+        # call2 did not error; its non-error result resolves cleanly.
+        assert call2.error_result(decision) is None
+        r2 = call2.result(decision)
+        assert r2 is not None
+        assert r2.remaining_tokens == 42
+
+    def test_no_error_results_plural_method(self) -> None:
+        # There is deliberately no plural error_results() accessor.
+        rule = TokenBucket(refill_rate=10, interval_seconds=60, max_tokens=100)
+        inp = rule(key="user_1")
+        assert not hasattr(rule, "error_results")
+        assert not hasattr(inp, "error_results")
+
+    def test_error_result_across_all_rule_types(self) -> None:
+        # error_result exists and behaves on every rule's WithInput + config.
+        rules = [
+            FixedWindow(max_requests=100, window_seconds=3600)(key="u"),
+            SlidingWindow(max_requests=100, interval_seconds=60)(key="u"),
+            DetectPromptInjection()("text"),
+            experimental_ModerateContent()("text"),
+            LocalDetectSensitiveInfo()("text"),
+        ]
+        for inp in rules:
+            response = make_response(pb.GUARD_CONCLUSION_ALLOW, [_errored_result(inp)])
+            decision = decision_from_proto(response)
+            assert inp.error_result(decision) is not None
+            assert inp.result(decision) is None


### PR DESCRIPTION
result()/results() filtered errored results out by isinstance, leaving no way to retrieve a RuleResultError. Add error_result() (per-input and per-config) matched by the rule identifiers, surfacing only the error variant. result()/results() still exclude errors and keep denials.