### PR TITLE
test(guard): drop unused type: ignore comments in convert test

### DIFF
--- a/tests/unit/guard/test_convert.py
+++ b/tests/unit/guard/test_convert.py
@@ -619,8 +619,8 @@ class TestWarningsAndFailedOpen:
 
         class _BadError:
             # Intentionally non-string to simulate malformed wire data.
-            code = 42  # type: ignore[assignment]
-            message = None  # type: ignore[assignment]
+            code = 42
+            message = None
 
         warnings = _warnings_from_proto(cast("list[pb.ResultError]", [_BadError()]))
         assert warnings == (ArcjetWarning(code="UNKNOWN", message="Unknown warning"),)


### PR DESCRIPTION
The `# type: ignore[assignment]` directives on the _BadError stand-in suppressed nothing — the class has no annotations to violate — so ty reported them as unused-type-ignore-comment warnings, which surfaced as warning annotations on main. Remove them; the cast on the call site already handles the type mismatch.