### PR TITLE
fix: raise a clear error when the wasmtime native lib is missing libgcc

### DIFF
--- a/src/arcjet/_errors.py
+++ b/src/arcjet/_errors.py
@@ -11,3 +11,7 @@ class ArcjetMisconfiguration(ArcjetError):
 
 class ArcjetTransportError(ArcjetError):
     """Raised when Arcjet API cannot be reached or returns a transport error."""
+
+
+class ArcjetRuntimeError(ArcjetError):
+    """Raised when a required native runtime dependency fails to load."""

--- a/src/arcjet/_local.py
+++ b/src/arcjet/_local.py
@@ -14,30 +14,11 @@ import json
 import threading
 from typing import Callable
 
-from arcjet._analyze import (
-    AllowedBotConfig,
-    AllowEmailValidationConfig,
-    AnalyzeComponent,
-    DeniedBotConfig,
-    DenyEmailValidationConfig,
-    DetectedSensitiveInfoEntity,
-    Err,
-    FilterResult,
-    Ok,
-    SensitiveInfoConfig,
-    SensitiveInfoEntitiesAllow,
-    SensitiveInfoEntitiesDeny,
-    SensitiveInfoEntity,
-    SensitiveInfoEntityCreditCardNumber,
-    SensitiveInfoEntityCustom,
-    SensitiveInfoEntityEmail,
-    SensitiveInfoEntityIpAddress,
-    SensitiveInfoEntityPhoneNumber,
-)
 from arcjet.proto.decide.v1alpha1 import decide_pb2
 
 from ._context import RequestContext
 from ._enums import Mode
+from ._errors import ArcjetRuntimeError
 from ._logging import logger
 from ._rules import (
     BotDetection,
@@ -46,6 +27,54 @@ from ._rules import (
     SensitiveInfoDetection,
     SensitiveInfoEntityType,
 )
+
+# Signature substring of the OSError wasmtime-py raises when its bundled
+# native library can't find libgcc — most commonly on Alpine Linux, which
+# (unlike most distros) doesn't ship libgcc by default. See arcjet-py#159.
+_MISSING_LIBGCC_SIGNATURE = "libgcc_s.so.1"
+
+
+def _translate_wasmtime_import_error(exc: OSError) -> BaseException:
+    """Translate a known wasmtime native-library load failure into a clearer error.
+
+    Only the specific missing-libgcc signature is translated; any other
+    OSError (a different missing library, a permissions issue, etc.) is
+    returned unchanged so we don't mask or misdiagnose unrelated failures.
+    """
+    if _MISSING_LIBGCC_SIGNATURE in str(exc):
+        return ArcjetRuntimeError(
+            "Arcjet's local WebAssembly runtime (wasmtime) could not load "
+            "because `libgcc` is missing. Most Linux distributions include "
+            "this by default, but Alpine Linux does not — run "
+            "`apk add libgcc` (or your distro's equivalent) and try again.\n"
+            f"Original error: {exc}"
+        )
+    return exc
+
+
+try:
+    from arcjet._analyze import (
+        AllowedBotConfig,
+        AllowEmailValidationConfig,
+        AnalyzeComponent,
+        DeniedBotConfig,
+        DenyEmailValidationConfig,
+        DetectedSensitiveInfoEntity,
+        Err,
+        FilterResult,
+        Ok,
+        SensitiveInfoConfig,
+        SensitiveInfoEntitiesAllow,
+        SensitiveInfoEntitiesDeny,
+        SensitiveInfoEntity,
+        SensitiveInfoEntityCreditCardNumber,
+        SensitiveInfoEntityCustom,
+        SensitiveInfoEntityEmail,
+        SensitiveInfoEntityIpAddress,
+        SensitiveInfoEntityPhoneNumber,
+    )
+except OSError as exc:
+    raise _translate_wasmtime_import_error(exc) from exc
 
 # Shared mapping from WASM blocked-reason strings to proto EmailType values
 _EMAIL_TYPE_MAP: dict[str, decide_pb2.EmailType] = {

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -19,6 +19,7 @@ from arcjet._client import _build_local_deny_report, _run_local_rules
 from arcjet._context import RequestContext
 from arcjet._decision import Decision
 from arcjet._enums import Mode
+from arcjet._errors import ArcjetRuntimeError
 from arcjet._rules import BotDetection, EmailType, EmailValidation, Shield
 from arcjet.proto.decide.v1alpha1 import decide_pb2
 
@@ -62,6 +63,54 @@ class TestContextToAnalyzeRequest:
         ctx = RequestContext(headers={"X-Custom-Header": "value"})
         result = json.loads(_local._context_to_analyze_request(ctx))
         assert "x-custom-header" in result["headers"]
+
+
+# ---------------------------------------------------------------------------
+# _translate_wasmtime_import_error
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateWasmtimeImportError:
+    def test_translates_missing_libgcc_error(self):
+        exc = OSError(
+            "Error loading shared library libgcc_s.so.1: No such file or "
+            "directory (needed by /usr/local/lib/python3.10/site-packages/"
+            "wasmtime/linux-x86_64/_libwasmtime.so)"
+        )
+
+        result = _local._translate_wasmtime_import_error(exc)
+
+        assert isinstance(result, ArcjetRuntimeError)
+        assert "libgcc" in str(result)
+        assert "apk add libgcc" in str(result)
+        # Don't lose the original diagnostic detail.
+        assert "libgcc_s.so.1" in str(result)
+
+    def test_passes_through_unrelated_oserror_unchanged(self):
+        """Only the known libgcc signature should be translated.
+
+        Any other OSError (a different missing library, a permissions
+        error, a sandboxed filesystem, etc.) must propagate unchanged —
+        translating it would misdiagnose an unrelated failure as a libgcc
+        problem and send the user chasing the wrong fix.
+        """
+        exc = OSError(
+            "Error loading shared library libssl.so.3: No such file or "
+            "directory (needed by /usr/local/lib/python3.10/site-packages/"
+            "some_other_package/_native.so)"
+        )
+
+        result = _local._translate_wasmtime_import_error(exc)
+
+        assert result is exc
+        assert not isinstance(result, ArcjetRuntimeError)
+
+    def test_passes_through_generic_oserror_unchanged(self):
+        exc = OSError("Permission denied")
+
+        result = _local._translate_wasmtime_import_error(exc)
+
+        assert result is exc
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Proposed solution for #159 but not sure its a good idea/worth it!

wasmtime-py's bundled native library needs libgcc_s.so.1, which most distros ship by default but Alpine Linux does not. Previously this surfaced as a raw ctypes OSError several frames deep, with no indication of the actual fix.

Now arcjet._local catches that specific OSError signature on import and re-raises a clear ArcjetRuntimeError pointing at `apk add libgcc`. Any other OSError (a different missing library, permissions, etc.) is left untouched so we don't misdiagnose unrelated failures.

Verified in Docker (astral/uv:python3.10-alpine): fails with the new clear error before `apk add libgcc`, imports cleanly after.

Fixes #159.