### PR TITLE
feat(guard): capture events with bounded batched delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,8 +1232,13 @@ It is **best-effort and never affects a decision**:
   slowing your request down. A failed send is never retried.
 - Nothing is dropped silently. Drops are reported through the `arcjet` logger
   with a stable code — `AJ3001` (queue full), `AJ3002` (send failed), `AJ3003`
-  (flush deadline). Set `ARCJET_LOG_LEVEL=warn` and attach a handler to see
-  them.
+  (flush deadline). The `arcjet` logger is already at `WARNING`, so you only
+  need to attach a handler to see them.
+
+  Repeats of the same code are coalesced for a minute and the suppressed count
+  is reported with the next line for that code, or by the next `flush()`. A
+  burst that ends without either will under-report its total — the figure is a
+  count of events seen, not a guaranteed total.
 
 Do not put secrets or PII in `metadata`; it is stored as untrusted data.
 
@@ -1251,10 +1256,17 @@ await aj.flush()
 arcjet_sync_guard.flush()
 ```
 
-`flush()` waits up to `timeout_ms` (default 1000) for queued and in-flight
-events, then drops whatever is left and reports `AJ3003`. There is no `close()`:
-a client holds no connection of its own to release, so flushing is the only
-shutdown step that changes what gets delivered.
+`flush()` waits up to `timeout_ms` (default 1000) for the events outstanding
+when you called it. On expiry, queued events are dropped and a request already
+on the wire is abandoned — not cancelled, so it may still arrive, and nothing
+will tell you either way. Both are counted in the `AJ3003` report.
+
+Events captured *while* a flush is waiting are not its responsibility and
+survive its deadline, so calling `flush()` per request in a concurrent server
+cannot discard another request's telemetry.
+
+There is no `close()`: a client holds no connection of its own to release, so
+flushing is the only shutdown step that changes what gets delivered.
 
 ## Best practices
 

--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,16 @@ It is **best-effort and never affects a decision**:
   burst that ends without either will under-report its total — the figure is a
   count of events seen, not a guaranteed total.
 
+  Pass your own logger to receive **every** diagnostic uncoalesced, which is what
+  you need to keep a metric of dropped events:
+
+  ```py
+  aj = launch_arcjet_sync(key=arcjet_key, logger=my_logger)
+  ```
+
+  Each record carries `code` and `count` attributes alongside the message, so a
+  handler can route or count on them without parsing text.
+
 Do not put secrets or PII in `metadata`; it is stored as untrusted data.
 
 #### Delivering events before shutdown

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ async def chat(request: Request, body: ChatRequest):
 | Request Filters | ✅ | — |
 | IP Analysis | ✅ | — |
 | Custom Rules | — | ✅ |
+| Capture (visibility events) | — | ✅ |
 
 - 🔒 [Prompt Injection Detection](#prompt-injection-detection) — detect and block
   prompt injection attacks before they reach your LLM.
@@ -1200,6 +1201,60 @@ user_limit = TokenBucket(
     mode="DRY_RUN",
 )
 ```
+
+### Recording what happened with `capture()`
+
+`guard()` decides whether something is allowed. `capture()` records that it
+happened. Use it for the actions you want to see in a security trace but do not
+want to gate — a refund issued, a document exported, a tool call completed.
+
+```py
+decision = await aj.guard(label="refund", rules=[inp])
+if decision.conclusion == "ALLOW":
+    refund_id = issue_refund(...)
+
+    aj.capture(
+        action="refund.issued",
+        correlation_id=workflow_id,   # ties this to other calls in the workflow
+        decision_id=decision.id,      # ties it to the decision above
+        metadata={"amount_cents": 4999, "invoice": {"id": "inv_123"}},
+    )
+```
+
+`capture()` returns immediately and is not awaited, even on the async client.
+Events are queued and sent in the background, batched together.
+
+It is **best-effort and never affects a decision**:
+
+- It never raises. A bad field is dropped and the rest of the event is sent; an
+  event with no usable `action` is dropped entirely.
+- Under sustained load or a failing backend, events are dropped rather than
+  slowing your request down. A failed send is never retried.
+- Nothing is dropped silently. Drops are reported through the `arcjet` logger
+  with a stable code — `AJ3001` (queue full), `AJ3002` (send failed), `AJ3003`
+  (flush deadline). Set `ARCJET_LOG_LEVEL=warn` and attach a handler to see
+  them.
+
+Do not put secrets or PII in `metadata`; it is stored as untrusted data.
+
+#### Delivering events before shutdown
+
+Delivery is asynchronous, so events queued as your process exits may never be
+sent — the sync worker is a daemon thread and will not hold the interpreter
+open. Call `flush()` at a shutdown point:
+
+```py
+# Async (FastAPI lifespan, or any async teardown)
+await aj.flush()
+
+# Sync (Flask teardown, atexit, or the end of a script)
+arcjet_sync_guard.flush()
+```
+
+`flush()` waits up to `timeout_ms` (default 1000) for queued and in-flight
+events, then drops whatever is left and reports `AJ3003`. There is no `close()`:
+a client holds no connection of its own to release, so flushing is the only
+shutdown step that changes what gets delivered.
 
 ## Best practices
 

--- a/src/arcjet/guard/__init__.py
+++ b/src/arcjet/guard/__init__.py
@@ -32,6 +32,11 @@ Public API
 
     launch_arcjet, launch_arcjet_sync
     ArcjetGuard, ArcjetGuardSync
+
+Both clients expose ``.guard()`` for decisions and ``.capture()`` /
+``.flush()`` for visibility events.  ``capture()`` is fire-and-forget: it
+records what your application did without affecting any decision, and is
+delivered in the background in batches.
 """
 
 from arcjet._metadata import Metadata, MetadataValue

--- a/src/arcjet/guard/_capture.py
+++ b/src/arcjet/guard/_capture.py
@@ -23,7 +23,7 @@ from arcjet._metadata import (
 )
 
 from ._convert import local_warnings_to_proto
-from ._diagnostics import CAPTURE_INPUT_INVALID, Diagnose
+from ._diagnostics import CAPTURE_INPUT_INVALID, OPTION_DROPPED, Diagnose
 from .proto.decide.v2 import decide_pb2 as pb
 
 CAPTURE_SOURCE_SDK = "sdk"
@@ -36,8 +36,11 @@ unknown — so sending nothing would leave the origin unknown rather than merely
 unstated.
 """
 
-CAPTURE_OPTION_DROPPED_CODE = "AJ1001"
+CAPTURE_OPTION_DROPPED_CODE = OPTION_DROPPED
 """Warning code for a capture field that was dropped during normalization.
+
+Re-exported from :mod:`arcjet.guard._diagnostics`, which owns the code, so the
+two cannot drift if it is ever renumbered.
 
 Shared with arcjet-js, which reports the same condition under the same code, so
 a support answer about ``AJ1001`` holds for either SDK.  Note this is an
@@ -89,6 +92,11 @@ def normalize_capture_event(
     Returns:
         The proto event, or ``None`` when it could not be built.
     """
+    # The try deliberately spans everything, including the isinstance check
+    # below. A caller can pass an object whose metaclass makes isinstance raise,
+    # and capture() must not propagate that into application code. Anything this
+    # boundary catches means the event could not be built, which is the same
+    # outcome as invalid input.
     try:
         if not isinstance(action, str) or not action:
             diagnose(CAPTURE_INPUT_INVALID)

--- a/src/arcjet/guard/_capture.py
+++ b/src/arcjet/guard/_capture.py
@@ -1,0 +1,189 @@
+"""Normalization for ``capture()`` calls.
+
+``capture()`` records something an application did, for visibility only.  It
+never affects a decision and never raises, so everything here is written to
+degrade rather than fail: a bad optional field costs you that field, a bad
+``action`` costs you the event, and neither costs you the call.
+
+Problems are reported through :mod:`arcjet.guard._diagnostics` (locally, via the
+``arcjet`` logger) and in the event's own ``local_warnings`` (to the server, so
+they are visible alongside the stored event).
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from typing import Mapping
+
+from arcjet._metadata import (
+    LocalWarning,
+    encode_metadata,
+    enforce_metadata_budget,
+)
+
+from ._convert import local_warnings_to_proto
+from ._diagnostics import CAPTURE_INPUT_INVALID, Diagnose
+from .proto.decide.v2 import decide_pb2 as pb
+
+CAPTURE_SOURCE_SDK = "sdk"
+"""``source`` for an event from an explicit ``capture()`` call.
+
+The producer decides this, not the caller, which is why it is not an argument.
+A future span-conversion path sets ``"otlp"`` instead.  The server never
+substitutes a default — it stores an absent ``source`` as NULL, meaning
+unknown — so sending nothing would leave the origin unknown rather than merely
+unstated.
+"""
+
+CAPTURE_OPTION_DROPPED_CODE = "AJ1001"
+"""Warning code for a capture field that was dropped during normalization.
+
+Shared with arcjet-js, which reports the same condition under the same code, so
+a support answer about ``AJ1001`` holds for either SDK.  Note this is an
+``AJ1xxx`` validation code, not one of the ``AJ30xx`` capture-delivery codes:
+the field was rejected before delivery was involved.
+"""
+
+
+def _option_dropped(name: str) -> LocalWarning:
+    # Message text matches arcjet-js so the two SDKs render this identically.
+    return LocalWarning(
+        code=CAPTURE_OPTION_DROPPED_CODE,
+        message=f"capture.{name} was invalid and was dropped by the SDK",
+    )
+
+
+def normalize_capture_event(
+    *,
+    action: object,
+    correlation_id: object = None,
+    decision_id: object = None,
+    occurred_at: object = None,
+    metadata: object = None,
+    diagnose: Diagnose,
+) -> pb.CaptureEvent | None:
+    """Build a wire ``CaptureEvent``, or ``None`` if the event must be dropped.
+
+    Arguments are typed ``object`` on purpose.  Python has no runtime type
+    enforcement, so a caller who ignores the type hints — or passes a value
+    through from user input — reaches this function with anything at all.  Each
+    field is validated independently so one bad optional value drops only
+    itself.
+
+    Only an unusable ``action`` drops the whole event, because an event that
+    does not say what happened records nothing.
+
+    Args:
+        action: What the application did, e.g. ``"refund.issued"``.  Required;
+            must be a non-empty string.
+        correlation_id: Optional identifier tying this event to other
+            ``guard()``/``capture()`` calls in the same workflow.
+        decision_id: Optional id of a decision this event relates to.
+        occurred_at: Optional :class:`~datetime.datetime` of when it happened.
+            Defaults to now.  A naive datetime is interpreted as local time,
+            matching :meth:`datetime.datetime.timestamp`.
+        metadata: Optional nested-JSON metadata.
+        diagnose: Local diagnostics sink.
+
+    Returns:
+        The proto event, or ``None`` when it could not be built.
+    """
+    try:
+        if not isinstance(action, str) or not action:
+            diagnose(CAPTURE_INPUT_INVALID)
+            return None
+
+        warnings: list[LocalWarning] = []
+
+        correlation = _optional_str(correlation_id, "correlation_id", warnings)
+        decision = _optional_str(decision_id, "decision_id", warnings)
+        occurred_at_unix_ms = _occurred_at_unix_ms(occurred_at, warnings)
+
+        encoded: dict[str, str] = {}
+        if isinstance(metadata, Mapping):
+            encoded, metadata_warnings = encode_metadata(
+                metadata,  # type: ignore[arg-type]  # narrowed to Mapping above
+                message_prefix="capture: ",
+            )
+            warnings.extend(metadata_warnings)
+        elif metadata is not None:
+            warnings.append(_option_dropped("metadata"))
+
+        warnings.extend(enforce_metadata_budget([encoded]))
+
+        for warning in warnings:
+            diagnose(warning.code)
+
+        return pb.CaptureEvent(
+            occurred_at_unix_ms=occurred_at_unix_ms,
+            correlation_id=correlation,
+            decision_id=decision,
+            action=action,
+            metadata_json=encoded,
+            local_warnings=local_warnings_to_proto(warnings),
+            source=CAPTURE_SOURCE_SDK,
+        )
+    except Exception:
+        # Normalization touches user-supplied objects, whose __iter__,
+        # __getitem__, or __str__ is user code that can raise anything.
+        diagnose(CAPTURE_INPUT_INVALID)
+        return None
+
+
+def _optional_str(value: object, name: str, warnings: list[LocalWarning]) -> str:
+    """Keep a string field, or drop it with a warning.
+
+    Absent is not the same as wrong: ``None`` means the caller did not set the
+    field, so it produces no warning.  Anything else that is not a string was
+    meant to be a value and failed, so it is reported.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    warnings.append(_option_dropped(name))
+    return ""
+
+
+def _occurred_at_unix_ms(value: object, warnings: list[LocalWarning]) -> int:
+    """Resolve ``occurred_at`` to unsigned milliseconds since the epoch.
+
+    Pre-epoch timestamps are rejected because the wire field is unsigned: a
+    negative millisecond value cannot be represented and would wrap to an
+    enormous timestamp.  Dropping the field and warning beats sending a wrong
+    one.
+    """
+    if value is None:
+        return int(time.time() * 1000)
+
+    if not isinstance(value, datetime):
+        warnings.append(_option_dropped("occurred_at"))
+        return int(time.time() * 1000)
+
+    try:
+        # A naive datetime has no offset, so `timestamp()` reads it as local
+        # time. That matches the stdlib and is what a caller who built one with
+        # `datetime.now()` means.
+        seconds = value.timestamp()
+    except (OverflowError, OSError, ValueError):
+        # Out of range for the platform's time functions.
+        warnings.append(_option_dropped("occurred_at"))
+        return int(time.time() * 1000)
+
+    millis = int(seconds * 1000)
+    if millis < 0:
+        warnings.append(_option_dropped("occurred_at"))
+        return int(time.time() * 1000)
+    return millis
+
+
+def build_capture_request(
+    events: list[pb.CaptureEvent], *, user_agent: str
+) -> pb.CaptureRequest:
+    """Wrap one batch of events in a ``CaptureRequest``."""
+    return pb.CaptureRequest(
+        user_agent=user_agent,
+        sent_at_unix_ms=int(time.time() * 1000),
+        events=events,
+    )

--- a/src/arcjet/guard/_client.py
+++ b/src/arcjet/guard/_client.py
@@ -267,7 +267,7 @@ class ArcjetGuard:
     _user_agent: str
     # Built on the first capture() call, so a client that never captures never
     # starts a worker task. Not a constructor argument.
-    _delivery: AsyncCaptureDelivery | None = field(default=None, repr=False)
+    _delivery: AsyncCaptureDelivery | None = field(default=None, repr=False, init=False)
 
     def capture(
         self,
@@ -335,6 +335,9 @@ class ArcjetGuard:
         if self._delivery is None:
             return
         await self._delivery.flush(timeout_ms)
+        # Report counts the diagnostics channel held back while coalescing.
+        # Without this a burst that stops reports only its first event.
+        _diagnose.drain()
 
     def _ensure_delivery(self) -> AsyncCaptureDelivery:
         if self._delivery is not None:
@@ -423,7 +426,7 @@ class ArcjetGuardSync:
     _user_agent: str
     # Built on the first capture() call, so a client that never captures never
     # starts a worker thread. Not a constructor argument.
-    _delivery: SyncCaptureDelivery | None = field(default=None, repr=False)
+    _delivery: SyncCaptureDelivery | None = field(default=None, repr=False, init=False)
 
     def capture(
         self,
@@ -491,6 +494,9 @@ class ArcjetGuardSync:
         if self._delivery is None:
             return
         self._delivery.flush(timeout_ms)
+        # Report counts the diagnostics channel held back while coalescing.
+        # Without this a burst that stops reports only its first event.
+        _diagnose.drain()
 
     def _ensure_delivery(self) -> SyncCaptureDelivery:
         # Double-checked locking. Two threads calling capture() for the first

--- a/src/arcjet/guard/_client.py
+++ b/src/arcjet/guard/_client.py
@@ -9,6 +9,7 @@ v2 Guard RPC, and returns a typed :class:`~arcjet.guard._types.Decision`.
 from __future__ import annotations
 
 import platform
+import threading
 import time
 from dataclasses import dataclass, field, replace
 from datetime import datetime
@@ -65,6 +66,12 @@ _DEFAULT_TIMEOUT_MS = 1000
 # repeated best-effort drop from flooding the log, and the log is per-process.
 # Two clients hitting the same problem should produce one line, not two.
 _diagnose = create_diagnose()
+
+# Guards first-capture delivery construction. Module-level rather than
+# per-client because it is held only while building one delivery object, so
+# cross-client contention is not measurable, and a per-instance lock would mean
+# another dataclass field for callers that construct clients directly.
+_delivery_init_lock = threading.Lock()
 
 
 def _auth_headers(key: str) -> dict[str, str]:
@@ -294,8 +301,10 @@ class ArcjetGuard:
                 ``decision.id`` from an earlier ``guard()`` call.
             occurred_at: When it happened. Defaults to now. A naive datetime is
                 read as local time, matching
-                :meth:`datetime.datetime.timestamp`. Pre-epoch values are
-                dropped, because the wire field is unsigned.
+                :meth:`datetime.datetime.timestamp`. A pre-epoch value
+                cannot be represented — the wire field is unsigned — so the
+                field falls back to the current time and is reported as a
+                dropped field rather than dropping the whole event.
             metadata: Optional metadata — string keys mapped to any
                 JSON-serializable value, including nested objects and arrays.
                 Untrusted: do not put secrets or PII in it.
@@ -448,8 +457,10 @@ class ArcjetGuardSync:
                 ``decision.id`` from an earlier ``guard()`` call.
             occurred_at: When it happened. Defaults to now. A naive datetime is
                 read as local time, matching
-                :meth:`datetime.datetime.timestamp`. Pre-epoch values are
-                dropped, because the wire field is unsigned.
+                :meth:`datetime.datetime.timestamp`. A pre-epoch value
+                cannot be represented — the wire field is unsigned — so the
+                field falls back to the current time and is reported as a
+                dropped field rather than dropping the whole event.
             metadata: Optional metadata — string keys mapped to any
                 JSON-serializable value, including nested objects and arrays.
                 Untrusted: do not put secrets or PII in it.
@@ -482,18 +493,30 @@ class ArcjetGuardSync:
         self._delivery.flush(timeout_ms)
 
     def _ensure_delivery(self) -> SyncCaptureDelivery:
-        if self._delivery is not None:
-            return self._delivery
+        # Double-checked locking. Two threads calling capture() for the first
+        # time can otherwise both see None, each build a SyncCaptureDelivery and
+        # start a worker thread, and one gets overwritten — orphaning its thread
+        # along with any events already queued on it. The unlocked fast path
+        # keeps the steady state free of lock traffic on the request path.
+        delivery = self._delivery
+        if delivery is not None:
+            return delivery
 
-        def send(events: list[pb.CaptureEvent]) -> None:
-            self._client.capture(
-                build_capture_request(events, user_agent=self._user_agent),
-                headers=_auth_headers(self._key),
-                timeout_ms=self._timeout_ms,
-            )
+        with _delivery_init_lock:
+            delivery = self._delivery
+            if delivery is not None:
+                return delivery
 
-        self._delivery = SyncCaptureDelivery(send=send, diagnose=_diagnose)
-        return self._delivery
+            def send(events: list[pb.CaptureEvent]) -> None:
+                self._client.capture(
+                    build_capture_request(events, user_agent=self._user_agent),
+                    headers=_auth_headers(self._key),
+                    timeout_ms=self._timeout_ms,
+                )
+
+            delivery = SyncCaptureDelivery(send=send, diagnose=_diagnose)
+            self._delivery = delivery
+            return delivery
 
     def guard(
         self,

--- a/src/arcjet/guard/_client.py
+++ b/src/arcjet/guard/_client.py
@@ -8,6 +8,7 @@ v2 Guard RPC, and returns a typed :class:`~arcjet.guard._types.Decision`.
 
 from __future__ import annotations
 
+import logging
 import platform
 import threading
 import time
@@ -37,7 +38,7 @@ from ._convert import (
     rule_to_proto,
 )
 from ._delivery import AsyncCaptureDelivery, SyncCaptureDelivery
-from ._diagnostics import create_diagnose
+from ._diagnostics import Diagnose, create_diagnose
 from ._local import (
     LocalSensitiveInfoError,
     LocalSensitiveInfoResult,
@@ -62,16 +63,32 @@ def _build_user_agent() -> str:
 _DEFAULT_BASE_URL = "https://decide.arcjet.com"
 _DEFAULT_TIMEOUT_MS = 1000
 
-# Shared by every client in the process, on purpose: this exists to keep a
-# repeated best-effort drop from flooding the log, and the log is per-process.
-# Two clients hitting the same problem should produce one line, not two.
-_diagnose = create_diagnose()
+# The fallback sink, shared by every client that was not given a logger. Shared
+# on purpose: it exists to keep a repeated best-effort drop from flooding the
+# log, and the log is per-process, so two clients hitting the same problem should
+# produce one line rather than two.
+#
+# A client built with `logger=` gets its own uncoalesced sink instead — see
+# `launch_arcjet`. That is what makes a caller able to count drops, and what
+# makes client-level diagnostics observable in a test.
+_default_diagnose = create_diagnose()
 
 # Guards first-capture delivery construction. Module-level rather than
 # per-client because it is held only while building one delivery object, so
 # cross-client contention is not measurable, and a per-instance lock would mean
 # another dataclass field for callers that construct clients directly.
 _delivery_init_lock = threading.Lock()
+
+
+def _drain(diagnose: Diagnose) -> None:
+    """Release any counts a coalescing sink is holding back.
+
+    Only coalescing sinks have anything to drain, and an injected one may not, so
+    this is duck-typed rather than required by the `Diagnose` protocol.
+    """
+    drain = getattr(diagnose, "drain", None)
+    if callable(drain):
+        drain()
 
 
 def _auth_headers(key: str) -> dict[str, str]:
@@ -268,6 +285,9 @@ class ArcjetGuard:
     # Built on the first capture() call, so a client that never captures never
     # starts a worker task. Not a constructor argument.
     _delivery: AsyncCaptureDelivery | None = field(default=None, repr=False, init=False)
+    # Where this client reports drops. Defaults to the shared coalescing
+    # sink; `launch_arcjet(logger=...)` replaces it, and tests inject it.
+    _diagnose: Diagnose = field(default=_default_diagnose, repr=False)
 
     def capture(
         self,
@@ -315,7 +335,7 @@ class ArcjetGuard:
             decision_id=decision_id,
             occurred_at=occurred_at,
             metadata=metadata,
-            diagnose=_diagnose,
+            diagnose=self._diagnose,
         )
         if event is None:
             return
@@ -337,7 +357,7 @@ class ArcjetGuard:
         await self._delivery.flush(timeout_ms)
         # Report counts the diagnostics channel held back while coalescing.
         # Without this a burst that stops reports only its first event.
-        _diagnose.drain()
+        _drain(self._diagnose)
 
     def _ensure_delivery(self) -> AsyncCaptureDelivery:
         if self._delivery is not None:
@@ -350,7 +370,7 @@ class ArcjetGuard:
                 timeout_ms=self._timeout_ms,
             )
 
-        self._delivery = AsyncCaptureDelivery(send=send, diagnose=_diagnose)
+        self._delivery = AsyncCaptureDelivery(send=send, diagnose=self._diagnose)
         return self._delivery
 
     async def guard(
@@ -427,6 +447,9 @@ class ArcjetGuardSync:
     # Built on the first capture() call, so a client that never captures never
     # starts a worker thread. Not a constructor argument.
     _delivery: SyncCaptureDelivery | None = field(default=None, repr=False, init=False)
+    # Where this client reports drops. Defaults to the shared coalescing
+    # sink; `launch_arcjet(logger=...)` replaces it, and tests inject it.
+    _diagnose: Diagnose = field(default=_default_diagnose, repr=False)
 
     def capture(
         self,
@@ -474,7 +497,7 @@ class ArcjetGuardSync:
             decision_id=decision_id,
             occurred_at=occurred_at,
             metadata=metadata,
-            diagnose=_diagnose,
+            diagnose=self._diagnose,
         )
         if event is None:
             return
@@ -496,7 +519,7 @@ class ArcjetGuardSync:
         self._delivery.flush(timeout_ms)
         # Report counts the diagnostics channel held back while coalescing.
         # Without this a burst that stops reports only its first event.
-        _diagnose.drain()
+        _drain(self._diagnose)
 
     def _ensure_delivery(self) -> SyncCaptureDelivery:
         # Double-checked locking. Two threads calling capture() for the first
@@ -520,7 +543,7 @@ class ArcjetGuardSync:
                     timeout_ms=self._timeout_ms,
                 )
 
-            delivery = SyncCaptureDelivery(send=send, diagnose=_diagnose)
+            delivery = SyncCaptureDelivery(send=send, diagnose=self._diagnose)
             self._delivery = delivery
             return delivery
 
@@ -592,6 +615,7 @@ def launch_arcjet(
     key: str,
     base_url: str = _DEFAULT_BASE_URL,
     timeout_ms: int = _DEFAULT_TIMEOUT_MS,
+    logger: logging.Logger | None = None,
 ) -> ArcjetGuard:
     """Create an async Arcjet Guard client.
 
@@ -599,6 +623,15 @@ def launch_arcjet(
         key: Your Arcjet site key.
         base_url: Override the Arcjet API endpoint.
         timeout_ms: Request timeout in milliseconds (default 1000).
+        logger: Where to report capture diagnostics — dropped events, failed
+            sends, expired flushes. Defaults to the ``arcjet`` logger with
+            repeats of the same code coalesced for a minute, which keeps a drop
+            storm from flooding your logs.
+
+            Pass your own and you receive **every** diagnostic, uncoalesced,
+            because you are then the one deciding what to filter or count. That
+            is what makes it possible to keep a metric of dropped events; the
+            coalesced default cannot be counted from.
 
     Returns:
         An :class:`ArcjetGuard` async client.
@@ -620,6 +653,13 @@ def launch_arcjet(
         _client=client,
         _timeout_ms=timeout_ms,
         _user_agent=_build_user_agent(),
+        # A caller-supplied logger sees every diagnostic: they control filtering,
+        # so coalescing would only hide detail they asked for.
+        _diagnose=(
+            _default_diagnose
+            if logger is None
+            else create_diagnose(logger=logger, coalesce_seconds=0)
+        ),
     )
 
 
@@ -628,6 +668,7 @@ def launch_arcjet_sync(
     key: str,
     base_url: str = _DEFAULT_BASE_URL,
     timeout_ms: int = _DEFAULT_TIMEOUT_MS,
+    logger: logging.Logger | None = None,
 ) -> ArcjetGuardSync:
     """Create a sync Arcjet Guard client.
 
@@ -635,6 +676,15 @@ def launch_arcjet_sync(
         key: Your Arcjet site key.
         base_url: Override the Arcjet API endpoint.
         timeout_ms: Request timeout in milliseconds (default 1000).
+        logger: Where to report capture diagnostics — dropped events, failed
+            sends, expired flushes. Defaults to the ``arcjet`` logger with
+            repeats of the same code coalesced for a minute, which keeps a drop
+            storm from flooding your logs.
+
+            Pass your own and you receive **every** diagnostic, uncoalesced,
+            because you are then the one deciding what to filter or count. That
+            is what makes it possible to keep a metric of dropped events; the
+            coalesced default cannot be counted from.
 
     Returns:
         An :class:`ArcjetGuardSync` sync client.
@@ -656,4 +706,11 @@ def launch_arcjet_sync(
         _client=client,
         _timeout_ms=timeout_ms,
         _user_agent=_build_user_agent(),
+        # A caller-supplied logger sees every diagnostic: they control filtering,
+        # so coalescing would only hide detail they asked for.
+        _diagnose=(
+            _default_diagnose
+            if logger is None
+            else create_diagnose(logger=logger, coalesce_seconds=0)
+        ),
     )

--- a/src/arcjet/guard/_client.py
+++ b/src/arcjet/guard/_client.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import platform
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
+from datetime import datetime
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from typing import Protocol, Sequence, Union
@@ -27,12 +28,15 @@ from arcjet._metadata import (
 )
 from arcjet._transport import build_async_transport, build_sync_transport
 
+from ._capture import build_capture_request, normalize_capture_event
 from ._convert import (
     decision_from_proto,
     local_warnings_to_proto,
     local_warnings_to_sdk,
     rule_to_proto,
 )
+from ._delivery import AsyncCaptureDelivery, SyncCaptureDelivery
+from ._diagnostics import create_diagnose
 from ._local import (
     LocalSensitiveInfoError,
     LocalSensitiveInfoResult,
@@ -56,6 +60,11 @@ def _build_user_agent() -> str:
 
 _DEFAULT_BASE_URL = "https://decide.arcjet.com"
 _DEFAULT_TIMEOUT_MS = 1000
+
+# Shared by every client in the process, on purpose: this exists to keep a
+# repeated best-effort drop from flooding the log, and the log is per-process.
+# Two clients hitting the same problem should produce one line, not two.
+_diagnose = create_diagnose()
 
 
 def _auth_headers(key: str) -> dict[str, str]:
@@ -214,6 +223,14 @@ class _AsyncGuardTransport(Protocol):
         timeout_ms: int | None = None,
     ) -> pb.GuardResponse: ...
 
+    async def capture(
+        self,
+        request: pb.CaptureRequest,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout_ms: int | None = None,
+    ) -> pb.CaptureResponse: ...
+
 
 class _SyncGuardTransport(Protocol):
     def guard(
@@ -224,6 +241,14 @@ class _SyncGuardTransport(Protocol):
         timeout_ms: int | None = None,
     ) -> pb.GuardResponse: ...
 
+    def capture(
+        self,
+        request: pb.CaptureRequest,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout_ms: int | None = None,
+    ) -> pb.CaptureResponse: ...
+
 
 @dataclass(slots=True)
 class ArcjetGuard:
@@ -233,6 +258,88 @@ class ArcjetGuard:
     _client: _AsyncGuardTransport
     _timeout_ms: int
     _user_agent: str
+    # Built on the first capture() call, so a client that never captures never
+    # starts a worker task. Not a constructor argument.
+    _delivery: AsyncCaptureDelivery | None = field(default=None, repr=False)
+
+    def capture(
+        self,
+        *,
+        action: str,
+        correlation_id: str | None = None,
+        decision_id: str | None = None,
+        occurred_at: datetime | None = None,
+        metadata: Metadata | None = None,
+    ) -> None:
+        """Record something the application did, for visibility only.
+
+        Returns immediately: the event is queued and sent in the background,
+        batched with any others. It never affects a decision, never raises, and
+        is best-effort — under sustained load or a failing backend, events are
+        dropped rather than delaying your request. Drops are reported through
+        the ``arcjet`` logger, never silently.
+
+        Because delivery is asynchronous, an event queued when your process
+        exits may never be sent. Call :meth:`flush` when you need delivery
+        before shutdown.
+
+        Args:
+            action: What happened, e.g. ``"refund.issued"``. Convention is
+                ``"resource.verb"`` in the past tense. Required; an event with
+                no usable action is dropped, since it records nothing.
+            correlation_id: Optional opaque identifier tying this event to
+                ``guard()`` and ``capture()`` calls in the same workflow or
+                agent run.
+            decision_id: Optional id of a decision this event relates to, e.g.
+                ``decision.id`` from an earlier ``guard()`` call.
+            occurred_at: When it happened. Defaults to now. A naive datetime is
+                read as local time, matching
+                :meth:`datetime.datetime.timestamp`. Pre-epoch values are
+                dropped, because the wire field is unsigned.
+            metadata: Optional metadata — string keys mapped to any
+                JSON-serializable value, including nested objects and arrays.
+                Untrusted: do not put secrets or PII in it.
+        """
+        event = normalize_capture_event(
+            action=action,
+            correlation_id=correlation_id,
+            decision_id=decision_id,
+            occurred_at=occurred_at,
+            metadata=metadata,
+            diagnose=_diagnose,
+        )
+        if event is None:
+            return
+        self._ensure_delivery().capture(event)
+
+    async def flush(self, timeout_ms: int | None = None) -> None:
+        """Wait for queued capture events to be sent.
+
+        Args:
+            timeout_ms: Deadline in milliseconds (default 1000). Events still
+                queued when it expires are dropped and reported as ``AJ3003``.
+
+        Does nothing if nothing has been captured. There is no ``close()``: a
+        client holds no connection of its own to release, and flushing is the
+        only shutdown step that affects what gets delivered.
+        """
+        if self._delivery is None:
+            return
+        await self._delivery.flush(timeout_ms)
+
+    def _ensure_delivery(self) -> AsyncCaptureDelivery:
+        if self._delivery is not None:
+            return self._delivery
+
+        async def send(events: list[pb.CaptureEvent]) -> None:
+            await self._client.capture(
+                build_capture_request(events, user_agent=self._user_agent),
+                headers=_auth_headers(self._key),
+                timeout_ms=self._timeout_ms,
+            )
+
+        self._delivery = AsyncCaptureDelivery(send=send, diagnose=_diagnose)
+        return self._delivery
 
     async def guard(
         self,
@@ -305,6 +412,88 @@ class ArcjetGuardSync:
     _client: _SyncGuardTransport
     _timeout_ms: int
     _user_agent: str
+    # Built on the first capture() call, so a client that never captures never
+    # starts a worker thread. Not a constructor argument.
+    _delivery: SyncCaptureDelivery | None = field(default=None, repr=False)
+
+    def capture(
+        self,
+        *,
+        action: str,
+        correlation_id: str | None = None,
+        decision_id: str | None = None,
+        occurred_at: datetime | None = None,
+        metadata: Metadata | None = None,
+    ) -> None:
+        """Record something the application did, for visibility only.
+
+        Returns immediately: the event is queued and sent on a background
+        daemon thread, batched with any others. It never affects a decision,
+        never raises, and is best-effort — under sustained load or a failing
+        backend, events are dropped rather than delaying your request. Drops are
+        reported through the ``arcjet`` logger, never silently.
+
+        The worker is a daemon thread, so a queued event will not keep your
+        process alive and may never be sent if you exit straight away. Call
+        :meth:`flush` when you need delivery before shutdown.
+
+        Args:
+            action: What happened, e.g. ``"refund.issued"``. Convention is
+                ``"resource.verb"`` in the past tense. Required; an event with
+                no usable action is dropped, since it records nothing.
+            correlation_id: Optional opaque identifier tying this event to
+                ``guard()`` and ``capture()`` calls in the same workflow or
+                agent run.
+            decision_id: Optional id of a decision this event relates to, e.g.
+                ``decision.id`` from an earlier ``guard()`` call.
+            occurred_at: When it happened. Defaults to now. A naive datetime is
+                read as local time, matching
+                :meth:`datetime.datetime.timestamp`. Pre-epoch values are
+                dropped, because the wire field is unsigned.
+            metadata: Optional metadata — string keys mapped to any
+                JSON-serializable value, including nested objects and arrays.
+                Untrusted: do not put secrets or PII in it.
+        """
+        event = normalize_capture_event(
+            action=action,
+            correlation_id=correlation_id,
+            decision_id=decision_id,
+            occurred_at=occurred_at,
+            metadata=metadata,
+            diagnose=_diagnose,
+        )
+        if event is None:
+            return
+        self._ensure_delivery().capture(event)
+
+    def flush(self, timeout_ms: int | None = None) -> None:
+        """Wait for queued capture events to be sent.
+
+        Args:
+            timeout_ms: Deadline in milliseconds (default 1000). Events still
+                queued when it expires are dropped and reported as ``AJ3003``.
+
+        Does nothing if nothing has been captured. There is no ``close()``: a
+        client holds no connection of its own to release, and flushing is the
+        only shutdown step that affects what gets delivered.
+        """
+        if self._delivery is None:
+            return
+        self._delivery.flush(timeout_ms)
+
+    def _ensure_delivery(self) -> SyncCaptureDelivery:
+        if self._delivery is not None:
+            return self._delivery
+
+        def send(events: list[pb.CaptureEvent]) -> None:
+            self._client.capture(
+                build_capture_request(events, user_agent=self._user_agent),
+                headers=_auth_headers(self._key),
+                timeout_ms=self._timeout_ms,
+            )
+
+        self._delivery = SyncCaptureDelivery(send=send, diagnose=_diagnose)
+        return self._delivery
 
     def guard(
         self,

--- a/src/arcjet/guard/_delivery.py
+++ b/src/arcjet/guard/_delivery.py
@@ -136,6 +136,13 @@ class SyncCaptureDelivery:
             # Reserved before the put so two concurrent callers cannot both pass
             # the check and overshoot the ceiling.
             self._outstanding += 1
+        # The put happens outside the condition, deliberately: reserve → put →
+        # send. For a brief window `_outstanding` counts an event that is not yet
+        # in the queue, which is the safe direction to be wrong — flush() waits
+        # for `_outstanding == 0`, so it conservatively waits for an event that is
+        # still on its way in. Reversing the order, or holding the lock across
+        # the put, would either undercount for flush() or put lock traffic on the
+        # caller's request path.
         try:
             self._queue.put_nowait(event)
         except queue.Full:  # pragma: no cover - _outstanding bounds this first
@@ -368,6 +375,19 @@ class AsyncCaptureDelivery:
 
         # asyncio primitives belong to the loop that created them, so a new loop
         # needs a fresh Event pair and task.
+        #
+        # This rebinds rather than cancelling the previous task, which is safe
+        # for the supported case — loops used one after another, as successive
+        # asyncio.run() calls or a per-test loop, where the old loop is closed
+        # and its task is already gone. It is NOT safe to drive one client from
+        # two loops running concurrently in different threads: two workers would
+        # pop from the same deque with `_in_flight` split between them, so
+        # flush() could return early. Cancelling the old task cannot fix that
+        # from here either, because cancelling a task belonging to another
+        # running loop is itself not thread-safe.
+        #
+        # A client is documented as belonging to one loop at a time. Sharing one
+        # across concurrent loops is unsupported; build a client per loop.
         self._loop = loop
         self._wake = asyncio.Event()
         self._idle = asyncio.Event()
@@ -388,6 +408,9 @@ class AsyncCaptureDelivery:
                 try:
                     await asyncio.wait_for(wake.wait(), timeout=_IDLE_WAIT_SECONDS)
                 except (asyncio.TimeoutError, TimeoutError):
+                    # Expected: nothing arrived within the idle window. The
+                    # timeout is the signal to re-check the queue and stop, not
+                    # an error, so there is nothing to handle or report.
                     pass
                 if not self._queue:
                     # Nothing arrived while idling. Ending the task frees the

--- a/src/arcjet/guard/_delivery.py
+++ b/src/arcjet/guard/_delivery.py
@@ -204,11 +204,28 @@ class SyncCaptureDelivery:
             )
             self._worker.start()
 
+    def _drain_available(self, limit: int) -> list[pb.CaptureEvent]:
+        """Take up to *limit* events that are already queued, without waiting."""
+        taken: list[pb.CaptureEvent] = []
+        while len(taken) < limit:
+            try:
+                taken.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return taken
+
     def _collect(self) -> list[pb.CaptureEvent]:
         """Block for one event, then fill the batch until size or delay.
 
         Returns an empty list if nothing arrived while idling, which ends the
         worker.
+
+        "Do not wait" and "do not batch" are different things, and conflating
+        them is a mistake worth naming: when a flush is pending, or when
+        batching is disabled, this still sweeps up everything already queued. It
+        just does not wait for more. Sending one request per event on the flush
+        path would break batching precisely on the shutdown path where a backlog
+        is most likely.
         """
         try:
             first = self._queue.get(timeout=_IDLE_WAIT_SECONDS)
@@ -216,13 +233,15 @@ class SyncCaptureDelivery:
             return []
 
         batch = [first]
-        if self._batch_delay <= 0:
+        if self._batch_delay <= 0 or self._flush_now.is_set():
+            batch.extend(self._drain_available(self._batch_size - len(batch)))
             return batch
 
         deadline = time.monotonic() + self._batch_delay
         while len(batch) < self._batch_size:
             if self._flush_now.is_set():
-                # Someone is waiting on flush(); take what is here and go.
+                # A flush is waiting: stop waiting, but still take the backlog.
+                batch.extend(self._drain_available(self._batch_size - len(batch)))
                 break
             remaining = deadline - time.monotonic()
             if remaining <= 0:

--- a/src/arcjet/guard/_delivery.py
+++ b/src/arcjet/guard/_delivery.py
@@ -152,20 +152,37 @@ class SyncCaptureDelivery:
         self._ensure_worker()
 
     def flush(self, timeout_ms: int | None = None) -> None:
-        """Drain queued and in-flight events, dropping whatever does not fit.
+        """Drain the events outstanding when this call started.
 
         Args:
-            timeout_ms: Deadline in milliseconds.  On expiry the queued
-                remainder is dropped and reported as ``AJ3003``.
+            timeout_ms: Deadline in milliseconds.  On expiry, whatever this call
+                was waiting for is abandoned and reported as ``AJ3003``.
 
-        A request already on the wire is not cancelled on expiry — the sync
-        transport exposes no cancellation handle — so this clears the queue and
-        leaves that request to finish or time out on its own.
+        Only events already outstanding when the flush began are its
+        responsibility. Anything captured while it is waiting belongs to whoever
+        captured it and survives an expiry — otherwise, in a concurrent server,
+        one request's flush deadline would discard another request's telemetry.
+        That matters because the capture ADR recommends calling ``flush()`` at
+        the end of a handler.
+
+        On expiry the queued remainder is dropped. A request already on the wire
+        is **not** cancelled — the sync transport exposes no cancellation
+        handle — so it is left to finish or time out on its own. It is still
+        counted in the ``AJ3003`` total, because from this call's point of view
+        the event was abandoned: it may or may not arrive, and nothing will
+        report which.
         """
         deadline = _nonnegative_int(timeout_ms, DEFAULT_FLUSH_TIMEOUT_MS) / 1000
         with self._idle:
             if self._outstanding == 0:
                 return
+            # Snapshot the two populations separately. Only queued events can be
+            # dropped, and only the ones queued *now* belong to this flush —
+            # bounding by `_outstanding` instead would count in-flight events,
+            # which are not in the queue, and so would consume that many later
+            # arrivals from the front instead.
+            queued_at_entry = self._queue.qsize()
+            in_flight_at_entry = max(self._outstanding - queued_at_entry, 0)
         self._ensure_worker()
         self._flush_now.set()
         try:
@@ -175,14 +192,19 @@ class SyncCaptureDelivery:
                 )
             if drained:
                 return
-            self._drop_queued()
+            self._abandon(queued_at_entry, in_flight_at_entry)
         finally:
             self._flush_now.clear()
 
-    def _drop_queued(self) -> None:
-        """Discard everything still queued and report it once."""
+    def _abandon(self, queued_at_entry: int, in_flight_at_entry: int) -> None:
+        """Give up on this flush's events and report them once.
+
+        The queue is FIFO, so the oldest *queued_at_entry* entries are the ones
+        this flush was waiting for. Anything captured while it waited sits behind
+        them and is left alone.
+        """
         dropped = 0
-        while True:
+        while dropped < queued_at_entry:
             try:
                 self._queue.get_nowait()
             except queue.Empty:
@@ -190,7 +212,16 @@ class SyncCaptureDelivery:
             dropped += 1
         if dropped:
             self._finish(dropped)
-            self._diagnose(CAPTURE_FLUSH_EXPIRED, dropped)
+
+        # Whatever is on the wire is not in the queue, not cancellable, and will
+        # never be confirmed to this caller. Count it so the total is not
+        # silently short, but leave `_outstanding` alone — the send decrements it
+        # when it finishes.
+        with self._idle:
+            still_in_flight = max(self._outstanding - self._queue.qsize(), 0)
+        abandoned = dropped + min(in_flight_at_entry, still_in_flight)
+        if abandoned:
+            self._diagnose(CAPTURE_FLUSH_EXPIRED, abandoned)
 
     def _finish(self, count: int) -> None:
         """Mark *count* events as no longer outstanding and wake any flush."""
@@ -263,7 +294,23 @@ class SyncCaptureDelivery:
         while True:
             batch = self._collect()
             if not batch:
-                return
+                # Exiting has to be atomic with releasing the worker slot.
+                # `Thread.is_alive()` stays True until this function actually
+                # returns, so `_ensure_worker` gating on it alone leaves a window
+                # where a `capture()` arriving just after the idle timeout gets
+                # no worker at all — queued, unsent, and undiagnosed.
+                #
+                # Holding the lock across "is the queue still empty?" and
+                # "release the slot" closes it. A concurrent `capture()` either
+                # enqueued before this check, in which case we keep going, or it
+                # calls `_ensure_worker` after the slot is cleared, which starts
+                # a replacement.
+                with self._worker_lock:
+                    if not self._queue.empty():
+                        continue
+                    if self._worker is threading.current_thread():
+                        self._worker = None
+                    return
             try:
                 self._send(batch)
             except Exception:
@@ -329,11 +376,21 @@ class AsyncCaptureDelivery:
             self._wake.set()
 
     async def flush(self, timeout_ms: int | None = None) -> None:
-        """Drain queued and in-flight events, dropping whatever does not fit.
+        """Drain the events outstanding when this call started.
 
         Args:
-            timeout_ms: Deadline in milliseconds.  On expiry the queued
-                remainder is dropped and reported as ``AJ3003``.
+            timeout_ms: Deadline in milliseconds.  On expiry, whatever this call
+                was waiting for is abandoned and reported as ``AJ3003``.
+
+        Only events already outstanding when the flush began are its
+        responsibility. Anything captured while it is waiting survives an
+        expiry — otherwise one request's flush deadline would discard another
+        request's telemetry in a concurrent server, and the capture ADR
+        recommends calling ``flush()`` at the end of a handler.
+
+        A send already awaiting a response is not cancelled, matching the sync
+        driver, but it is counted in the ``AJ3003`` total so the number is not
+        silently short.
         """
         deadline = _nonnegative_int(timeout_ms, DEFAULT_FLUSH_TIMEOUT_MS) / 1000
         if not self._queue and self._in_flight == 0:
@@ -346,16 +403,27 @@ class AsyncCaptureDelivery:
             # caller has no running loop, which cannot happen inside `await`.
             return
 
+        # Snapshot the two populations separately, for the reason spelled out in
+        # the sync driver: only queued events can be dropped, and bounding by the
+        # combined total would consume later arrivals from the front.
+        queued_at_entry = len(self._queue)
+        in_flight_at_entry = self._in_flight
         self._flush_now = True
         if self._wake is not None:
             self._wake.set()
         try:
             await asyncio.wait_for(idle.wait(), timeout=deadline)
         except (asyncio.TimeoutError, TimeoutError):
-            dropped = len(self._queue)
-            self._queue.clear()
-            if dropped:
-                self._diagnose(CAPTURE_FLUSH_EXPIRED, dropped)
+            # Take from the left: the queue is FIFO, so the oldest entries are
+            # the ones this flush was waiting for. Events captured during the
+            # wait sit behind them and survive.
+            dropped = 0
+            while dropped < queued_at_entry and self._queue:
+                self._queue.popleft()
+                dropped += 1
+            abandoned = dropped + min(in_flight_at_entry, self._in_flight)
+            if abandoned:
+                self._diagnose(CAPTURE_FLUSH_EXPIRED, abandoned)
         finally:
             self._flush_now = False
 

--- a/src/arcjet/guard/_delivery.py
+++ b/src/arcjet/guard/_delivery.py
@@ -1,0 +1,405 @@
+"""Bounded, send-once delivery for capture events.
+
+Capture is best-effort telemetry on a request path, which fixes the shape of
+this code:
+
+* **Bounded.**  The queue has a ceiling and drops when full.  Making the caller
+  wait is not an option — ``capture()`` runs inside someone else's application,
+  so blocking for space would turn our telemetry into their latency.
+* **Batched.**  An event waits briefly for company, so a burst of calls costs one
+  request instead of one each.
+* **Send-once.**  A failed batch is dropped, never retried.  Retries pile work
+  onto a backend that is already struggling, and a stale visibility event is
+  worth less than the capacity a retry would consume.
+* **Never process-holding.**  The sync worker is a daemon thread, so a queued
+  event cannot keep an application alive at exit.  Call :meth:`flush` when you
+  need delivery before shutting down.
+
+Every drop is reported through :mod:`arcjet.guard._diagnostics`; nothing is
+discarded silently.
+
+There are two drivers because arcjet-py has two clients.  The sync client gets a
+worker thread and the async client an ``asyncio`` task, so each uses its own
+transport and neither pays for the other's machinery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+import time
+from collections import deque
+from typing import Awaitable, Deque, Protocol
+
+from ._diagnostics import (
+    CAPTURE_FLUSH_EXPIRED,
+    CAPTURE_QUEUE_FULL,
+    CAPTURE_SEND_FAILED,
+    Diagnose,
+)
+from .proto.decide.v2 import decide_pb2 as pb
+
+DEFAULT_QUEUE_SIZE = 1000
+"""Most events held in memory, queued and in flight together."""
+
+DEFAULT_BATCH_SIZE = 50
+"""Most events in one Capture request."""
+
+DEFAULT_BATCH_DELAY_MS = 100
+"""Longest an event waits for a batch to fill before being sent on its own."""
+
+DEFAULT_FLUSH_TIMEOUT_MS = 1000
+"""Default :meth:`flush` deadline."""
+
+_IDLE_WAIT_SECONDS = 0.5
+"""How long a worker sits idle before it stops.
+
+The worker exits when nothing arrives so an application that captures rarely is
+not left holding a thread or a loop task.  The next event starts a new one.
+"""
+
+
+class _SendSync(Protocol):
+    def __call__(self, events: list[pb.CaptureEvent]) -> None: ...
+
+
+class _SendAsync(Protocol):
+    def __call__(self, events: list[pb.CaptureEvent]) -> Awaitable[None]: ...
+
+
+def _positive_int(value: object, fallback: int) -> int:
+    """Accept a positive int, else fall back.  ``bool`` is not an int here."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return fallback
+    return value if value > 0 else fallback
+
+
+def _nonnegative_int(value: object, fallback: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return fallback
+    return value if value >= 0 else fallback
+
+
+class SyncCaptureDelivery:
+    """Bounded batched delivery on a daemon worker thread.
+
+    Args:
+        send: Sends one batch exactly once.  May raise, in which case the batch
+            is dropped and reported.
+        diagnose: Local diagnostics sink.
+        queue_size: Ceiling on queued plus in-flight events.
+        batch_size: Most events per request.
+        batch_delay_ms: How long a partial batch waits before being sent.
+    """
+
+    def __init__(
+        self,
+        *,
+        send: _SendSync,
+        diagnose: Diagnose,
+        queue_size: int = DEFAULT_QUEUE_SIZE,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        batch_delay_ms: int = DEFAULT_BATCH_DELAY_MS,
+    ) -> None:
+        self._send = send
+        self._diagnose = diagnose
+        self._batch_size = _positive_int(batch_size, DEFAULT_BATCH_SIZE)
+        delay_ms = _nonnegative_int(batch_delay_ms, DEFAULT_BATCH_DELAY_MS)
+        self._batch_delay = delay_ms / 1000
+
+        self._queue_size = _positive_int(queue_size, DEFAULT_QUEUE_SIZE)
+        # The queue handles the batching timers via get(timeout=...). Admission
+        # is decided against `_outstanding` below, not against maxsize, so the
+        # ceiling covers in-flight events too.
+        self._queue: queue.Queue[pb.CaptureEvent] = queue.Queue(
+            maxsize=self._queue_size
+        )
+        # Outstanding = accepted but not yet sent or dropped, so queued plus
+        # in flight. This is what the ceiling applies to: a batch already on the
+        # wire still occupies memory, and a slow backend must show up as drops
+        # rather than unbounded growth.
+        self._outstanding = 0
+        self._idle = threading.Condition()
+        # Set while a flush() is waiting, so a partial batch is sent at once
+        # instead of sitting out its full delay.
+        self._flush_now = threading.Event()
+        self._worker_lock = threading.Lock()
+        self._worker: threading.Thread | None = None
+
+    def capture(self, event: pb.CaptureEvent) -> None:
+        """Enqueue one event without blocking the caller."""
+        with self._idle:
+            if self._outstanding >= self._queue_size:
+                self._diagnose(CAPTURE_QUEUE_FULL, 1)
+                return
+            # Reserved before the put so two concurrent callers cannot both pass
+            # the check and overshoot the ceiling.
+            self._outstanding += 1
+        try:
+            self._queue.put_nowait(event)
+        except queue.Full:  # pragma: no cover - _outstanding bounds this first
+            self._finish(1)
+            self._diagnose(CAPTURE_QUEUE_FULL, 1)
+            return
+        self._ensure_worker()
+
+    def flush(self, timeout_ms: int | None = None) -> None:
+        """Drain queued and in-flight events, dropping whatever does not fit.
+
+        Args:
+            timeout_ms: Deadline in milliseconds.  On expiry the queued
+                remainder is dropped and reported as ``AJ3003``.
+
+        A request already on the wire is not cancelled on expiry — the sync
+        transport exposes no cancellation handle — so this clears the queue and
+        leaves that request to finish or time out on its own.
+        """
+        deadline = _nonnegative_int(timeout_ms, DEFAULT_FLUSH_TIMEOUT_MS) / 1000
+        with self._idle:
+            if self._outstanding == 0:
+                return
+        self._ensure_worker()
+        self._flush_now.set()
+        try:
+            with self._idle:
+                drained = self._idle.wait_for(
+                    lambda: self._outstanding == 0, timeout=deadline
+                )
+            if drained:
+                return
+            self._drop_queued()
+        finally:
+            self._flush_now.clear()
+
+    def _drop_queued(self) -> None:
+        """Discard everything still queued and report it once."""
+        dropped = 0
+        while True:
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                break
+            dropped += 1
+        if dropped:
+            self._finish(dropped)
+            self._diagnose(CAPTURE_FLUSH_EXPIRED, dropped)
+
+    def _finish(self, count: int) -> None:
+        """Mark *count* events as no longer outstanding and wake any flush."""
+        with self._idle:
+            self._outstanding -= count
+            if self._outstanding <= 0:
+                self._outstanding = 0
+                self._idle.notify_all()
+
+    def _ensure_worker(self) -> None:
+        with self._worker_lock:
+            if self._worker is not None and self._worker.is_alive():
+                return
+            # A daemon thread cannot keep the interpreter alive at exit, which
+            # is what stops a queued best-effort event from delaying shutdown.
+            self._worker = threading.Thread(
+                target=self._run, name="arcjet-capture", daemon=True
+            )
+            self._worker.start()
+
+    def _collect(self) -> list[pb.CaptureEvent]:
+        """Block for one event, then fill the batch until size or delay.
+
+        Returns an empty list if nothing arrived while idling, which ends the
+        worker.
+        """
+        try:
+            first = self._queue.get(timeout=_IDLE_WAIT_SECONDS)
+        except queue.Empty:
+            return []
+
+        batch = [first]
+        if self._batch_delay <= 0:
+            return batch
+
+        deadline = time.monotonic() + self._batch_delay
+        while len(batch) < self._batch_size:
+            if self._flush_now.is_set():
+                # Someone is waiting on flush(); take what is here and go.
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                batch.append(self._queue.get(timeout=remaining))
+            except queue.Empty:
+                break
+        return batch
+
+    def _run(self) -> None:
+        while True:
+            batch = self._collect()
+            if not batch:
+                return
+            try:
+                self._send(batch)
+            except Exception:
+                # Send-once: a failed batch is dropped, never retried.
+                self._diagnose(CAPTURE_SEND_FAILED, len(batch))
+            finally:
+                self._finish(len(batch))
+
+
+class AsyncCaptureDelivery:
+    """Bounded batched delivery on an ``asyncio`` task.
+
+    The worker task is created on the first :meth:`capture` call rather than in
+    the constructor, because a client is usually built at import time when no
+    event loop is running yet.
+
+    Args:
+        send: Sends one batch exactly once.  May raise, in which case the batch
+            is dropped and reported.
+        diagnose: Local diagnostics sink.
+        queue_size: Ceiling on queued plus in-flight events.
+        batch_size: Most events per request.
+        batch_delay_ms: How long a partial batch waits before being sent.
+    """
+
+    def __init__(
+        self,
+        *,
+        send: _SendAsync,
+        diagnose: Diagnose,
+        queue_size: int = DEFAULT_QUEUE_SIZE,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        batch_delay_ms: int = DEFAULT_BATCH_DELAY_MS,
+    ) -> None:
+        self._send = send
+        self._diagnose = diagnose
+        self._queue_size = _positive_int(queue_size, DEFAULT_QUEUE_SIZE)
+        self._batch_size = _positive_int(batch_size, DEFAULT_BATCH_SIZE)
+        delay_ms = _nonnegative_int(batch_delay_ms, DEFAULT_BATCH_DELAY_MS)
+        self._batch_delay = delay_ms / 1000
+
+        # A plain deque rather than asyncio.Queue: the queue would bind to one
+        # event loop, and a client outlives any single loop (a per-test loop, or
+        # successive asyncio.run calls).
+        self._queue: Deque[pb.CaptureEvent] = deque()
+        self._in_flight = 0
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._worker: asyncio.Task[None] | None = None
+        self._wake: asyncio.Event | None = None
+        self._idle: asyncio.Event | None = None
+        self._flush_now = False
+
+    def capture(self, event: pb.CaptureEvent) -> None:
+        """Enqueue one event without blocking or awaiting."""
+        if len(self._queue) + self._in_flight >= self._queue_size:
+            self._diagnose(CAPTURE_QUEUE_FULL, 1)
+            return
+        self._queue.append(event)
+        self._ensure_worker()
+        if self._idle is not None:
+            self._idle.clear()
+        if self._wake is not None:
+            self._wake.set()
+
+    async def flush(self, timeout_ms: int | None = None) -> None:
+        """Drain queued and in-flight events, dropping whatever does not fit.
+
+        Args:
+            timeout_ms: Deadline in milliseconds.  On expiry the queued
+                remainder is dropped and reported as ``AJ3003``.
+        """
+        deadline = _nonnegative_int(timeout_ms, DEFAULT_FLUSH_TIMEOUT_MS) / 1000
+        if not self._queue and self._in_flight == 0:
+            return
+
+        self._ensure_worker()
+        idle = self._idle
+        if idle is None:
+            # No loop was running, so nothing can drain. Reachable only if the
+            # caller has no running loop, which cannot happen inside `await`.
+            return
+
+        self._flush_now = True
+        if self._wake is not None:
+            self._wake.set()
+        try:
+            await asyncio.wait_for(idle.wait(), timeout=deadline)
+        except (asyncio.TimeoutError, TimeoutError):
+            dropped = len(self._queue)
+            self._queue.clear()
+            if dropped:
+                self._diagnose(CAPTURE_FLUSH_EXPIRED, dropped)
+        finally:
+            self._flush_now = False
+
+    def _ensure_worker(self) -> None:
+        """Start the worker task, or leave events queued until a loop exists."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop. Events stay queued until a capture() or flush()
+            # happens inside one; dropping here would lose events that a later
+            # flush() could still deliver.
+            return
+
+        alive = self._worker is not None and not self._worker.done()
+        if alive and self._loop is loop:
+            return
+
+        # asyncio primitives belong to the loop that created them, so a new loop
+        # needs a fresh Event pair and task.
+        self._loop = loop
+        self._wake = asyncio.Event()
+        self._idle = asyncio.Event()
+        self._worker = loop.create_task(self._run())
+
+    def _mark_idle_if_done(self) -> None:
+        if not self._queue and self._in_flight == 0 and self._idle is not None:
+            self._idle.set()
+
+    async def _run(self) -> None:
+        wake = self._wake
+        if wake is None:  # pragma: no cover - set by _ensure_worker
+            return
+        while True:
+            if not self._queue:
+                self._mark_idle_if_done()
+                wake.clear()
+                try:
+                    await asyncio.wait_for(wake.wait(), timeout=_IDLE_WAIT_SECONDS)
+                except (asyncio.TimeoutError, TimeoutError):
+                    pass
+                if not self._queue:
+                    # Nothing arrived while idling. Ending the task frees the
+                    # loop; the next capture() starts a new one.
+                    return
+
+            if (
+                len(self._queue) < self._batch_size
+                and self._batch_delay > 0
+                and not self._flush_now
+            ):
+                await asyncio.sleep(self._batch_delay)
+
+            batch: list[pb.CaptureEvent] = []
+            while self._queue and len(batch) < self._batch_size:
+                batch.append(self._queue.popleft())
+            if not batch:
+                continue
+
+            self._in_flight += len(batch)
+            try:
+                await self._send(batch)
+            except (asyncio.CancelledError, GeneratorExit):
+                # The loop is going away. This is not a send failure, so it is
+                # not reported as one.
+                self._in_flight -= len(batch)
+                raise
+            except Exception:
+                # Send-once: a failed batch is dropped, never retried.
+                self._diagnose(CAPTURE_SEND_FAILED, len(batch))
+                self._in_flight -= len(batch)
+            else:
+                self._in_flight -= len(batch)
+            self._mark_idle_if_done()

--- a/src/arcjet/guard/_diagnostics.py
+++ b/src/arcjet/guard/_diagnostics.py
@@ -17,10 +17,11 @@ length-bounded key names that :mod:`arcjet._metadata` already sanitizes.
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Callable, Protocol
 
-from arcjet._logging import logger
+from arcjet._logging import logger as _default_logger
 
 CAPTURE_INPUT_INVALID = "AJ3000"
 """A capture call's input could not be normalized; the event was dropped."""
@@ -85,6 +86,7 @@ class CoalescingDiagnose(Diagnose, Protocol):
 
 def create_diagnose(
     *,
+    logger: logging.Logger | None = None,
     monotonic: Callable[[], float] = time.monotonic,
     coalesce_seconds: float = _COALESCE_SECONDS,
 ) -> CoalescingDiagnose:
@@ -105,6 +107,7 @@ def create_diagnose(
     why the reported figure is a count of events, not a guarantee of the total.
 
     Args:
+        logger: Where to report.  Defaults to the ``arcjet`` logger.
         monotonic: Clock used for the coalescing window.  Injectable so tests
             do not have to sleep.
         coalesce_seconds: Quiet period per code.  ``0`` logs every diagnostic.
@@ -121,8 +124,10 @@ def create_diagnose(
     suppressed: dict[str, int] = {}
     last_logged: dict[str, float] = {}
 
+    sink = logger if logger is not None else _default_logger
+
     def emit(code: str, count: int) -> None:
-        logger.warning(
+        sink.warning(
             "arcjet %s: %s (%d event(s))",
             code,
             _MESSAGES.get(code, "Capture diagnostic"),
@@ -163,5 +168,3 @@ def create_diagnose(
 
     diagnose.drain = drain  # type: ignore[attr-defined]  # matches the Diagnose protocol
     return diagnose  # type: ignore[return-value]  # drain attached above
-
-    return diagnose

--- a/src/arcjet/guard/_diagnostics.py
+++ b/src/arcjet/guard/_diagnostics.py
@@ -1,0 +1,132 @@
+"""Local diagnostics for problems that cannot travel over the wire.
+
+Most SDK-side validation problems reach you as ``decision.warnings``: the SDK
+reports them to the server in ``local_warnings`` and they come back attached to
+the decision.  Capture has no such channel.  It is fire-and-forget, so an event
+dropped before it was sent has no response to carry a warning back on — if we
+do not report it locally, nobody ever finds out.
+
+Diagnostics therefore go to the ``arcjet`` stdlib logger, which is silent by
+default (a ``NullHandler``) and which applications already configure to control
+Arcjet's output.  See :mod:`arcjet._logging`.
+
+Messages are static text plus counts.  They never contain metadata values,
+capture actions, credentials, headers, or request bodies — only the escaped and
+length-bounded key names that :mod:`arcjet._metadata` already sanitizes.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Protocol
+
+from arcjet._logging import logger
+
+CAPTURE_INPUT_INVALID = "AJ3000"
+"""A capture call's input could not be normalized; the event was dropped."""
+
+CAPTURE_QUEUE_FULL = "AJ3001"
+"""The send queue was full; the newest events were dropped."""
+
+CAPTURE_SEND_FAILED = "AJ3002"
+"""A batch send failed; its events were dropped without retry."""
+
+CAPTURE_FLUSH_EXPIRED = "AJ3003"
+"""A ``flush()`` deadline expired; the remaining events were dropped."""
+
+OPTION_DROPPED = "AJ1001"
+"""A field was rejected during validation and dropped."""
+
+METADATA_ENCODE_FAILED = "AJ1017"
+"""A metadata key could not be encoded and was dropped."""
+
+_MESSAGES = {
+    CAPTURE_INPUT_INVALID: "Capture input was invalid; the event was dropped",
+    CAPTURE_QUEUE_FULL: "Capture queue is full; newest events were dropped",
+    CAPTURE_SEND_FAILED: (
+        "Capture batch send failed; events were dropped without retry"
+    ),
+    CAPTURE_FLUSH_EXPIRED: (
+        "Capture flush deadline expired; remaining events were dropped"
+    ),
+    # Validation codes. On a guard() call these reach you as decision.warnings;
+    # a capture() call has no response to carry them, so they come through here
+    # as well. They are also still sent in the event's local_warnings.
+    OPTION_DROPPED: "A capture field was invalid and was dropped",
+    METADATA_ENCODE_FAILED: "Metadata keys could not be encoded and were dropped",
+}
+
+_COALESCE_SECONDS = 60.0
+"""How long a code stays quiet after being logged, while counts accumulate.
+
+Capture is called on a request path, so a persistent problem — a full queue
+under sustained load, an unreachable API — would otherwise emit one log line per
+event and turn a best-effort telemetry drop into a logging incident.  Counts are
+accumulated while a code is quiet and reported with the next line, so the
+volume is bounded without losing the total.
+"""
+
+
+class Diagnose(Protocol):
+    """Reports one local diagnostic.  Never raises."""
+
+    def __call__(self, code: str, count: int = 1) -> None: ...
+
+
+def create_diagnose(
+    *,
+    monotonic: Callable[[], float] = time.monotonic,
+    coalesce_seconds: float = _COALESCE_SECONDS,
+) -> Diagnose:
+    """Build a coalescing diagnostics reporter.
+
+    Each code is logged at most once per *coalesce_seconds*.  Events dropped
+    while a code is quiet are counted and included in the next line for that
+    code, so the reported total is never short even though the line count is
+    bounded.
+
+    Args:
+        monotonic: Clock used for the coalescing window.  Injectable so tests
+            do not have to sleep.
+        coalesce_seconds: Quiet period per code.  ``0`` logs every diagnostic.
+
+    Returns:
+        A callable taking ``(code, count)``.  It never raises: a diagnostics
+        sink is observational and must not break application control flow or
+        the background delivery worker.
+    """
+    # Not lock-guarded. Concurrent reports can race to emit an extra line or
+    # briefly double-count, which costs a duplicate log entry; taking a lock on
+    # every dropped event would put contention on the request path to protect
+    # nothing that matters.
+    suppressed: dict[str, int] = {}
+    last_logged: dict[str, float] = {}
+
+    def diagnose(code: str, count: int = 1) -> None:
+        try:
+            message = _MESSAGES.get(code, "Capture diagnostic")
+            pending = suppressed.pop(code, 0) + count
+
+            now = monotonic()
+            previous = last_logged.get(code)
+            if (
+                coalesce_seconds > 0
+                and previous is not None
+                and now - previous < coalesce_seconds
+            ):
+                suppressed[code] = pending
+                return
+
+            last_logged[code] = now
+            logger.warning(
+                "arcjet %s: %s (%d event(s))",
+                code,
+                message,
+                pending,
+                extra={"event": "capture_diagnostic", "code": code, "count": pending},
+            )
+        except Exception:
+            # Including a logging handler that raises.
+            pass
+
+    return diagnose

--- a/src/arcjet/guard/_diagnostics.py
+++ b/src/arcjet/guard/_diagnostics.py
@@ -61,29 +61,48 @@ _COALESCE_SECONDS = 60.0
 
 Capture is called on a request path, so a persistent problem — a full queue
 under sustained load, an unreachable API — would otherwise emit one log line per
-event and turn a best-effort telemetry drop into a logging incident.  Counts are
-accumulated while a code is quiet and reported with the next line, so the
-volume is bounded without losing the total.
+event and turn a best-effort telemetry drop into a logging incident.
 """
 
 
 class Diagnose(Protocol):
-    """Reports one local diagnostic.  Never raises."""
+    """Reports one local diagnostic.  Never raises.
+
+    Deliberately call-only: the delivery drivers report drops and nothing more,
+    so a bare function or a recording test double satisfies this. Draining is a
+    separate capability — see :class:`CoalescingDiagnose`.
+    """
 
     def __call__(self, code: str, count: int = 1) -> None: ...
+
+
+class CoalescingDiagnose(Diagnose, Protocol):
+    """A :class:`Diagnose` that holds counts back and can be asked to release."""
+
+    def drain(self) -> None:
+        """Emit any counts held back by coalescing.  Never raises."""
 
 
 def create_diagnose(
     *,
     monotonic: Callable[[], float] = time.monotonic,
     coalesce_seconds: float = _COALESCE_SECONDS,
-) -> Diagnose:
+) -> CoalescingDiagnose:
     """Build a coalescing diagnostics reporter.
 
-    Each code is logged at most once per *coalesce_seconds*.  Events dropped
-    while a code is quiet are counted and included in the next line for that
-    code, so the reported total is never short even though the line count is
-    bounded.
+    Each code is logged at most once per *coalesce_seconds*.  Counts arriving
+    while a code is quiet accumulate and are reported by whichever comes first:
+    the next line for that code, or :meth:`drain`, which ``flush()`` calls.
+
+    That pairing matters. Coalescing alone under-reports a burst that stops:
+    a thousand drops inside one window would log ``1`` and hold the rest for a
+    successor that never comes. ``flush()`` draining the remainder is what makes
+    the total honest for the shape the capture ADR recommends — capture during a
+    request, flush at the end of it.
+
+    A burst that ends with neither a later drop nor a ``flush()`` still
+    under-reports. That is the residual cost of bounding log volume, and it is
+    why the reported figure is a count of events, not a guarantee of the total.
 
     Args:
         monotonic: Clock used for the coalescing window.  Injectable so tests
@@ -91,9 +110,9 @@ def create_diagnose(
         coalesce_seconds: Quiet period per code.  ``0`` logs every diagnostic.
 
     Returns:
-        A callable taking ``(code, count)``.  It never raises: a diagnostics
-        sink is observational and must not break application control flow or
-        the background delivery worker.
+        A callable taking ``(code, count)``, with a ``drain()`` attribute.
+        Neither raises: a diagnostics sink is observational and must not break
+        application control flow or the background delivery worker.
     """
     # Not lock-guarded. Concurrent reports can race to emit an extra line or
     # briefly double-count, which costs a duplicate log entry; taking a lock on
@@ -102,9 +121,17 @@ def create_diagnose(
     suppressed: dict[str, int] = {}
     last_logged: dict[str, float] = {}
 
+    def emit(code: str, count: int) -> None:
+        logger.warning(
+            "arcjet %s: %s (%d event(s))",
+            code,
+            _MESSAGES.get(code, "Capture diagnostic"),
+            count,
+            extra={"event": "capture_diagnostic", "code": code, "count": count},
+        )
+
     def diagnose(code: str, count: int = 1) -> None:
         try:
-            message = _MESSAGES.get(code, "Capture diagnostic")
             pending = suppressed.pop(code, 0) + count
 
             now = monotonic()
@@ -118,15 +145,23 @@ def create_diagnose(
                 return
 
             last_logged[code] = now
-            logger.warning(
-                "arcjet %s: %s (%d event(s))",
-                code,
-                message,
-                pending,
-                extra={"event": "capture_diagnostic", "code": code, "count": pending},
-            )
+            emit(code, pending)
         except Exception:
             # Including a logging handler that raises.
             pass
+
+    def drain() -> None:
+        """Report every count still held back, ignoring the quiet period."""
+        try:
+            while suppressed:
+                code, count = suppressed.popitem()
+                if count:
+                    last_logged[code] = monotonic()
+                    emit(code, count)
+        except Exception:
+            pass
+
+    diagnose.drain = drain  # type: ignore[attr-defined]  # matches the Diagnose protocol
+    return diagnose  # type: ignore[return-value]  # drain attached above
 
     return diagnose

--- a/tests/integration/guard/test_capture_client.py
+++ b/tests/integration/guard/test_capture_client.py
@@ -247,6 +247,53 @@ class TestCaptureSync:
             f"race.{i}" for i in range(threads)
         )
 
+    def test_flush_drains_coalesced_diagnostics(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """flush() must release counts the diagnostics channel held back.
+
+        Coalescing means a burst of drops reports only its first event until
+        something releases the rest. flush() is that something — without this
+        wiring the fix in `_diagnostics` would never be reached in practice.
+        """
+        drained: list[bool] = []
+
+        class Spy:
+            def __call__(self, code: str, count: int = 1) -> None:
+                pass
+
+            def drain(self) -> None:
+                drained.append(True)
+
+        monkeypatch.setattr(guard_client, "_diagnose", Spy())
+
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+        guard.capture(action="drain.me")
+        guard.flush(TIMEOUT_MS)
+
+        assert drained == [True], "flush() should drain held-back diagnostics"
+
+    def test_flush_without_capture_does_not_drain(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing was captured, so there is no delivery and nothing to drain."""
+        drained: list[bool] = []
+
+        class Spy:
+            def __call__(self, code: str, count: int = 1) -> None:
+                pass
+
+            def drain(self) -> None:
+                drained.append(True)
+
+        monkeypatch.setattr(guard_client, "_diagnose", Spy())
+
+        guard = _make_guard_sync(FakeCaptureSyncClient())
+        guard.flush(TIMEOUT_MS)
+
+        assert drained == []
+
     def test_guard_still_works_alongside_capture(self) -> None:
         """Capture must not disturb the decision path."""
         client = FakeCaptureSyncClient()

--- a/tests/integration/guard/test_capture_client.py
+++ b/tests/integration/guard/test_capture_client.py
@@ -1,0 +1,303 @@
+"""Integration tests for ``capture()`` on the guard clients.
+
+These drive the whole path a user's call takes — ``capture()`` → normalization →
+delivery → transport — with a fake transport standing in for the network, so the
+wire request is inspected rather than mocked away.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+from arcjet.guard import ArcjetGuard, ArcjetGuardSync
+from arcjet.guard.proto.decide.v2 import decide_pb2 as pb
+
+TIMEOUT_MS = 5000
+
+
+class FakeCaptureAsyncClient:
+    """Async transport that records Capture requests."""
+
+    def __init__(self, fail: bool = False) -> None:
+        self.requests: list[pb.CaptureRequest] = []
+        self.headers: list[dict[str, str] | None] = []
+        self.timeouts: list[int | None] = []
+        self._fail = fail
+
+    async def capture(
+        self,
+        request: pb.CaptureRequest,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout_ms: int | None = None,
+    ) -> pb.CaptureResponse:
+        self.requests.append(request)
+        self.headers.append(headers)
+        self.timeouts.append(timeout_ms)
+        if self._fail:
+            raise ConnectionError("network down")
+        return pb.CaptureResponse()
+
+    @property
+    def events(self) -> list[pb.CaptureEvent]:
+        return [e for r in self.requests for e in r.events]
+
+
+class FakeCaptureSyncClient:
+    """Sync transport that records Capture requests."""
+
+    def __init__(self, fail: bool = False) -> None:
+        self._lock = threading.Lock()
+        self.requests: list[pb.CaptureRequest] = []
+        self.headers: list[dict[str, str] | None] = []
+        self.timeouts: list[int | None] = []
+        self._fail = fail
+
+    def capture(
+        self,
+        request: pb.CaptureRequest,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout_ms: int | None = None,
+    ) -> pb.CaptureResponse:
+        with self._lock:
+            self.requests.append(request)
+            self.headers.append(headers)
+            self.timeouts.append(timeout_ms)
+        if self._fail:
+            raise ConnectionError("network down")
+        return pb.CaptureResponse()
+
+    @property
+    def events(self) -> list[pb.CaptureEvent]:
+        with self._lock:
+            return [e for r in self.requests for e in r.events]
+
+
+def _make_guard(client: Any) -> ArcjetGuard:
+    return ArcjetGuard(
+        _key="test_key_123",
+        _client=client,
+        _timeout_ms=1000,
+        _user_agent="arcjet-py/test",
+    )
+
+
+def _make_guard_sync(client: Any) -> ArcjetGuardSync:
+    return ArcjetGuardSync(
+        _key="test_key_123",
+        _client=client,
+        _timeout_ms=1000,
+        _user_agent="arcjet-py/test",
+    )
+
+
+class TestCaptureSync:
+    def test_captures_an_event(self) -> None:
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+
+        guard.capture(action="refund.issued")
+        guard.flush(TIMEOUT_MS)
+
+        assert [e.action for e in client.events] == ["refund.issued"]
+
+    def test_sends_auth_and_user_agent(self) -> None:
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+
+        guard.capture(action="refund.issued")
+        guard.flush(TIMEOUT_MS)
+
+        assert client.headers[0] == {"Authorization": "Bearer test_key_123"}
+        assert client.requests[0].user_agent == "arcjet-py/test"
+        # Capture reuses the client's configured timeout rather than its own.
+        assert client.timeouts[0] == 1000
+
+    def test_sets_source_to_sdk(self) -> None:
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+
+        guard.capture(action="refund.issued")
+        guard.flush(TIMEOUT_MS)
+
+        assert client.events[0].source == "sdk"
+
+    def test_forwards_all_fields(self) -> None:
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+        occurred = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+
+        guard.capture(
+            action="refund.issued",
+            correlation_id="workflow_123",
+            decision_id="gdec_abc",
+            occurred_at=occurred,
+            metadata={"invoice": {"id": "inv_1"}},
+        )
+        guard.flush(TIMEOUT_MS)
+
+        event = client.events[0]
+        assert event.correlation_id == "workflow_123"
+        assert event.decision_id == "gdec_abc"
+        assert event.occurred_at_unix_ms == int(occurred.timestamp() * 1000)
+        assert dict(event.metadata_json) == {"invoice": '{"id":"inv_1"}'}
+
+    def test_invalid_event_never_reaches_the_transport(self) -> None:
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+
+        guard.capture(action="")  # no action: dropped during normalization
+        guard.flush(TIMEOUT_MS)
+
+        assert client.requests == []
+
+    def test_capture_does_not_raise_on_transport_failure(self) -> None:
+        client = FakeCaptureSyncClient(fail=True)
+        guard = _make_guard_sync(client)
+
+        guard.capture(action="refund.issued")
+        guard.flush(TIMEOUT_MS)  # must not raise
+
+        assert len(client.requests) == 1, "failed sends are not retried"
+
+    def test_flush_without_capture_does_nothing(self) -> None:
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+
+        guard.flush(TIMEOUT_MS)
+
+        assert client.requests == []
+
+    def test_batches_a_burst(self) -> None:
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+
+        for i in range(5):
+            guard.capture(action=f"thing.{i}")
+        guard.flush(TIMEOUT_MS)
+
+        assert len(client.events) == 5
+        assert len(client.requests) < 5, "a burst should not be one request each"
+
+    def test_guard_still_works_alongside_capture(self) -> None:
+        """Capture must not disturb the decision path."""
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+
+        guard.capture(action="refund.issued")
+        guard.flush(TIMEOUT_MS)
+
+        # An empty rule list short-circuits before the transport, which is
+        # enough to show guard() is unaffected by the capture machinery. It
+        # fails open, so the conclusion is ALLOW with the error on the result.
+        decision = guard.guard([], label="test")
+        assert decision.conclusion == "ALLOW"
+
+
+class TestCaptureAsync:
+    """Async client tests, driven with ``asyncio.run`` (no pytest-asyncio)."""
+
+    def test_captures_an_event(self) -> None:
+        client = FakeCaptureAsyncClient()
+        guard = _make_guard(client)
+
+        async def scenario() -> None:
+            guard.capture(action="refund.issued")
+            await guard.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert [e.action for e in client.events] == ["refund.issued"]
+
+    def test_sends_auth_and_user_agent(self) -> None:
+        client = FakeCaptureAsyncClient()
+        guard = _make_guard(client)
+
+        async def scenario() -> None:
+            guard.capture(action="refund.issued")
+            await guard.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert client.headers[0] == {"Authorization": "Bearer test_key_123"}
+        assert client.requests[0].user_agent == "arcjet-py/test"
+        assert client.timeouts[0] == 1000
+
+    def test_sets_source_to_sdk(self) -> None:
+        client = FakeCaptureAsyncClient()
+        guard = _make_guard(client)
+
+        async def scenario() -> None:
+            guard.capture(action="refund.issued")
+            await guard.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert client.events[0].source == "sdk"
+
+    def test_capture_returns_without_awaiting(self) -> None:
+        """capture() is fire-and-forget: it is not a coroutine."""
+        client = FakeCaptureAsyncClient()
+        guard = _make_guard(client)
+
+        async def scenario() -> None:
+            result = guard.capture(action="refund.issued")
+            assert result is None
+            await guard.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert len(client.events) == 1
+
+    def test_invalid_event_never_reaches_the_transport(self) -> None:
+        client = FakeCaptureAsyncClient()
+        guard = _make_guard(client)
+
+        async def scenario() -> None:
+            guard.capture(action=None)  # type: ignore[arg-type]
+            await guard.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert client.requests == []
+
+    def test_capture_does_not_raise_on_transport_failure(self) -> None:
+        client = FakeCaptureAsyncClient(fail=True)
+        guard = _make_guard(client)
+
+        async def scenario() -> None:
+            guard.capture(action="refund.issued")
+            await guard.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert len(client.requests) == 1, "failed sends are not retried"
+
+    def test_batches_a_burst_into_one_request(self) -> None:
+        client = FakeCaptureAsyncClient()
+        guard = _make_guard(client)
+
+        async def scenario() -> None:
+            for i in range(5):
+                guard.capture(action=f"thing.{i}")
+            await guard.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert len(client.events) == 5
+        assert len(client.requests) == 1
+
+    def test_flush_without_capture_does_nothing(self) -> None:
+        client = FakeCaptureAsyncClient()
+        guard = _make_guard(client)
+
+        async def scenario() -> None:
+            await guard.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert client.requests == []

--- a/tests/integration/guard/test_capture_client.py
+++ b/tests/integration/guard/test_capture_client.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 from datetime import datetime, timezone
 from typing import Any
 
+import pytest
+
+import arcjet.guard._client as guard_client
 from arcjet.guard import ArcjetGuard, ArcjetGuardSync
 from arcjet.guard.proto.decide.v2 import decide_pb2 as pb
 
@@ -182,6 +186,66 @@ class TestCaptureSync:
 
         assert len(client.events) == 5
         assert len(client.requests) < 5, "a burst should not be one request each"
+
+    def test_concurrent_first_capture_builds_one_delivery(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two threads racing the first capture() must not each build a delivery.
+
+        Without double-checked locking in `_ensure_delivery`, both threads see
+        `_delivery is None`, each construct a `SyncCaptureDelivery` and start a
+        worker thread, and one is overwritten — orphaning its thread along with
+        any events already queued on it. Those events are then invisible to
+        `flush()`, which only knows about the surviving delivery.
+
+        The construction window is widened artificially. Written the obvious way
+        — threads on a barrier, then assert one delivery — this test passed 20/20
+        against the *unlocked* code: construction is fast enough that the GIL
+        hands it over before a second thread can enter. Sleeping inside the
+        constructor is what makes the race deterministic instead of hoping the
+        scheduler cooperates.
+        """
+        client = FakeCaptureSyncClient()
+        guard = _make_guard_sync(client)
+
+        built = []
+        built_lock = threading.Lock()
+        real_delivery = guard_client.SyncCaptureDelivery
+
+        def slow_delivery(**kwargs: Any) -> Any:
+            with built_lock:
+                built.append(1)
+            # Hold the window open so every waiting thread would also enter an
+            # unlocked check-then-construct.
+            time.sleep(0.05)
+            return real_delivery(**kwargs)
+
+        monkeypatch.setattr(guard_client, "SyncCaptureDelivery", slow_delivery)
+
+        threads = 8
+        start = threading.Barrier(threads)
+
+        def worker(index: int) -> None:
+            start.wait(TIMEOUT_MS / 1000)
+            guard.capture(action=f"race.{index}")
+
+        workers = [threading.Thread(target=worker, args=(i,)) for i in range(threads)]
+        for t in workers:
+            t.start()
+        for t in workers:
+            t.join(TIMEOUT_MS / 1000)
+
+        assert len(built) == 1, (
+            f"{len(built)} deliveries were constructed; each extra one orphans a "
+            "worker thread and any events queued on it"
+        )
+
+        guard.flush(TIMEOUT_MS)
+
+        # No event was orphaned on a discarded delivery.
+        assert sorted(e.action for e in client.events) == sorted(
+            f"race.{i}" for i in range(threads)
+        )
 
     def test_guard_still_works_alongside_capture(self) -> None:
         """Capture must not disturb the decision path."""

--- a/tests/integration/guard/test_capture_client.py
+++ b/tests/integration/guard/test_capture_client.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 
 import arcjet.guard._client as guard_client
-from arcjet.guard import ArcjetGuard, ArcjetGuardSync
+from arcjet.guard import ArcjetGuard, ArcjetGuardSync, launch_arcjet_sync
 from arcjet.guard.proto.decide.v2 import decide_pb2 as pb
 
 TIMEOUT_MS = 5000
@@ -90,12 +90,22 @@ def _make_guard(client: Any) -> ArcjetGuard:
     )
 
 
-def _make_guard_sync(client: Any) -> ArcjetGuardSync:
+def _make_guard_sync(client: Any, diagnose: Any = None) -> ArcjetGuardSync:
+    # `client` and `diagnose` are `Any` because the fakes implement only the
+    # methods a given test needs, not the whole transport protocol.
+    if diagnose is None:
+        return ArcjetGuardSync(
+            _key="test_key_123",
+            _client=client,
+            _timeout_ms=1000,
+            _user_agent="arcjet-py/test",
+        )
     return ArcjetGuardSync(
         _key="test_key_123",
         _client=client,
         _timeout_ms=1000,
         _user_agent="arcjet-py/test",
+        _diagnose=diagnose,
     )
 
 
@@ -247,9 +257,7 @@ class TestCaptureSync:
             f"race.{i}" for i in range(threads)
         )
 
-    def test_flush_drains_coalesced_diagnostics(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_flush_drains_coalesced_diagnostics(self) -> None:
         """flush() must release counts the diagnostics channel held back.
 
         Coalescing means a burst of drops reports only its first event until
@@ -265,18 +273,13 @@ class TestCaptureSync:
             def drain(self) -> None:
                 drained.append(True)
 
-        monkeypatch.setattr(guard_client, "_diagnose", Spy())
-
-        client = FakeCaptureSyncClient()
-        guard = _make_guard_sync(client)
+        guard = _make_guard_sync(FakeCaptureSyncClient(), Spy())
         guard.capture(action="drain.me")
         guard.flush(TIMEOUT_MS)
 
         assert drained == [True], "flush() should drain held-back diagnostics"
 
-    def test_flush_without_capture_does_not_drain(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_flush_without_capture_does_not_drain(self) -> None:
         """Nothing was captured, so there is no delivery and nothing to drain."""
         drained: list[bool] = []
 
@@ -287,12 +290,51 @@ class TestCaptureSync:
             def drain(self) -> None:
                 drained.append(True)
 
-        monkeypatch.setattr(guard_client, "_diagnose", Spy())
-
-        guard = _make_guard_sync(FakeCaptureSyncClient())
+        guard = _make_guard_sync(FakeCaptureSyncClient(), Spy())
         guard.flush(TIMEOUT_MS)
 
         assert drained == []
+
+    def test_a_failed_send_reports_aj3002_at_the_client(self) -> None:
+        """A client-level failed send must be observable.
+
+        This could not be asserted before: diagnostics went to a process-global
+        coalescing sink whose state no test could reset, so the existing failure
+        test could only count requests. A per-client sink makes the report itself
+        checkable, which is the whole point of being able to pass one in.
+        """
+        codes: list[tuple[str, int]] = []
+        client = FakeCaptureSyncClient(fail=True)
+        guard = _make_guard_sync(
+            client, lambda code, count=1: codes.append((code, count))
+        )
+
+        guard.capture(action="doomed")
+        guard.flush(TIMEOUT_MS)
+
+        assert ("AJ3002", 1) in codes, f"expected a send-failure report, got {codes}"
+        assert len(client.requests) == 1, "and still no retry"
+
+    def test_a_supplied_logger_receives_every_diagnostic(self, caplog) -> None:
+        """A caller-supplied logger is not coalesced.
+
+        The default sink deliberately reports each code once a minute to bound log
+        volume. A caller who passes a logger is the one deciding what to filter,
+        and needs all of them — anything keeping a count of dropped events cannot
+        work from the coalesced stream.
+        """
+        import logging
+
+        supplied = logging.getLogger("test.arcjet.capture.supplied")
+        guard = launch_arcjet_sync(key="ajkey_test", logger=supplied)
+
+        with caplog.at_level(logging.WARNING, logger=supplied.name):
+            # Three invalid events: three reports, not one.
+            for _ in range(3):
+                guard.capture(action="")
+
+        codes = [getattr(r, "code", None) for r in caplog.records]
+        assert codes == ["AJ3000", "AJ3000", "AJ3000"], codes
 
     def test_guard_still_works_alongside_capture(self) -> None:
         """Capture must not disturb the decision path."""

--- a/tests/unit/guard/test_capture.py
+++ b/tests/unit/guard/test_capture.py
@@ -1,0 +1,258 @@
+"""Unit tests for capture event normalization.
+
+Normalization is the part of capture with no concurrency in it, so these tests
+are plain and deterministic. Delivery is covered in ``test_delivery.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from arcjet.guard._capture import (
+    CAPTURE_OPTION_DROPPED_CODE,
+    CAPTURE_SOURCE_SDK,
+    build_capture_request,
+    normalize_capture_event,
+)
+from arcjet.guard._diagnostics import CAPTURE_INPUT_INVALID
+
+
+class _Diagnostics:
+    """Records diagnostic codes instead of logging them."""
+
+    def __init__(self) -> None:
+        self.codes: list[tuple[str, int]] = []
+
+    def __call__(self, code: str, count: int = 1) -> None:
+        self.codes.append((code, count))
+
+    @property
+    def just_codes(self) -> list[str]:
+        return [code for code, _ in self.codes]
+
+
+def _normalize(**kwargs: object):
+    diag = _Diagnostics()
+    event = normalize_capture_event(diagnose=diag, **kwargs)
+    return event, diag
+
+
+class TestAction:
+    def test_minimal_event(self) -> None:
+        event, diag = _normalize(action="refund.issued")
+
+        assert event is not None
+        assert event.action == "refund.issued"
+        assert event.correlation_id == ""
+        assert event.decision_id == ""
+        assert list(event.local_warnings) == []
+        assert diag.codes == []
+
+    def test_source_is_always_sdk(self) -> None:
+        """The producer sets source; the server never defaults it."""
+        event, _ = _normalize(action="refund.issued")
+
+        assert event is not None
+        assert event.source == CAPTURE_SOURCE_SDK == "sdk"
+
+    def test_occurred_at_defaults_to_now(self) -> None:
+        before = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        event, _ = _normalize(action="refund.issued")
+        after = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+        assert event is not None
+        assert before <= event.occurred_at_unix_ms <= after
+
+    def test_missing_action_drops_the_event(self) -> None:
+        event, diag = _normalize(action=None)
+
+        assert event is None
+        assert diag.just_codes == [CAPTURE_INPUT_INVALID]
+
+    def test_empty_action_drops_the_event(self) -> None:
+        event, diag = _normalize(action="")
+
+        assert event is None
+        assert diag.just_codes == [CAPTURE_INPUT_INVALID]
+
+    def test_non_string_action_drops_the_event(self) -> None:
+        event, diag = _normalize(action=42)
+
+        assert event is None
+        assert diag.just_codes == [CAPTURE_INPUT_INVALID]
+
+
+class TestOptionalFields:
+    def test_all_fields_survive(self) -> None:
+        occurred = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+        event, diag = _normalize(
+            action="refund.issued",
+            correlation_id="workflow_123",
+            decision_id="gdec_abc",
+            occurred_at=occurred,
+            metadata={"invoice": {"id": "inv_123"}, "refunded": True},
+        )
+
+        assert event is not None
+        assert event.correlation_id == "workflow_123"
+        assert event.decision_id == "gdec_abc"
+        assert event.occurred_at_unix_ms == int(occurred.timestamp() * 1000)
+        assert dict(event.metadata_json) == {
+            "invoice": '{"id":"inv_123"}',
+            "refunded": "true",
+        }
+        assert diag.codes == []
+
+    def test_none_is_not_a_dropped_field(self) -> None:
+        """Absent means unset, so it earns no warning."""
+        event, diag = _normalize(
+            action="refund.issued",
+            correlation_id=None,
+            decision_id=None,
+            occurred_at=None,
+            metadata=None,
+        )
+
+        assert event is not None
+        assert list(event.local_warnings) == []
+        assert diag.codes == []
+
+    def test_bad_optional_field_drops_only_itself(self) -> None:
+        event, diag = _normalize(
+            action="refund.issued",
+            correlation_id=123,
+            decision_id="gdec_abc",
+        )
+
+        assert event is not None
+        # The event survives, and the good sibling field is untouched.
+        assert event.action == "refund.issued"
+        assert event.decision_id == "gdec_abc"
+        assert event.correlation_id == ""
+        codes = [w.code for w in event.local_warnings]
+        assert codes == [CAPTURE_OPTION_DROPPED_CODE]
+        assert "correlation_id" in event.local_warnings[0].message
+        assert diag.just_codes == [CAPTURE_OPTION_DROPPED_CODE]
+
+    def test_several_bad_fields_each_warn(self) -> None:
+        event, _ = _normalize(
+            action="refund.issued",
+            correlation_id=123,
+            decision_id=[],
+            occurred_at="yesterday",
+            metadata=7,
+        )
+
+        assert event is not None
+        messages = " ".join(w.message for w in event.local_warnings)
+        for name in ("correlation_id", "decision_id", "occurred_at", "metadata"):
+            assert name in messages
+
+    def test_non_mapping_metadata_is_dropped(self) -> None:
+        event, _ = _normalize(action="refund.issued", metadata=["not", "a", "map"])
+
+        assert event is not None
+        assert dict(event.metadata_json) == {}
+        assert [w.code for w in event.local_warnings] == [CAPTURE_OPTION_DROPPED_CODE]
+
+    def test_unencodable_metadata_value_drops_one_key(self) -> None:
+        event, _ = _normalize(
+            action="refund.issued",
+            metadata={"good": 1, "bad": {1, 2, 3}},
+        )
+
+        assert event is not None
+        assert dict(event.metadata_json) == {"good": "1"}
+        assert any("bad" in w.message for w in event.local_warnings)
+
+
+class TestOccurredAt:
+    def test_naive_datetime_is_local_time(self) -> None:
+        naive = datetime(2026, 7, 27, 12, 0)
+        event, diag = _normalize(action="refund.issued", occurred_at=naive)
+
+        assert event is not None
+        assert event.occurred_at_unix_ms == int(naive.timestamp() * 1000)
+        assert diag.codes == []
+
+    def test_pre_epoch_is_rejected(self) -> None:
+        """The wire field is unsigned, so a negative value would wrap."""
+        event, diag = _normalize(
+            action="refund.issued",
+            occurred_at=datetime(1969, 7, 20, tzinfo=timezone.utc),
+        )
+
+        assert event is not None
+        # Falls back to now rather than sending a wrapped timestamp.
+        assert event.occurred_at_unix_ms > 0
+        assert [w.code for w in event.local_warnings] == [CAPTURE_OPTION_DROPPED_CODE]
+        assert "occurred_at" in event.local_warnings[0].message
+        assert diag.just_codes == [CAPTURE_OPTION_DROPPED_CODE]
+
+    def test_epoch_itself_is_allowed(self) -> None:
+        event, diag = _normalize(
+            action="refund.issued",
+            occurred_at=datetime(1970, 1, 1, tzinfo=timezone.utc),
+        )
+
+        assert event is not None
+        assert event.occurred_at_unix_ms == 0
+        assert diag.codes == []
+
+    def test_far_future_is_allowed(self) -> None:
+        """Clock skew is the server's problem; the SDK only guards the sign."""
+        future = datetime.now(tz=timezone.utc) + timedelta(days=365 * 20)
+        event, diag = _normalize(action="refund.issued", occurred_at=future)
+
+        assert event is not None
+        assert event.occurred_at_unix_ms == int(future.timestamp() * 1000)
+        assert diag.codes == []
+
+
+class TestHostileInput:
+    def test_throwing_mapping_does_not_raise(self) -> None:
+        class Hostile(dict):
+            def items(self):
+                raise RuntimeError("boom")
+
+        event, _ = _normalize(action="refund.issued", metadata=Hostile())
+
+        # encode_metadata swallows the failure, so the event still goes out.
+        assert event is not None
+        assert dict(event.metadata_json) == {}
+
+    def test_throwing_datetime_subclass_does_not_raise(self) -> None:
+        class Hostile(datetime):
+            def timestamp(self) -> float:
+                raise ValueError("boom")
+
+        event, diag = _normalize(
+            action="refund.issued",
+            occurred_at=Hostile(2026, 7, 27, tzinfo=timezone.utc),
+        )
+
+        assert event is not None
+        assert event.occurred_at_unix_ms > 0
+        assert diag.just_codes == [CAPTURE_OPTION_DROPPED_CODE]
+
+    def test_action_with_lone_surrogate_does_not_raise(self) -> None:
+        """protobuf cannot encode a lone surrogate; it must not escape."""
+        event, diag = _normalize(action="refund\ud800.issued")
+
+        # Either dropped cleanly or carried; the requirement is no exception.
+        assert event is None or event.action is not None
+        if event is None:
+            assert diag.just_codes == [CAPTURE_INPUT_INVALID]
+
+
+class TestCaptureRequest:
+    def test_wraps_events_with_user_agent(self) -> None:
+        event, _ = _normalize(action="refund.issued")
+        assert event is not None
+
+        request = build_capture_request([event], user_agent="arcjet-py/test")
+
+        assert request.user_agent == "arcjet-py/test"
+        assert len(request.events) == 1
+        assert request.events[0].action == "refund.issued"
+        assert request.sent_at_unix_ms > 0

--- a/tests/unit/guard/test_capture.py
+++ b/tests/unit/guard/test_capture.py
@@ -236,13 +236,21 @@ class TestHostileInput:
         assert diag.just_codes == [CAPTURE_OPTION_DROPPED_CODE]
 
     def test_action_with_lone_surrogate_does_not_raise(self) -> None:
-        """protobuf cannot encode a lone surrogate; it must not escape."""
+        """protobuf cannot encode a lone surrogate; it must not escape.
+
+        Either outcome is acceptable — dropped with a diagnostic, or carried
+        through — so this asserts each branch is internally consistent rather
+        than picking one. `event.action` is checked for truthiness, not for
+        `is not None`: a protobuf string field defaults to `""`, so the
+        not-None form was always true and asserted nothing.
+        """
         event, diag = _normalize(action="refund\ud800.issued")
 
-        # Either dropped cleanly or carried; the requirement is no exception.
-        assert event is None or event.action is not None
         if event is None:
             assert diag.just_codes == [CAPTURE_INPUT_INVALID]
+        else:
+            assert event.action, "a surviving event must carry its action"
+            assert event.source == CAPTURE_SOURCE_SDK
 
 
 class TestCaptureRequest:

--- a/tests/unit/guard/test_delivery.py
+++ b/tests/unit/guard/test_delivery.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 
 from arcjet.guard._delivery import AsyncCaptureDelivery, SyncCaptureDelivery
 from arcjet.guard._diagnostics import (
@@ -222,7 +223,79 @@ class TestSyncDelivery:
 
             delivery.flush(50)  # cannot drain: the send is stuck
 
-            assert diag.total(CAPTURE_FLUSH_EXPIRED) == 1
+            # Two: the queued event, dropped, plus the in-flight one, abandoned.
+            # The in-flight event used to be omitted from this total entirely.
+            assert diag.total(CAPTURE_FLUSH_EXPIRED) == 2
+        finally:
+            blocked.set()
+
+    def test_flush_does_not_drop_events_captured_after_it_started(self) -> None:
+        """One caller's flush deadline must not discard another's telemetry.
+
+        The capture ADR recommends calling flush() at the end of a handler, so in
+        a concurrent server several flushes overlap with ongoing captures. Both
+        drivers previously drained the whole queue on expiry, so request A's
+        deadline deleted request B's queued events.
+        """
+        sent: list[str] = []
+        blocked = threading.Event()
+        in_send = threading.Event()
+        diag = Diagnostics()
+
+        def send(events: list[pb.CaptureEvent]) -> None:
+            sent.extend(e.action for e in events)
+            if not in_send.is_set():
+                in_send.set()
+                blocked.wait(TIMEOUT)
+
+        delivery = SyncCaptureDelivery(
+            send=send, diagnose=diag, batch_size=1, batch_delay_ms=0
+        )
+        try:
+            delivery.capture(event("early"))
+            assert in_send.wait(TIMEOUT)
+
+            def capture_late() -> None:
+                time.sleep(0.02)
+                delivery.capture(event("late-1"))
+                delivery.capture(event("late-2"))
+
+            threading.Thread(target=capture_late, daemon=True).start()
+            delivery.flush(100)  # cannot drain: the first send is stuck
+
+            assert delivery._queue.qsize() == 2, "late events must still be queued"
+        finally:
+            blocked.set()
+
+        delivery.flush(TIMEOUT_MS)
+        assert sorted(sent) == ["early", "late-1", "late-2"]
+
+    def test_flush_expiry_counts_in_flight_events(self) -> None:
+        """An abandoned in-flight send must still be reported.
+
+        It is deliberately not cancelled — the sync transport has no handle — but
+        leaving it out of the AJ3003 total would under-report the loss.
+        """
+        blocked = threading.Event()
+        in_send = threading.Event()
+        diag = Diagnostics()
+
+        def send(events: list[pb.CaptureEvent]) -> None:
+            in_send.set()
+            blocked.wait(TIMEOUT)
+
+        delivery = SyncCaptureDelivery(
+            send=send, diagnose=diag, batch_size=2, batch_delay_ms=0
+        )
+        try:
+            delivery.capture(event("in-flight"))
+            assert in_send.wait(TIMEOUT)
+            delivery.capture(event("queued"))
+
+            delivery.flush(50)
+
+            # One dropped from the queue, one abandoned on the wire.
+            assert diag.total(CAPTURE_FLUSH_EXPIRED) == 2
         finally:
             blocked.set()
 
@@ -396,7 +469,8 @@ class TestAsyncDelivery:
 
         asyncio.run(scenario())
 
-        assert diag.total(CAPTURE_FLUSH_EXPIRED) == 1
+        # Two: the queued event, dropped, plus the in-flight one, abandoned.
+        assert diag.total(CAPTURE_FLUSH_EXPIRED) == 2
 
     def test_survives_a_new_event_loop(self) -> None:
         """A client outlives any one loop, so the worker must rebind."""

--- a/tests/unit/guard/test_delivery.py
+++ b/tests/unit/guard/test_delivery.py
@@ -315,6 +315,50 @@ class TestSyncDelivery:
         assert workers, "expected a worker thread"
         assert all(t.daemon for t in workers)
 
+    def test_worker_releases_its_slot_when_it_exits(self) -> None:
+        """The exiting worker must clear the slot, not just die.
+
+        `Thread.is_alive()` stays True until the thread function returns, so
+        `_ensure_worker` gating on it alone left a window where an event enqueued
+        just after the idle timeout got no worker at all — queued, unsent, and
+        undiagnosed. The fix makes the exit decision atomic with releasing the
+        slot, so the observable invariant is that a dead worker is never left
+        recorded as the current one.
+
+        Asserted on the invariant rather than by racing it: the window is real
+        but too narrow to hit reliably, and forcing it open by holding
+        `_worker_lock` deadlocks, since `capture()` takes that same lock.
+        """
+        sent: list[str] = []
+        diag = Diagnostics()
+        delivery = SyncCaptureDelivery(
+            send=lambda events: sent.extend(e.action for e in events),
+            diagnose=diag,
+            batch_delay_ms=0,
+        )
+
+        delivery.capture(event("first"))
+        delivery.flush(TIMEOUT_MS)
+        assert sent == ["first"]
+
+        # Wait out the idle window so the worker exits on its own.
+        deadline = time.monotonic() + TIMEOUT
+        while time.monotonic() < deadline:
+            if delivery._worker is None:
+                break
+            time.sleep(0.05)
+
+        assert delivery._worker is None, (
+            "the exiting worker left itself recorded as current; a capture() "
+            "arriving now would find is_alive() True and start no replacement"
+        )
+
+        # And the next capture is picked up by a fresh worker.
+        delivery.capture(event("second"))
+        delivery.flush(TIMEOUT_MS)
+        assert sent == ["first", "second"]
+        assert diag.total(CAPTURE_FLUSH_EXPIRED) == 0
+
     def test_no_worker_thread_before_first_capture(self) -> None:
         before = len([t for t in threading.enumerate() if t.name == "arcjet-capture"])
         SyncCaptureDelivery(send=lambda events: None, diagnose=Diagnostics())
@@ -470,6 +514,79 @@ class TestAsyncDelivery:
         asyncio.run(scenario())
 
         # Two: the queued event, dropped, plus the in-flight one, abandoned.
+        assert diag.total(CAPTURE_FLUSH_EXPIRED) == 2
+
+    def test_flush_does_not_drop_events_captured_after_it_started(self) -> None:
+        """Async counterpart of the sync test with the same name.
+
+        Both drivers had the bug and both were fixed; only the sync one was
+        covered, so this driver's fix was unverified.
+        """
+        sent: list[str] = []
+        diag = Diagnostics()
+
+        async def scenario() -> None:
+            blocked = asyncio.Event()
+            in_send = asyncio.Event()
+
+            async def send(events: list[pb.CaptureEvent]) -> None:
+                sent.extend(e.action for e in events)
+                if not in_send.is_set():
+                    in_send.set()
+                    await blocked.wait()
+
+            delivery = AsyncCaptureDelivery(
+                send=send, diagnose=diag, batch_size=1, batch_delay_ms=0
+            )
+            try:
+                delivery.capture(event("early"))
+                await asyncio.wait_for(in_send.wait(), TIMEOUT)
+
+                async def capture_late() -> None:
+                    await asyncio.sleep(0.02)
+                    delivery.capture(event("late-1"))
+                    delivery.capture(event("late-2"))
+
+                task = asyncio.create_task(capture_late())
+                await delivery.flush(100)  # cannot drain: the send is stuck
+
+                assert len(delivery._queue) == 2, "late events must still be queued"
+                await task
+            finally:
+                blocked.set()
+            await delivery.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert sorted(sent) == ["early", "late-1", "late-2"]
+
+    def test_flush_expiry_counts_in_flight_events(self) -> None:
+        """Async counterpart: an abandoned in-flight send is still reported."""
+        diag = Diagnostics()
+
+        async def scenario() -> None:
+            blocked = asyncio.Event()
+            in_send = asyncio.Event()
+
+            async def send(events: list[pb.CaptureEvent]) -> None:
+                in_send.set()
+                await blocked.wait()
+
+            delivery = AsyncCaptureDelivery(
+                send=send, diagnose=diag, batch_size=1, batch_delay_ms=0
+            )
+            try:
+                delivery.capture(event("in-flight"))
+                await asyncio.wait_for(in_send.wait(), TIMEOUT)
+                delivery.capture(event("queued"))
+
+                await delivery.flush(50)
+            finally:
+                blocked.set()
+
+        asyncio.run(scenario())
+
+        # One dropped from the queue, one abandoned on the wire.
         assert diag.total(CAPTURE_FLUSH_EXPIRED) == 2
 
     def test_survives_a_new_event_loop(self) -> None:

--- a/tests/unit/guard/test_delivery.py
+++ b/tests/unit/guard/test_delivery.py
@@ -85,6 +85,46 @@ class TestSyncDelivery:
         assert sum(len(b) for b in sent) == 5
         assert len(sent) < 5
 
+    def test_flush_still_batches_the_backlog(self) -> None:
+        """A pending flush must not turn a backlog into one request per event.
+
+        Regression test. Live against the API, a five-event burst followed by
+        `flush()` produced five separate requests: the worker saw the flush flag
+        and sent only the event it already held, abandoning the queue. In-process
+        sends are instant, so the looser "fewer requests than events" assertion
+        above passed anyway — this test blocks the first send to build a real
+        backlog, which is what made the bug visible in production.
+        """
+        sent: list[int] = []
+        blocked = threading.Event()
+        in_send = threading.Event()
+
+        def send(events: list[pb.CaptureEvent]) -> None:
+            sent.append(len(events))
+            if not in_send.is_set():
+                in_send.set()
+                blocked.wait(TIMEOUT)
+
+        delivery = SyncCaptureDelivery(
+            send=send, diagnose=Diagnostics(), batch_size=10, batch_delay_ms=50
+        )
+
+        try:
+            delivery.capture(event("first"))
+            # The worker is now inside send(), holding nothing else.
+            assert in_send.wait(TIMEOUT)
+            for i in range(5):
+                delivery.capture(event(f"backlog.{i}"))
+        finally:
+            blocked.set()
+
+        delivery.flush(TIMEOUT_MS)
+
+        assert sum(sent) == 6, f"all six events should be sent, got {sent}"
+        assert sent == [1, 5], (
+            f"the five queued events should go as one batch, got {sent}"
+        )
+
     def test_drops_when_the_queue_is_full(self) -> None:
         """The ceiling covers in-flight events, so a stuck send applies it."""
         blocked = threading.Event()

--- a/tests/unit/guard/test_delivery.py
+++ b/tests/unit/guard/test_delivery.py
@@ -1,0 +1,403 @@
+"""Unit tests for bounded, batched capture delivery.
+
+Delivery is concurrent, so these tests avoid sleeping to observe a result.  They
+synchronize on ``threading.Event`` / ``asyncio.Event`` and on ``flush()``, and
+every test that blocks a send releases it in a ``finally`` so a failure cannot
+hang the suite.
+
+``batch_delay_ms=0`` is used wherever batching itself is not under test, so a
+send happens as soon as the worker picks the event up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from arcjet.guard._delivery import AsyncCaptureDelivery, SyncCaptureDelivery
+from arcjet.guard._diagnostics import (
+    CAPTURE_FLUSH_EXPIRED,
+    CAPTURE_QUEUE_FULL,
+    CAPTURE_SEND_FAILED,
+)
+from arcjet.guard.proto.decide.v2 import decide_pb2 as pb
+
+# Long enough that a correct implementation never reaches it, short enough that
+# a deadlock fails the test instead of hanging the suite.
+TIMEOUT = 5.0
+TIMEOUT_MS = 5000
+
+
+def event(action: str = "refund.issued") -> pb.CaptureEvent:
+    return pb.CaptureEvent(action=action, source="sdk")
+
+
+class Diagnostics:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.codes: list[tuple[str, int]] = []
+
+    def __call__(self, code: str, count: int = 1) -> None:
+        with self._lock:
+            self.codes.append((code, count))
+
+    def total(self, code: str) -> int:
+        with self._lock:
+            return sum(n for c, n in self.codes if c == code)
+
+
+class TestSyncDelivery:
+    def test_sends_a_captured_event(self) -> None:
+        sent: list[list[pb.CaptureEvent]] = []
+        diag = Diagnostics()
+        delivery = SyncCaptureDelivery(
+            send=lambda events: sent.append(events),
+            diagnose=diag,
+            batch_delay_ms=0,
+        )
+
+        delivery.capture(event())
+        delivery.flush(TIMEOUT_MS)
+
+        assert [e.action for batch in sent for e in batch] == ["refund.issued"]
+        assert diag.codes == []
+
+    def test_batches_several_events_into_one_request(self) -> None:
+        """A burst costs one request, not one per event."""
+        sent: list[list[pb.CaptureEvent]] = []
+        release = threading.Event()
+
+        def send(events: list[pb.CaptureEvent]) -> None:
+            sent.append(events)
+            release.set()
+
+        delivery = SyncCaptureDelivery(
+            send=send, diagnose=Diagnostics(), batch_size=10, batch_delay_ms=50
+        )
+
+        for i in range(5):
+            delivery.capture(event(f"a.{i}"))
+        delivery.flush(TIMEOUT_MS)
+
+        assert release.wait(TIMEOUT)
+        # The exact split depends on worker timing; what matters is that all
+        # five arrived and they did not each become their own request.
+        assert sum(len(b) for b in sent) == 5
+        assert len(sent) < 5
+
+    def test_drops_when_the_queue_is_full(self) -> None:
+        """The ceiling covers in-flight events, so a stuck send applies it."""
+        blocked = threading.Event()
+        in_send = threading.Event()
+        diag = Diagnostics()
+
+        def send(events: list[pb.CaptureEvent]) -> None:
+            in_send.set()
+            blocked.wait(TIMEOUT)
+
+        delivery = SyncCaptureDelivery(
+            send=send,
+            diagnose=diag,
+            queue_size=2,
+            batch_size=1,
+            batch_delay_ms=0,
+        )
+
+        try:
+            delivery.capture(event("first"))
+            # Wait until it is genuinely on the wire, so `outstanding` is 1 and
+            # the queue is empty — otherwise the counts race.
+            assert in_send.wait(TIMEOUT)
+
+            delivery.capture(event("second"))  # queued: outstanding == 2
+            delivery.capture(event("third"))  # over the ceiling: dropped
+            delivery.capture(event("fourth"))  # also dropped
+
+            assert diag.total(CAPTURE_QUEUE_FULL) == 2
+        finally:
+            blocked.set()
+
+    def test_a_failed_send_is_not_retried(self) -> None:
+        attempts: list[int] = []
+        diag = Diagnostics()
+
+        def send(events: list[pb.CaptureEvent]) -> None:
+            attempts.append(len(events))
+            raise ConnectionError("network down")
+
+        delivery = SyncCaptureDelivery(
+            send=send, diagnose=diag, batch_size=1, batch_delay_ms=0
+        )
+
+        delivery.capture(event())
+        delivery.flush(TIMEOUT_MS)
+
+        assert attempts == [1], "a failed batch must not be retried"
+        assert diag.total(CAPTURE_SEND_FAILED) == 1
+
+    def test_a_failed_send_does_not_stop_the_worker(self) -> None:
+        results: list[str] = []
+        diag = Diagnostics()
+
+        def send(events: list[pb.CaptureEvent]) -> None:
+            action = events[0].action
+            results.append(action)
+            if action == "bad":
+                raise ConnectionError("network down")
+
+        delivery = SyncCaptureDelivery(
+            send=send, diagnose=diag, batch_size=1, batch_delay_ms=0
+        )
+
+        delivery.capture(event("bad"))
+        delivery.flush(TIMEOUT_MS)
+        delivery.capture(event("good"))
+        delivery.flush(TIMEOUT_MS)
+
+        assert results == ["bad", "good"]
+        assert diag.total(CAPTURE_SEND_FAILED) == 1
+
+    def test_flush_with_nothing_queued_returns(self) -> None:
+        delivery = SyncCaptureDelivery(send=lambda events: None, diagnose=Diagnostics())
+
+        delivery.flush(TIMEOUT_MS)  # must not block or raise
+
+    def test_flush_deadline_drops_the_remainder(self) -> None:
+        blocked = threading.Event()
+        in_send = threading.Event()
+        diag = Diagnostics()
+
+        def send(events: list[pb.CaptureEvent]) -> None:
+            in_send.set()
+            blocked.wait(TIMEOUT)
+
+        delivery = SyncCaptureDelivery(
+            send=send, diagnose=diag, batch_size=1, batch_delay_ms=0
+        )
+
+        try:
+            delivery.capture(event("in-flight"))
+            assert in_send.wait(TIMEOUT)
+            delivery.capture(event("queued"))
+
+            delivery.flush(50)  # cannot drain: the send is stuck
+
+            assert diag.total(CAPTURE_FLUSH_EXPIRED) == 1
+        finally:
+            blocked.set()
+
+    def test_worker_thread_is_a_daemon(self) -> None:
+        """A queued event must not keep the interpreter alive at exit."""
+        started = threading.Event()
+        delivery = SyncCaptureDelivery(
+            send=lambda events: started.set(),
+            diagnose=Diagnostics(),
+            batch_delay_ms=0,
+        )
+
+        delivery.capture(event())
+        assert started.wait(TIMEOUT)
+
+        workers = [t for t in threading.enumerate() if t.name == "arcjet-capture"]
+        assert workers, "expected a worker thread"
+        assert all(t.daemon for t in workers)
+
+    def test_no_worker_thread_before_first_capture(self) -> None:
+        before = len([t for t in threading.enumerate() if t.name == "arcjet-capture"])
+        SyncCaptureDelivery(send=lambda events: None, diagnose=Diagnostics())
+        after = len([t for t in threading.enumerate() if t.name == "arcjet-capture"])
+
+        assert after == before
+
+    def test_invalid_tuning_falls_back_to_defaults(self) -> None:
+        sent: list[list[pb.CaptureEvent]] = []
+        delivery = SyncCaptureDelivery(
+            send=lambda events: sent.append(events),
+            diagnose=Diagnostics(),
+            queue_size=0,
+            batch_size=-5,
+            batch_delay_ms=None,  # type: ignore[arg-type]
+        )
+
+        delivery.capture(event())
+        delivery.flush(TIMEOUT_MS)
+
+        assert sum(len(b) for b in sent) == 1
+
+
+class TestAsyncDelivery:
+    """Async driver tests.
+
+    arcjet-py has no pytest-asyncio, so each test is a sync function that drives
+    a coroutine with ``asyncio.run``, matching ``TestArcjetGuardAsync`` in
+    ``tests/integration/guard/test_client.py``.
+    """
+
+    def test_sends_a_captured_event(self) -> None:
+        sent: list[list[pb.CaptureEvent]] = []
+        diag = Diagnostics()
+
+        async def send(events: list[pb.CaptureEvent]) -> None:
+            sent.append(events)
+
+        async def scenario() -> None:
+            delivery = AsyncCaptureDelivery(send=send, diagnose=diag, batch_delay_ms=0)
+            delivery.capture(event())
+            await delivery.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert [e.action for batch in sent for e in batch] == ["refund.issued"]
+        assert diag.codes == []
+
+    def test_batches_several_events_into_one_request(self) -> None:
+        sent: list[list[pb.CaptureEvent]] = []
+
+        async def send(events: list[pb.CaptureEvent]) -> None:
+            sent.append(events)
+
+        async def scenario() -> None:
+            delivery = AsyncCaptureDelivery(
+                send=send, diagnose=Diagnostics(), batch_size=10, batch_delay_ms=10
+            )
+            for i in range(5):
+                delivery.capture(event(f"a.{i}"))
+            await delivery.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert sum(len(b) for b in sent) == 5
+        assert len(sent) == 1, "one flush of five events should be one request"
+
+    def test_drops_when_the_queue_is_full(self) -> None:
+        diag = Diagnostics()
+
+        async def scenario() -> None:
+            blocked = asyncio.Event()
+            in_send = asyncio.Event()
+
+            async def send(events: list[pb.CaptureEvent]) -> None:
+                in_send.set()
+                await blocked.wait()
+
+            delivery = AsyncCaptureDelivery(
+                send=send,
+                diagnose=diag,
+                queue_size=2,
+                batch_size=1,
+                batch_delay_ms=0,
+            )
+            try:
+                delivery.capture(event("first"))
+                await asyncio.wait_for(in_send.wait(), TIMEOUT)
+
+                delivery.capture(event("second"))
+                delivery.capture(event("third"))
+                delivery.capture(event("fourth"))
+            finally:
+                blocked.set()
+
+        asyncio.run(scenario())
+
+        assert diag.total(CAPTURE_QUEUE_FULL) == 2
+
+    def test_a_failed_send_is_not_retried(self) -> None:
+        attempts: list[int] = []
+        diag = Diagnostics()
+
+        async def send(events: list[pb.CaptureEvent]) -> None:
+            attempts.append(len(events))
+            raise ConnectionError("network down")
+
+        async def scenario() -> None:
+            delivery = AsyncCaptureDelivery(
+                send=send, diagnose=diag, batch_size=1, batch_delay_ms=0
+            )
+            delivery.capture(event())
+            await delivery.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+        assert attempts == [1], "a failed batch must not be retried"
+        assert diag.total(CAPTURE_SEND_FAILED) == 1
+
+    def test_flush_with_nothing_queued_returns(self) -> None:
+        async def send(events: list[pb.CaptureEvent]) -> None:
+            return None
+
+        async def scenario() -> None:
+            delivery = AsyncCaptureDelivery(send=send, diagnose=Diagnostics())
+            await delivery.flush(TIMEOUT_MS)
+
+        asyncio.run(scenario())
+
+    def test_flush_deadline_drops_the_remainder(self) -> None:
+        diag = Diagnostics()
+
+        async def scenario() -> None:
+            blocked = asyncio.Event()
+            in_send = asyncio.Event()
+
+            async def send(events: list[pb.CaptureEvent]) -> None:
+                in_send.set()
+                await blocked.wait()
+
+            delivery = AsyncCaptureDelivery(
+                send=send, diagnose=diag, batch_size=1, batch_delay_ms=0
+            )
+            try:
+                delivery.capture(event("in-flight"))
+                await asyncio.wait_for(in_send.wait(), TIMEOUT)
+                delivery.capture(event("queued"))
+
+                await delivery.flush(50)
+            finally:
+                blocked.set()
+
+        asyncio.run(scenario())
+
+        assert diag.total(CAPTURE_FLUSH_EXPIRED) == 1
+
+    def test_survives_a_new_event_loop(self) -> None:
+        """A client outlives any one loop, so the worker must rebind."""
+        sent: list[str] = []
+
+        async def send(events: list[pb.CaptureEvent]) -> None:
+            sent.extend(e.action for e in events)
+
+        delivery = AsyncCaptureDelivery(
+            send=send, diagnose=Diagnostics(), batch_delay_ms=0
+        )
+
+        async def use(action: str) -> None:
+            delivery.capture(event(action))
+            await delivery.flush(TIMEOUT_MS)
+
+        # Two separate asyncio.run calls are two distinct event loops, which is
+        # what a per-test loop or a second entrypoint looks like.
+        asyncio.run(use("first-loop"))
+        asyncio.run(use("second-loop"))
+
+        assert sent == ["first-loop", "second-loop"]
+
+    def test_capture_without_a_running_loop_keeps_the_event(self) -> None:
+        """Queued outside a loop, delivered by a later flush inside one."""
+        sent: list[str] = []
+
+        async def send(events: list[pb.CaptureEvent]) -> None:
+            sent.extend(e.action for e in events)
+
+        delivery = AsyncCaptureDelivery(
+            send=send, diagnose=Diagnostics(), batch_delay_ms=0
+        )
+
+        # No loop is running here, so no worker can start yet.
+        delivery.capture(event("queued-early"))
+        assert sent == []
+
+        async def later() -> None:
+            await delivery.flush(TIMEOUT_MS)
+
+        asyncio.run(later())
+
+        assert sent == ["queued-early"]

--- a/tests/unit/guard/test_diagnostics.py
+++ b/tests/unit/guard/test_diagnostics.py
@@ -1,0 +1,117 @@
+"""Unit tests for the local capture diagnostics channel.
+
+The clock is injected so coalescing can be tested without sleeping.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from arcjet.guard._diagnostics import (
+    CAPTURE_QUEUE_FULL,
+    CAPTURE_SEND_FAILED,
+    create_diagnose,
+)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class TestDiagnostics:
+    def test_logs_a_warning(self, caplog) -> None:
+        diagnose = create_diagnose()
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            diagnose(CAPTURE_QUEUE_FULL, 3)
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelno == logging.WARNING
+        assert CAPTURE_QUEUE_FULL in record.getMessage()
+        assert "3 event(s)" in record.getMessage()
+        # Structured fields, so a handler can route on them.
+        assert record.code == CAPTURE_QUEUE_FULL
+        assert record.count == 3
+
+    def test_defaults_to_a_count_of_one(self, caplog) -> None:
+        diagnose = create_diagnose()
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            diagnose(CAPTURE_QUEUE_FULL)
+
+        assert "1 event(s)" in caplog.records[0].getMessage()
+
+    def test_repeats_are_coalesced(self, caplog) -> None:
+        """A hot loop dropping events must not become a logging incident."""
+        clock = FakeClock()
+        diagnose = create_diagnose(monotonic=clock, coalesce_seconds=60)
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            for _ in range(100):
+                diagnose(CAPTURE_QUEUE_FULL, 1)
+
+        assert len(caplog.records) == 1, "only the first should be logged"
+
+    def test_suppressed_counts_are_reported_later(self, caplog) -> None:
+        """Quiet does not mean lost: the next line carries the backlog."""
+        clock = FakeClock()
+        diagnose = create_diagnose(monotonic=clock, coalesce_seconds=60)
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            diagnose(CAPTURE_QUEUE_FULL, 1)  # logged: 1
+            for _ in range(9):
+                diagnose(CAPTURE_QUEUE_FULL, 1)  # suppressed: 9 accumulate
+            clock.advance(61)
+            diagnose(CAPTURE_QUEUE_FULL, 1)  # logged: 9 + 1
+
+        assert len(caplog.records) == 2
+        assert "1 event(s)" in caplog.records[0].getMessage()
+        assert "10 event(s)" in caplog.records[1].getMessage()
+
+    def test_codes_are_coalesced_independently(self, caplog) -> None:
+        clock = FakeClock()
+        diagnose = create_diagnose(monotonic=clock, coalesce_seconds=60)
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            diagnose(CAPTURE_QUEUE_FULL, 1)
+            diagnose(CAPTURE_SEND_FAILED, 1)
+            diagnose(CAPTURE_QUEUE_FULL, 1)
+
+        codes = [r.code for r in caplog.records]
+        assert codes == [CAPTURE_QUEUE_FULL, CAPTURE_SEND_FAILED]
+
+    def test_zero_window_logs_everything(self, caplog) -> None:
+        diagnose = create_diagnose(monotonic=FakeClock(), coalesce_seconds=0)
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            for _ in range(3):
+                diagnose(CAPTURE_QUEUE_FULL, 1)
+
+        assert len(caplog.records) == 3
+
+    def test_unknown_code_still_logs(self, caplog) -> None:
+        diagnose = create_diagnose()
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            diagnose("AJ9999", 1)
+
+        assert len(caplog.records) == 1
+        assert "AJ9999" in caplog.records[0].getMessage()
+
+    def test_never_raises_when_the_handler_fails(self) -> None:
+        """A diagnostics sink is observational; it must not break delivery."""
+
+        def exploding_monotonic() -> float:
+            raise RuntimeError("boom")
+
+        diagnose = create_diagnose(monotonic=exploding_monotonic)
+
+        diagnose(CAPTURE_QUEUE_FULL, 1)  # must not raise

--- a/tests/unit/guard/test_diagnostics.py
+++ b/tests/unit/guard/test_diagnostics.py
@@ -106,6 +106,63 @@ class TestDiagnostics:
         assert len(caplog.records) == 1
         assert "AJ9999" in caplog.records[0].getMessage()
 
+    def test_drain_reports_counts_held_back_by_coalescing(self, caplog) -> None:
+        """Coalescing alone under-reports a burst that stops.
+
+        This is the defect drain() exists for: 1000 drops inside one quiet window
+        logged a single line reading "1 event(s)" and held the other 999 for a
+        successor that never arrived — 0.1% of the real total.
+        """
+        clock = FakeClock()
+        diagnose = create_diagnose(monotonic=clock, coalesce_seconds=60)
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            for _ in range(1000):
+                diagnose(CAPTURE_QUEUE_FULL, 1)
+            # Before draining, only the first event has been reported.
+            assert sum(r.count for r in caplog.records) == 1
+
+            diagnose.drain()
+
+        assert sum(r.count for r in caplog.records) == 1000, (
+            "drain() must release the suppressed remainder"
+        )
+
+    def test_drain_with_nothing_held_back_is_silent(self, caplog) -> None:
+        diagnose = create_diagnose(monotonic=FakeClock(), coalesce_seconds=60)
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            diagnose(CAPTURE_QUEUE_FULL, 1)
+            before = len(caplog.records)
+            diagnose.drain()
+            diagnose.drain()
+
+        assert len(caplog.records) == before
+
+    def test_drain_covers_every_code_independently(self, caplog) -> None:
+        clock = FakeClock()
+        diagnose = create_diagnose(monotonic=clock, coalesce_seconds=60)
+
+        with caplog.at_level(logging.WARNING, logger="arcjet"):
+            for _ in range(3):
+                diagnose(CAPTURE_QUEUE_FULL, 1)
+                diagnose(CAPTURE_SEND_FAILED, 2)
+            diagnose.drain()
+
+        totals: dict[str, int] = {}
+        for record in caplog.records:
+            totals[record.code] = totals.get(record.code, 0) + record.count
+        assert totals == {CAPTURE_QUEUE_FULL: 3, CAPTURE_SEND_FAILED: 6}
+
+    def test_drain_never_raises(self) -> None:
+        def exploding_monotonic() -> float:
+            raise RuntimeError("boom")
+
+        diagnose = create_diagnose(monotonic=exploding_monotonic)
+
+        diagnose(CAPTURE_QUEUE_FULL, 1)
+        diagnose.drain()  # must not raise
+
     def test_never_raises_when_the_handler_fails(self) -> None:
         """A diagnostics sink is observational; it must not break delivery."""
 


### PR DESCRIPTION
Adds `capture()` and `flush()` to both guard clients. `capture()` records something the application did, for visibility only: it never affects a decision, never raises, and returns without awaiting on either client.

Delivery follows the shape the capture ADRs set out:

- Bounded queue, dropping when full. Blocking for space would turn our telemetry into the caller's latency, since capture() runs on a request path inside someone else's application.
- Batched, so a burst of calls costs one request instead of one each.
- Send-once. A failed batch is dropped and never retried; a stale visibility event is worth less than the capacity a retry consumes.
- `flush(timeout_ms)` drains queued and in-flight events and drops the remainder on expiry. There is no `close()`.

Every drop is reported through the `arcjet` logger with a stable code — AJ3000 invalid input, AJ3001 queue full, AJ3002 send failed, AJ3003 flush deadline. Nothing is discarded silently. Capture is fire-and-forget, so there is no response to carry a warning back on; without a local channel a drop would be invisible. Diagnostics coalesce per code so a persistent problem cannot turn a best-effort drop into a logging incident, while the accumulated count is still reported.

Each event sets `source` to "sdk". The producer decides this, not the caller, so it is not an argument; the server stores an absent source as NULL, meaning unknown, and never substitutes a default.

There are two delivery drivers because arcjet-py has two clients: a daemon worker thread for the sync client and an asyncio task for the async one, so each uses its own transport and neither pays for the other's machinery. The async worker is created on first use and rebinds if the event loop changes, because a client outlives any single loop.

Normalization validates each field independently, so one bad optional value drops only itself and is reported both locally and in the event's local_warnings. Only an unusable `action` drops the whole event, since an event that does not say what happened records nothing. Pre-epoch timestamps are rejected because the wire field is unsigned.

Tests cover normalization, both delivery drivers, the diagnostics channel, and both clients end to end against a fake transport: 63 new tests.