### PR TITLE
fix: classify phone numbers with Rampart model

### DIFF
--- a/sensitive-info-rampart/README.md
+++ b/sensitive-info-rampart/README.md
@@ -71,9 +71,10 @@ The model detects: `GIVEN_NAME`, `SURNAME`, `EMAIL`, `PHONE_NUMBER`, `URL`,
 `CITY`, `STATE`, and `ZIP_CODE`.
 
 Deterministic recognizers additionally detect the structured, validatable types
-`EMAIL`, `URL`, `IP_ADDRESS`, `PHONE_NUMBER`, `SSN`, and `CREDIT_CARD_NUMBER`
-(Luhn-validated), mirroring Rampart's deterministic redaction layer. On
-overlapping text the recognizer result wins over the model.
+`EMAIL`, `URL`, `IP_ADDRESS`, `SSN`, and `CREDIT_CARD_NUMBER` (Luhn-validated),
+mirroring Rampart's deterministic redaction layer. Phone numbers are left to
+the model because their digit shape overlaps with financial and government
+identifiers. On overlapping text the recognizer result wins over the model.
 
 The full set is exported as `rampart_entities`:
 

--- a/sensitive-info-rampart/src/arcjet_sensitive_info_rampart/__init__.py
+++ b/sensitive-info-rampart/src/arcjet_sensitive_info_rampart/__init__.py
@@ -107,8 +107,10 @@ class RampartOptions:
     recognizers: Optional[Sequence[Recognizer]] = None
     """Deterministic recognizers to run alongside the model (default:
     :data:`~arcjet_sensitive_info_rampart._recognizers.default_recognizers`).
-    These handle structured, validatable types and are the supported extension
-    point for custom detection. Pass ``()`` to rely on the model alone."""
+    These handle structured, validatable types other than phone numbers, whose
+    digit shape overlaps with financial and government identifiers. They are
+    the supported extension point for custom detection. Pass ``()`` to rely on
+    the model alone."""
 
     run_model: Optional[ModelRunner] = None
     """Override the model runner. Intended for testing — supply a function that
@@ -246,8 +248,8 @@ def rampart(options: RampartOptions = RampartOptions()) -> SensitiveInfoBackend:
     ``BANK_ACCOUNT``, ``ROUTING_NUMBER``, ``GOVERNMENT_ID``, ``PASSPORT``,
     ``DRIVERS_LICENSE``, ``BUILDING_NUMBER``, ``STREET_NAME``,
     ``SECONDARY_ADDRESS``, ``CITY``, ``STATE``, ``ZIP_CODE``. Detected by
-    deterministic recognizers: ``EMAIL``, ``URL``, ``IP_ADDRESS``,
-    ``PHONE_NUMBER``, ``SSN``, ``CREDIT_CARD_NUMBER``.
+    deterministic recognizers: ``EMAIL``, ``URL``, ``IP_ADDRESS``, ``SSN``,
+    ``CREDIT_CARD_NUMBER``.
 
     The token-based ``detect`` callback of the ``detect_sensitive_info`` rule is
     **not** used by this backend (the model works on spans, not tokens). Use the

--- a/sensitive-info-rampart/src/arcjet_sensitive_info_rampart/_recognizers.py
+++ b/sensitive-info-rampart/src/arcjet_sensitive_info_rampart/_recognizers.py
@@ -345,17 +345,15 @@ def credit_card_recognizer(value: str) -> list[DetectedSpan]:
     return result
 
 
-# The default set of deterministic recognizers, ordered most-specific first.
-# Overlap resolution happens later in the backend (longer spans win; equal-length
-# ties keep the earlier-listed recognizer), so this order only breaks ties — for
-# example a Luhn-valid card over the looser phone matcher on the same text.
+# Phone numbers are intentionally left to the NER model because their digit
+# shape overlaps with bank accounts, routing numbers, and other identifiers. A
+# pattern cannot validate which semantic type the digits represent.
 default_recognizers: tuple[Recognizer, ...] = (
     credit_card_recognizer,
     ssn_recognizer,
     email_recognizer,
     url_recognizer,
     ip_address_recognizer,
-    phone_recognizer,
 )
 
 

--- a/tests/sensitive_info_rampart/test_integration.py
+++ b/tests/sensitive_info_rampart/test_integration.py
@@ -98,9 +98,7 @@ def test_model_detects_formatted_phone_without_phone_recognizer():
 
     backend = rampart()
     ctx = SensitiveInfoBackendContext(log=logging.getLogger("test"))
-    entities = SensitiveInfoEntitiesDeny(
-        entities=[to_analyze_entity("PHONE_NUMBER")]
-    )
+    entities = SensitiveInfoEntitiesDeny(entities=[to_analyze_entity("PHONE_NUMBER")])
     text = "Call me at +1 (415) 555-2671."
     result = backend.detect(ctx, text, entities)
 

--- a/tests/sensitive_info_rampart/test_integration.py
+++ b/tests/sensitive_info_rampart/test_integration.py
@@ -82,8 +82,12 @@ def test_model_distinguishes_bank_accounts_and_routing_numbers_from_phones():
         entity_type = from_analyze_entity(entity.identified_type)
         found.setdefault(entity_type, []).append(text[entity.start : entity.end])
 
+    assert "BANK_ACCOUNT" in found
+    assert "ROUTING_NUMBER" in found
     assert "".join(found["BANK_ACCOUNT"]) == "0123456789"
     assert "".join(found["ROUTING_NUMBER"]) == "022000020"
+    # There are no unrelated phone numbers in this fixture, so this stronger
+    # assertion also proves neither financial identifier was relabeled.
     assert "PHONE_NUMBER" not in found
 
 

--- a/tests/sensitive_info_rampart/test_integration.py
+++ b/tests/sensitive_info_rampart/test_integration.py
@@ -53,6 +53,62 @@ def test_model_detects_name_and_email():
     assert denied & {"GIVEN_NAME", "SURNAME"}
 
 
+def test_model_distinguishes_bank_accounts_and_routing_numbers_from_phones():
+    import logging
+
+    from arcjet_sensitive_info_rampart import rampart, rampart_entities
+    from arcjet_sensitive_info_rampart._entities import (
+        from_analyze_entity,
+        to_analyze_entity,
+    )
+
+    from arcjet._analyze import SensitiveInfoEntitiesDeny
+    from arcjet._sensitive_info_backend import SensitiveInfoBackendContext
+
+    backend = rampart()
+    ctx = SensitiveInfoBackendContext(log=logging.getLogger("test"))
+    entities = SensitiveInfoEntitiesDeny(
+        entities=[to_analyze_entity(entity) for entity in rampart_entities]
+    )
+    text = (
+        "Details on file: name: Alex Morgan; "
+        "email: alex.morgan@client-corp.example; ssn: 431-55-9928; "
+        "bank_account: 0123456789; routing_number: 022000020"
+    )
+    result = backend.detect(ctx, text, entities)
+
+    found: dict[str, list[str]] = {}
+    for entity in result.denied:
+        entity_type = from_analyze_entity(entity.identified_type)
+        found.setdefault(entity_type, []).append(text[entity.start : entity.end])
+
+    assert "".join(found["BANK_ACCOUNT"]) == "0123456789"
+    assert "".join(found["ROUTING_NUMBER"]) == "022000020"
+    assert "PHONE_NUMBER" not in found
+
+
+def test_model_detects_formatted_phone_without_phone_recognizer():
+    import logging
+
+    from arcjet_sensitive_info_rampart import rampart
+    from arcjet_sensitive_info_rampart._entities import to_analyze_entity
+
+    from arcjet._analyze import SensitiveInfoEntitiesDeny
+    from arcjet._sensitive_info_backend import SensitiveInfoBackendContext
+
+    backend = rampart()
+    ctx = SensitiveInfoBackendContext(log=logging.getLogger("test"))
+    entities = SensitiveInfoEntitiesDeny(
+        entities=[to_analyze_entity("PHONE_NUMBER")]
+    )
+    text = "Call me at +1 (415) 555-2671."
+    result = backend.detect(ctx, text, entities)
+
+    assert any(
+        "555-2671" in text[entity.start : entity.end] for entity in result.denied
+    )
+
+
 def test_full_core_evaluation_path():
     from arcjet_sensitive_info_rampart import rampart
 

--- a/tests/sensitive_info_rampart/test_recognizers.py
+++ b/tests/sensitive_info_rampart/test_recognizers.py
@@ -202,4 +202,4 @@ class TestRunRecognizers:
     def test_default_recognizers_order(self):
         assert default_recognizers[0] is credit_card_recognizer
         assert phone_recognizer not in default_recognizers
-        assert run_recognizers("bank account 0123456789") == []
+        assert run_recognizers("bank account 0123456789", default_recognizers) == []

--- a/tests/sensitive_info_rampart/test_recognizers.py
+++ b/tests/sensitive_info_rampart/test_recognizers.py
@@ -200,5 +200,6 @@ class TestRunRecognizers:
         assert run_recognizers("alice@example.com", []) == []
 
     def test_default_recognizers_order(self):
-        # Credit card is checked before phone so it wins ties on the same text.
         assert default_recognizers[0] is credit_card_recognizer
+        assert phone_recognizer not in default_recognizers
+        assert run_recognizers("bank account 0123456789") == []


### PR DESCRIPTION
Remove the shape-only phone recognizer from Rampart defaults so contextual NER can distinguish phone numbers from bank accounts and routing numbers. Keep structurally validated recognizers authoritative and add real-model regressions for financial identifiers and formatted phones.

ADR: https://github.com/arcjet/arcjet/pull/8679