### PR TITLE
feat(guard): add optional client registration and a test client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,6 +1278,142 @@ cannot discard another request's telemetry.
 There is no `close()`: a client holds no connection of its own to release, so
 flushing is the only shutdown step that changes what gets delivered.
 
+### Registering a client (optional)
+
+Passing the client explicitly is the recommended path, and everything above does
+exactly that. Registration is a shortcut for the case it cannot cover: code too
+deep in an application to be handed a client, where `capture()` is often most
+useful.
+
+`launch_arcjet()` never touches global state. Registering is always a separate,
+explicit call:
+
+```python
+# wherever your application starts up
+import os
+
+from arcjet.guard import launch_arcjet, register_arcjet
+
+register_arcjet(launch_arcjet(key=os.environ["ARCJET_KEY"]))
+```
+
+`capture()` is then importable on its own and reaches the registered client:
+
+```python
+# deep in application code — nothing was passed down here
+from arcjet.guard import capture
+
+
+async def refund(invoice_id: str) -> None:
+    await issue_refund(invoice_id)
+    capture(action="refund.issued", metadata={"invoice": invoice_id})
+```
+
+#### Sync and async
+
+`capture()` is one function for both client flavours, because it queues and
+returns on each of them. `guard()` and `flush()` cannot be, so they come in
+pairs matching `launch_arcjet` / `launch_arcjet_sync`:
+
+| Registered client | Guard | Flush |
+| --- | --- | --- |
+| `launch_arcjet()` | `await guard(...)` | `await flush()` |
+| `launch_arcjet_sync()` | `guard_sync(...)` | `flush_sync()` |
+
+Registration accepts either and does not record which, so calling the wrong one
+is not something a type checker can catch. It fails open and reports `AJ3007` on
+the registered client's logger.
+
+#### What happens with nothing registered
+
+`guard()` and `guard_sync()` return a fail-open `ALLOW` carrying an error
+result, so a caller that inspects the decision can see that no policy ran. They
+do not raise.
+
+```python
+decision = await guard([limit(key=user_id)], label="refund")
+
+if decision.has_failed_open():
+    # No rule was evaluated. Treat this as "policy did not run", not as a pass.
+    ...
+```
+
+`capture()` drops the event silently, and the `flush()` variants return.
+Nothing is logged: the client that would have carried a logger is the thing
+that is missing, so the only available sink would be an unconfigurable warning
+on a request path.
+
+#### Registering twice, and unregistering
+
+Registration is guarded. A second client does not displace the first — the
+attempt is reported as `AJ3004` on the **incumbent's** logger, so a library or a
+stray second `launch_arcjet()` cannot quietly redirect an application's
+telemetry to a different key. Registering the client that is already registered
+is a silent no-op.
+
+`unregister_arcjet()` takes no argument and clears whatever is there. The cost
+is that anything calling it clears the application's client and every free call
+afterwards fails open, so **libraries should not call it** — they take a client
+explicitly. That is a convention, not something the SDK enforces.
+
+The registration is a module-level global, so it is visible from every thread
+and every event loop. It is deliberately *not* a `contextvars.ContextVar`: a
+context variable set at startup is invisible inside worker threads, which is
+exactly how Flask, Django and other WSGI servers run request handlers, so
+registration would appear to work in development and silently do nothing in
+production.
+
+### Testing
+
+`arcjet.guard.testing` registers an in-memory client that records calls and
+talks to nothing:
+
+```python
+from arcjet.guard import capture
+from arcjet.guard.testing import register_test_client
+
+
+async def test_refund_captures_an_event():
+    with register_test_client() as arcjet:
+        await refund("inv_1")
+
+        assert arcjet.captures[0].action == "refund.issued"
+```
+
+The `with` block unregisters the client on the way out, including when the test
+fails part-way through. Note the `await`: the capture happens wherever the code
+under test reaches it, so a test that forgets to await an async function asserts
+before the event exists.
+
+Usually this belongs in a fixture:
+
+```python
+import pytest
+from arcjet.guard.testing import register_test_client
+
+
+@pytest.fixture
+def arcjet():
+    with register_test_client() as client:
+        yield client
+```
+
+`register_test_client()` raises if a client is already registered, which
+surfaces a leak from an earlier test rather than letting this one assert against
+the wrong recorder. `unregister()` is also available for teardown that cannot
+use `with`, and only clears the registration if it is still this client.
+
+Each recorded capture goes through the same validation and metadata encoding as
+a real `capture()`, so a call the real client would drop is not recorded here
+either, and anything the SDK rewrote is on `capture.warnings`. Recording itself
+is synchronous — once the code under test reaches `capture()`, the event is
+there with no flushing or waiting.
+
+The test client answers both `guard()` and `guard_sync()`, so it does not care
+which flavour your application uses. It records the call and returns a fail-open
+`ALLOW`, because no rule actually ran. It is not a mock server and does not let
+you stub per-rule verdicts.
+
 ## Best practices
 
 ### Single-instance pattern

--- a/README.md
+++ b/README.md
@@ -1311,7 +1311,7 @@ async def refund(invoice_id: str) -> None:
 
 #### Sync and async
 
-`capture()` is one function for both client flavours, because it queues and
+`capture()` is one function for both client flavors, because it queues and
 returns on each of them. `guard()` and `flush()` cannot be, so they come in
 pairs matching `launch_arcjet` / `launch_arcjet_sync`:
 
@@ -1410,7 +1410,7 @@ is synchronous — once the code under test reaches `capture()`, the event is
 there with no flushing or waiting.
 
 The test client answers both `guard()` and `guard_sync()`, so it does not care
-which flavour your application uses. It records the call and returns a fail-open
+which flavor your application uses. It records the call and returns a fail-open
 `ALLOW`, because no rule actually ran. It is not a mock server and does not let
 you stub per-rule verdicts.
 

--- a/src/arcjet/guard/__init__.py
+++ b/src/arcjet/guard/__init__.py
@@ -35,7 +35,7 @@ Public API
 
 **Optional registration** (from ``registry``)::
 
-    register_arcjet, unregister_arcjet, registered_client
+    register_arcjet, unregister_arcjet
     guard, guard_sync, capture, flush, flush_sync
 
 Registering a client is optional and separate from launching one.  It exists so
@@ -68,7 +68,6 @@ from ._registry import (
     guard,
     guard_sync,
     register_arcjet,
-    registered_client,
     unregister_arcjet,
 )
 from ._rules import (
@@ -169,7 +168,6 @@ __all__ = [
     # effect until an application calls register_arcjet(); launch_arcjet()
     # touches no global state.
     "register_arcjet",
-    "registered_client",
     "unregister_arcjet",
     "capture",
     "flush",

--- a/src/arcjet/guard/__init__.py
+++ b/src/arcjet/guard/__init__.py
@@ -33,6 +33,20 @@ Public API
     launch_arcjet, launch_arcjet_sync
     ArcjetGuard, ArcjetGuardSync
 
+**Optional registration** (from ``registry``)::
+
+    register_arcjet, unregister_arcjet, registered_client
+    guard, guard_sync, capture, flush, flush_sync
+
+Registering a client is optional and separate from launching one.  It exists so
+code that cannot reach a client handle can still call ``guard()`` and
+``capture()``; passing a client explicitly always works and is the recommended
+path.  ``capture()`` is a single function because it queues and returns on both
+clients, while ``guard``/``flush`` come in async and ``_sync`` pairs mirroring
+the two client flavours.
+
+The in-memory test client lives in :mod:`arcjet.guard.testing`.
+
 Both clients expose ``.guard()`` for decisions and ``.capture()`` /
 ``.flush()`` for visibility events.  ``capture()`` is fire-and-forget: it
 records what your application did without affecting any decision, and is
@@ -46,6 +60,16 @@ from ._client import (
     ArcjetGuardSync,
     launch_arcjet,
     launch_arcjet_sync,
+)
+from ._registry import (
+    capture,
+    flush,
+    flush_sync,
+    guard,
+    guard_sync,
+    register_arcjet,
+    registered_client,
+    unregister_arcjet,
 )
 from ._rules import (
     DetectPromptInjection,
@@ -141,4 +165,15 @@ __all__ = [
     "ArcjetGuardSync",
     "launch_arcjet",
     "launch_arcjet_sync",
+    # Optional registration, and the free calls it enables. Nothing here takes
+    # effect until an application calls register_arcjet(); launch_arcjet()
+    # touches no global state.
+    "register_arcjet",
+    "registered_client",
+    "unregister_arcjet",
+    "capture",
+    "flush",
+    "flush_sync",
+    "guard",
+    "guard_sync",
 ]

--- a/src/arcjet/guard/__init__.py
+++ b/src/arcjet/guard/__init__.py
@@ -43,7 +43,7 @@ code that cannot reach a client handle can still call ``guard()`` and
 ``capture()``; passing a client explicitly always works and is the recommended
 path.  ``capture()`` is a single function because it queues and returns on both
 clients, while ``guard``/``flush`` come in async and ``_sync`` pairs mirroring
-the two client flavours.
+the two client flavors.
 
 The in-memory test client lives in :mod:`arcjet.guard.testing`.
 

--- a/src/arcjet/guard/_diagnostics.py
+++ b/src/arcjet/guard/_diagnostics.py
@@ -23,6 +23,31 @@ from typing import Callable, Protocol
 
 from arcjet._logging import logger as _default_logger
 
+# SDK-local diagnostic codes.
+#
+# ``AJ1000``–``AJ1999`` is the server-side guard registry and travels on the
+# wire; ``AJ3000``+ is SDK-local and is only ever reported here, so the range is
+# owned by the SDKs and allocated append-only across all of them. A code means
+# the same thing in every SDK, so allocate a new one rather than reusing a
+# number another SDK spent on a different meaning.
+#
+# Allocated so far:
+#   AJ3000 capture input invalid            AJ3004 client already registered
+#   AJ3001 capture queue full               AJ3005 RETIRED — never reuse
+#   AJ3002 capture batch send failed        AJ3006 registration version clash
+#   AJ3003 capture flush expired                   (JavaScript only)
+#                                           AJ3007 wrong client flavour
+#
+# ``AJ3005`` briefly meant "no client is registered" in the JavaScript SDK and
+# was withdrawn before release: the free calls report that through their own
+# return value instead. It stays burned so a future codegen pass cannot quietly
+# hand it a second meaning.
+#
+# ``AJ3006`` has no Python counterpart. It guards JavaScript's realm-wide
+# ``Symbol.for`` slot, which every copy of the package shares. Python's import
+# cache gives one module object per name, and a vendored second copy gets its
+# own module global, so a cross-version read is unrepresentable here.
+
 CAPTURE_INPUT_INVALID = "AJ3000"
 """A capture call's input could not be normalized; the event was dropped."""
 
@@ -41,6 +66,12 @@ OPTION_DROPPED = "AJ1001"
 METADATA_ENCODE_FAILED = "AJ1017"
 """A metadata key could not be encoded and was dropped."""
 
+CLIENT_ALREADY_REGISTERED = "AJ3004"
+"""A second client tried to register; the first one was kept."""
+
+CLIENT_FLAVOUR_MISMATCH = "AJ3007"
+"""The registered client is sync/async the other way round from the call."""
+
 _MESSAGES = {
     CAPTURE_INPUT_INVALID: "Capture input was invalid; the event was dropped",
     CAPTURE_QUEUE_FULL: "Capture queue is full; newest events were dropped",
@@ -55,6 +86,14 @@ _MESSAGES = {
     # as well. They are also still sent in the event's local_warnings.
     OPTION_DROPPED: "A capture field was invalid and was dropped",
     METADATA_ENCODE_FAILED: "Metadata keys could not be encoded and were dropped",
+    # Registration codes. Neither concerns an individual event.
+    CLIENT_ALREADY_REGISTERED: (
+        "An Arcjet client is already registered; the existing one was kept"
+    ),
+    CLIENT_FLAVOUR_MISMATCH: (
+        "The registered Arcjet client is the other of sync/async from this "
+        "call; the call failed open"
+    ),
 }
 
 _COALESCE_SECONDS = 60.0

--- a/src/arcjet/guard/_diagnostics.py
+++ b/src/arcjet/guard/_diagnostics.py
@@ -23,30 +23,11 @@ from typing import Callable, Protocol
 
 from arcjet._logging import logger as _default_logger
 
-# SDK-local diagnostic codes.
-#
-# ``AJ1000``–``AJ1999`` is the server-side guard registry and travels on the
-# wire; ``AJ3000``+ is SDK-local and is only ever reported here, so the range is
-# owned by the SDKs and allocated append-only across all of them. A code means
-# the same thing in every SDK, so allocate a new one rather than reusing a
-# number another SDK spent on a different meaning.
-#
-# Allocated so far:
-#   AJ3000 capture input invalid            AJ3004 client already registered
-#   AJ3001 capture queue full               AJ3005 RETIRED — never reuse
-#   AJ3002 capture batch send failed        AJ3006 registration version clash
-#   AJ3003 capture flush expired                   (JavaScript only)
-#                                           AJ3007 wrong client flavour
-#
-# ``AJ3005`` briefly meant "no client is registered" in the JavaScript SDK and
-# was withdrawn before release: the free calls report that through their own
-# return value instead. It stays burned so a future codegen pass cannot quietly
-# hand it a second meaning.
-#
-# ``AJ3006`` has no Python counterpart. It guards JavaScript's realm-wide
-# ``Symbol.for`` slot, which every copy of the package shares. Python's import
-# cache gives one module object per name, and a vendored second copy gets its
-# own module global, so a cross-version read is unrepresentable here.
+# ``AJ1000``-``AJ1999`` is the server-side registry and travels on the wire.
+# ``AJ3000``+ is SDK-local, reported only here, and allocated append-only across
+# every Arcjet SDK: a code means the same thing in all of them, so a new meaning
+# takes a new number. ``AJ3005`` is retired — it briefly meant "no client is
+# registered" in JavaScript and was withdrawn before release.
 
 CAPTURE_INPUT_INVALID = "AJ3000"
 """A capture call's input could not be normalized; the event was dropped."""
@@ -69,7 +50,7 @@ METADATA_ENCODE_FAILED = "AJ1017"
 CLIENT_ALREADY_REGISTERED = "AJ3004"
 """A second client tried to register; the first one was kept."""
 
-CLIENT_FLAVOUR_MISMATCH = "AJ3007"
+CLIENT_FLAVOR_MISMATCH = "AJ3007"
 """The registered client is sync/async the other way round from the call."""
 
 _MESSAGES = {
@@ -90,7 +71,7 @@ _MESSAGES = {
     CLIENT_ALREADY_REGISTERED: (
         "An Arcjet client is already registered; the existing one was kept"
     ),
-    CLIENT_FLAVOUR_MISMATCH: (
+    CLIENT_FLAVOR_MISMATCH: (
         "The registered Arcjet client is the other of sync/async from this "
         "call; the call failed open"
     ),

--- a/src/arcjet/guard/_registry.py
+++ b/src/arcjet/guard/_registry.py
@@ -20,16 +20,6 @@ A module global is visible from every thread and every event loop, which is what
 "register once at startup, call from anywhere" has to mean.  ``ContextVar`` is
 still the right answer for *ambient correlation context*, which is a different
 problem and deliberately out of scope.
-
-Why there is no version check
------------------------------
-
-The JavaScript SDK stamps its registration with an SDK version because its slot
-lives on a realm-wide ``Symbol.for`` key that every copy of the package shares,
-so one copy can read a record another version wrote.  Python has no equivalent
-exposure: the import cache gives exactly one module object per name, and a
-vendored second copy is a *different* module with its own global that cannot see
-this one.  There is no cross-version read to guard against.
 """
 
 from __future__ import annotations
@@ -42,7 +32,7 @@ from typing import Any, Awaitable, Callable, Optional, Sequence, Union
 from arcjet._metadata import Metadata
 
 from ._client import ArcjetGuard, ArcjetGuardSync, _make_error_decision
-from ._diagnostics import CLIENT_ALREADY_REGISTERED, CLIENT_FLAVOUR_MISMATCH
+from ._diagnostics import CLIENT_ALREADY_REGISTERED, CLIENT_FLAVOR_MISMATCH
 from ._rules import RuleWithInput
 from ._types import Decision
 
@@ -58,7 +48,7 @@ __all__ = [
 ]
 
 AnyArcjetGuard = Union[ArcjetGuard, ArcjetGuardSync]
-"""Either client flavour.  Registration accepts both; the free calls do not."""
+"""Either client flavor.  Registration accepts both; the free calls do not."""
 
 _registered: Optional[AnyArcjetGuard] = None
 
@@ -223,7 +213,7 @@ async def guard(
             correlation_id=correlation_id,
         )
 
-    _diagnose_flavour_mismatch(client)
+    _diagnose_flavor_mismatch(client)
     return _make_error_decision(
         "guard() was called with no registered async Arcjet client"
     )
@@ -253,7 +243,7 @@ def guard_sync(
             correlation_id=correlation_id,
         )
 
-    _diagnose_flavour_mismatch(client)
+    _diagnose_flavor_mismatch(client)
     return _make_error_decision(
         "guard_sync() was called with no registered sync Arcjet client"
     )
@@ -270,7 +260,7 @@ def capture(
     """Record a fact about what the application did, through the registered
     client.
 
-    One function for both client flavours, because ``capture()`` queues and
+    One function for both client flavors, because ``capture()`` queues and
     returns on each of them — it does no I/O on the caller's path, so there is
     nothing to await and nothing to block.
 
@@ -315,7 +305,7 @@ async def flush(timeout_ms: Optional[int] = None) -> None:
         await method(timeout_ms)
         return
 
-    _diagnose_flavour_mismatch(client)
+    _diagnose_flavor_mismatch(client)
 
 
 def flush_sync(timeout_ms: Optional[int] = None) -> None:
@@ -330,7 +320,7 @@ def flush_sync(timeout_ms: Optional[int] = None) -> None:
         method(timeout_ms)
         return
 
-    _diagnose_flavour_mismatch(client)
+    _diagnose_flavor_mismatch(client)
 
 
 def _awaitable(
@@ -340,7 +330,7 @@ def _awaitable(
 
     Dispatch is on whether the method is a coroutine function rather than on
     ``isinstance`` of the two concrete client classes.  That is what Python
-    actually means by "is this the async flavour", and it keeps registration
+    actually means by "is this the async flavor", and it keeps registration
     structural: the in-memory test client and any hand-rolled double satisfy the
     free calls without subclassing anything.
     """
@@ -355,7 +345,7 @@ def _blocking(
 
     Tries *preferred* — the explicitly sync name — before *fallback*, because
     ``ArcjetGuardSync`` spells its blocking method ``guard``/``flush`` while a
-    double offering both flavours spells them ``guard_sync``/``flush_sync``.
+    double offering both flavors spells them ``guard_sync``/``flush_sync``.
     Either way an awaitable is rejected: this caller cannot await it.
     """
     for name in (preferred, fallback):
@@ -365,16 +355,16 @@ def _blocking(
     return None
 
 
-def _diagnose_flavour_mismatch(client: Optional[AnyArcjetGuard]) -> None:
-    """Report a call that found the other flavour of client registered.
+def _diagnose_flavor_mismatch(client: Optional[AnyArcjetGuard]) -> None:
+    """Report a call that found the other flavor of client registered.
 
     Only when something *is* registered.  Nothing registered is the ordinary
     unconfigured case and stays silent; a registered client of the wrong
-    flavour is a wiring mistake worth a line, and there is a configured logger
+    flavor is a wiring mistake worth a line, and there is a configured logger
     on it to put that line on.
     """
     if client is not None:
-        _diagnose(client, CLIENT_FLAVOUR_MISMATCH)
+        _diagnose(client, CLIENT_FLAVOR_MISMATCH)
 
 
 def _diagnose(client: AnyArcjetGuard, code: str) -> None:
@@ -390,4 +380,7 @@ def _diagnose(client: AnyArcjetGuard, code: str) -> None:
         if callable(diagnose):
             diagnose(code)
     except Exception:
+        # Deliberately swallowed, including a logging handler that raises. A
+        # diagnostics sink is observational: reporting that a client could not
+        # be registered must not become a second, louder failure in the caller.
         pass

--- a/src/arcjet/guard/_registry.py
+++ b/src/arcjet/guard/_registry.py
@@ -132,10 +132,55 @@ def unregister_arcjet() -> None:
 def registered_client() -> Optional[AnyArcjetGuard]:
     """Return the registered client, or ``None``.
 
-    Exposed so an application can branch on whether registration happened —
-    during startup checks, say — without reaching into module internals.
+    Internal.  Deliberately not re-exported from :mod:`arcjet.guard`: the ADR
+    does not define it and neither does the JavaScript SDK, which tests that its
+    equivalent stays unexported.  Publishing it now would make removing it a
+    breaking change later.
     """
     return _registered
+
+
+def register_arcjet_for_testing(client: AnyArcjetGuard) -> None:
+    """Register *client*, refusing to displace or share with an incumbent.
+
+    The check and the set happen under one lock, so concurrent callers cannot
+    both observe an empty slot and both believe they registered — which would
+    leave one of them asserting against a recorder no call ever reaches.
+
+    The test client uses this instead of :func:`register_arcjet` because the
+    failure modes invert under test.  In an application a second registration
+    should be survivable, so it warns and carries on.  In a test suite a client
+    left registered by an earlier test is a leak that makes the current test
+    assert against the wrong recorder — quietly, and usually somewhere else.
+
+    Raises:
+        RuntimeError: If a client is already registered.
+    """
+    global _registered
+
+    with _lock:
+        if _registered is not None:
+            raise RuntimeError(
+                "An Arcjet client is already registered. Call "
+                "unregister_arcjet() first — an earlier test probably left "
+                "one behind."
+            )
+        _registered = client
+
+
+def unregister_arcjet_if(client: AnyArcjetGuard) -> None:
+    """Clear the registration, but only if *client* still holds it.
+
+    Compare-and-clear under one lock.  A teardown that checked ownership and
+    then cleared unconditionally could clear a *replacement* registered in
+    between, so a stale handle would silently unregister somebody else's
+    client.
+    """
+    global _registered
+
+    with _lock:
+        if _registered is client:
+            _registered = None
 
 
 async def guard(
@@ -149,8 +194,8 @@ async def guard(
 
     With nothing registered — or with a *sync* client registered, which this
     cannot await — the call fails open: it returns an ALLOW carrying an error
-    result, so ``decision.is_error()`` is true and a caller that inspects the
-    decision can see that no policy ran.  It does not raise.
+    result, so ``decision.has_failed_open()`` is true and a caller that
+    inspects the decision can see that no policy ran.  It does not raise.
 
     The decision is the report.  There is deliberately no log line for the
     unregistered case: the client that would have carried a logger is the thing

--- a/src/arcjet/guard/_registry.py
+++ b/src/arcjet/guard/_registry.py
@@ -1,0 +1,348 @@
+"""Optional process-wide registration for an Arcjet guard client.
+
+Registering exists for one reason: so code that cannot reach a client handle can
+still call :func:`guard` and :func:`capture`.  Passing a client explicitly always
+works and is the recommended path — this is the shortcut, not the default.
+
+Nothing here takes effect until an application calls :func:`register_arcjet`.
+``launch_arcjet()`` has no global side effects.
+
+Why a module global rather than a :class:`~contextvars.ContextVar`
+------------------------------------------------------------------
+
+A ``ContextVar`` is the usual home for ambient state, and it is the wrong tool
+here.  Each thread starts with a fresh context, so a value set once at startup
+is invisible to every worker thread — which is exactly how Flask, Django and any
+other WSGI server run request handlers.  Registration would appear to work in
+the main thread and silently do nothing in production.
+
+A module global is visible from every thread and every event loop, which is what
+"register once at startup, call from anywhere" has to mean.  ``ContextVar`` is
+still the right answer for *ambient correlation context*, which is a different
+problem and deliberately out of scope.
+
+Why there is no version check
+-----------------------------
+
+The JavaScript SDK stamps its registration with an SDK version because its slot
+lives on a realm-wide ``Symbol.for`` key that every copy of the package shares,
+so one copy can read a record another version wrote.  Python has no equivalent
+exposure: the import cache gives exactly one module object per name, and a
+vendored second copy is a *different* module with its own global that cannot see
+this one.  There is no cross-version read to guard against.
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Optional, Sequence, Union
+
+from arcjet._metadata import Metadata
+
+from ._client import ArcjetGuard, ArcjetGuardSync, _make_error_decision
+from ._diagnostics import CLIENT_ALREADY_REGISTERED, CLIENT_FLAVOUR_MISMATCH
+from ._rules import RuleWithInput
+from ._types import Decision
+
+__all__ = [
+    "capture",
+    "flush",
+    "flush_sync",
+    "guard",
+    "guard_sync",
+    "register_arcjet",
+    "registered_client",
+    "unregister_arcjet",
+]
+
+AnyArcjetGuard = Union[ArcjetGuard, ArcjetGuardSync]
+"""Either client flavour.  Registration accepts both; the free calls do not."""
+
+_registered: Optional[AnyArcjetGuard] = None
+
+# Guards the check-then-set in `register_arcjet`. Assignment is atomic under the
+# GIL, so the lock is not protecting the variable — it is protecting the
+# decision, so two threads racing at startup cannot both observe an empty slot
+# and both believe they won.
+_lock = threading.Lock()
+
+
+def register_arcjet(client: AnyArcjetGuard) -> None:
+    """Register *client* for the free :func:`guard`, :func:`capture` and
+    :func:`flush` calls.
+
+    Guarded on purpose.  If something tries to register a second client the
+    first one stays and the attempt is reported, so a library — or a stray
+    second ``launch_arcjet()`` — cannot quietly redirect an application's
+    telemetry to a different key.  Registering the client that is already
+    registered is a no-op rather than a warning, so a module imported twice
+    stays silent.
+
+    Never raises.
+
+    Example:
+        Register once, wherever your application starts up::
+
+            from arcjet.guard import launch_arcjet, register_arcjet
+
+            register_arcjet(launch_arcjet(key=os.environ["ARCJET_KEY"]))
+    """
+    global _registered
+
+    with _lock:
+        incumbent = _registered
+
+        if incumbent is None:
+            _registered = client
+            return
+
+        if incumbent is client:
+            return
+
+    # Reported outside the lock, and on the incumbent's channel rather than the
+    # late registrant's: the application that registered first configured that
+    # logger, and it is the one whose telemetry an unnoticed second
+    # registration would have redirected.
+    _diagnose(incumbent, CLIENT_ALREADY_REGISTERED)
+
+
+def unregister_arcjet() -> None:
+    """Clear the registered client, if any.
+
+    Takes no argument and clears whatever is there.  That asymmetry with
+    :func:`register_arcjet` is deliberate: requiring the client back would mean
+    every teardown has to keep hold of it, which is the problem registration
+    exists to avoid.
+
+    The cost is that anything calling this clears the application's client and
+    every free call afterwards fails open, so **libraries should not call it**.
+    Libraries take a client explicitly.  That is a convention, not something
+    enforced here.
+
+    Never raises.  Safe to call when nothing is registered.
+    """
+    global _registered
+
+    with _lock:
+        _registered = None
+
+
+def registered_client() -> Optional[AnyArcjetGuard]:
+    """Return the registered client, or ``None``.
+
+    Exposed so an application can branch on whether registration happened —
+    during startup checks, say — without reaching into module internals.
+    """
+    return _registered
+
+
+async def guard(
+    rules: Sequence[RuleWithInput],
+    *,
+    label: str,
+    metadata: Optional[Metadata] = None,
+    correlation_id: Optional[str] = None,
+) -> Decision:
+    """Evaluate guard rules through the registered async client.
+
+    With nothing registered — or with a *sync* client registered, which this
+    cannot await — the call fails open: it returns an ALLOW carrying an error
+    result, so ``decision.is_error()`` is true and a caller that inspects the
+    decision can see that no policy ran.  It does not raise.
+
+    The decision is the report.  There is deliberately no log line for the
+    unregistered case: the client that would have carried a logger is the thing
+    that is missing, so the only available sink would be an unconfigurable
+    warning on a request path.
+
+    Example:
+        ::
+
+            from arcjet.guard import guard, DetectPromptInjection
+
+            decision = await guard(
+                label="support.reply",
+                rules=[DetectPromptInjection()(user_message)],
+            )
+    """
+    client = _registered
+    method = _awaitable(client, "guard")
+
+    if method is not None:
+        return await method(
+            rules,
+            label=label,
+            metadata=metadata,
+            correlation_id=correlation_id,
+        )
+
+    _diagnose_flavour_mismatch(client)
+    return _make_error_decision(
+        "guard() was called with no registered async Arcjet client"
+    )
+
+
+def guard_sync(
+    rules: Sequence[RuleWithInput],
+    *,
+    label: str,
+    metadata: Optional[Metadata] = None,
+    correlation_id: Optional[str] = None,
+) -> Decision:
+    """Evaluate guard rules through the registered sync client.
+
+    The blocking counterpart of :func:`guard`, for Flask, Django and other sync
+    frameworks.  Fails open the same way, including when the registered client
+    is the async one — which this cannot await.
+    """
+    client = _registered
+    method = _blocking(client, "guard_sync", "guard")
+
+    if method is not None:
+        return method(
+            rules,
+            label=label,
+            metadata=metadata,
+            correlation_id=correlation_id,
+        )
+
+    _diagnose_flavour_mismatch(client)
+    return _make_error_decision(
+        "guard_sync() was called with no registered sync Arcjet client"
+    )
+
+
+def capture(
+    *,
+    action: str,
+    correlation_id: Optional[str] = None,
+    decision_id: Optional[str] = None,
+    occurred_at: Optional[datetime] = None,
+    metadata: Optional[Metadata] = None,
+) -> None:
+    """Record a fact about what the application did, through the registered
+    client.
+
+    One function for both client flavours, because ``capture()`` queues and
+    returns on each of them — it does no I/O on the caller's path, so there is
+    nothing to await and nothing to block.
+
+    With nothing registered the event is dropped silently.  Capture is
+    best-effort telemetry, which is what makes dropping acceptable, and there is
+    no configured logger to report to when the client itself is what is missing.
+
+    Never raises.
+
+    Example:
+        Deep in application code, with nothing passed down::
+
+            from arcjet.guard import capture
+
+            async def refund(invoice_id: str) -> None:
+                await issue_refund(invoice_id)
+                capture(action="refund.issued", metadata={"invoice": invoice_id})
+    """
+    client = _registered
+    if client is None:
+        return
+
+    client.capture(
+        action=action,
+        correlation_id=correlation_id,
+        decision_id=decision_id,
+        occurred_at=occurred_at,
+        metadata=metadata,
+    )
+
+
+async def flush(timeout_ms: Optional[int] = None) -> None:
+    """Drain the registered async client's queued capture events.
+
+    Returns immediately when nothing is registered, or when the registered
+    client is the sync one — there is no queue this call can drain.
+    """
+    client = _registered
+    method = _awaitable(client, "flush")
+
+    if method is not None:
+        await method(timeout_ms)
+        return
+
+    _diagnose_flavour_mismatch(client)
+
+
+def flush_sync(timeout_ms: Optional[int] = None) -> None:
+    """Drain the registered sync client's queued capture events.
+
+    The blocking counterpart of :func:`flush`.
+    """
+    client = _registered
+    method = _blocking(client, "flush_sync", "flush")
+
+    if method is not None:
+        method(timeout_ms)
+        return
+
+    _diagnose_flavour_mismatch(client)
+
+
+def _awaitable(
+    client: Optional[AnyArcjetGuard], name: str
+) -> Optional[Callable[..., Awaitable[Any]]]:
+    """The awaitable *name* on *client*, or ``None``.
+
+    Dispatch is on whether the method is a coroutine function rather than on
+    ``isinstance`` of the two concrete client classes.  That is what Python
+    actually means by "is this the async flavour", and it keeps registration
+    structural: the in-memory test client and any hand-rolled double satisfy the
+    free calls without subclassing anything.
+    """
+    method = getattr(client, name, None)
+    return method if inspect.iscoroutinefunction(method) else None
+
+
+def _blocking(
+    client: Optional[AnyArcjetGuard], preferred: str, fallback: str
+) -> Optional[Callable[..., Any]]:
+    """The blocking method on *client*, or ``None``.
+
+    Tries *preferred* — the explicitly sync name — before *fallback*, because
+    ``ArcjetGuardSync`` spells its blocking method ``guard``/``flush`` while a
+    double offering both flavours spells them ``guard_sync``/``flush_sync``.
+    Either way an awaitable is rejected: this caller cannot await it.
+    """
+    for name in (preferred, fallback):
+        method = getattr(client, name, None)
+        if callable(method) and not inspect.iscoroutinefunction(method):
+            return method
+    return None
+
+
+def _diagnose_flavour_mismatch(client: Optional[AnyArcjetGuard]) -> None:
+    """Report a call that found the other flavour of client registered.
+
+    Only when something *is* registered.  Nothing registered is the ordinary
+    unconfigured case and stays silent; a registered client of the wrong
+    flavour is a wiring mistake worth a line, and there is a configured logger
+    on it to put that line on.
+    """
+    if client is not None:
+        _diagnose(client, CLIENT_FLAVOUR_MISMATCH)
+
+
+def _diagnose(client: AnyArcjetGuard, code: str) -> None:
+    """Report *code* on a client's own diagnostics channel.
+
+    Never raises: a diagnostics sink is observational and must not break the
+    caller.  Anything can be registered — the test client is not built by
+    ``launch_arcjet()``, and neither is a hand-rolled fake — so the channel is
+    looked for rather than assumed.
+    """
+    try:
+        diagnose = getattr(client, "_diagnose", None)
+        if callable(diagnose):
+            diagnose(code)
+    except Exception:
+        pass

--- a/src/arcjet/guard/testing.py
+++ b/src/arcjet/guard/testing.py
@@ -1,0 +1,278 @@
+"""An in-memory Arcjet guard client for application tests.
+
+Registers a client that records what was called and talks to nothing.  It exists
+so a test can assert that application code captured the event it was supposed to,
+without a key, a network, or a running server.
+
+This is deliberately not a mock server.  It records calls and answers guards
+uniformly; it does not let a test stub per-rule verdicts.  Simulating real
+decisions is a much larger job and is not what this is for.
+
+Public module, unlike its ``_``-prefixed siblings, but kept separate so
+``import arcjet.guard`` never loads it.
+
+Example:
+    ::
+
+        from arcjet.guard.testing import register_test_client
+        from myapp.billing import refund
+
+        async def test_refund_captures_an_event():
+            with register_test_client() as arcjet:
+                await refund("inv_1")
+
+                assert arcjet.captures[0].action == "refund.issued"
+
+    As a fixture, which is usually where this belongs::
+
+        @pytest.fixture
+        def arcjet():
+            with register_test_client() as client:
+                yield client
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from types import TracebackType
+from typing import Any, Mapping, Optional, Sequence
+
+from arcjet._metadata import Metadata
+
+from ._capture import normalize_capture_event
+from ._client import _make_error_decision
+from ._registry import register_arcjet, registered_client, unregister_arcjet
+from ._rules import RuleWithInput
+from ._types import ArcjetWarning, Decision
+
+__all__ = [
+    "ArcjetTestClient",
+    "RecordedCapture",
+    "RecordedGuard",
+    "register_test_client",
+]
+
+
+def _ignore(code: str, count: int = 1) -> None:
+    """Drop diagnostics instead of logging them.
+
+    A test that captures something invalid asserts on the recorded event's
+    ``warnings``, which say the same thing in the place the test is already
+    looking.  Logging as well would put warnings in the output of every test
+    that exercises a drop deliberately.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedCapture:
+    """A capture event recorded by an :class:`ArcjetTestClient`."""
+
+    action: str
+    """What the application said it did."""
+    occurred_at: datetime
+    """The call's timestamp, or when it was recorded."""
+    metadata: Metadata
+    """Metadata as it would have been sent, decoded back from the wire."""
+    warnings: tuple[ArcjetWarning, ...]
+    """Anything the SDK dropped or rewrote while encoding this event."""
+    correlation_id: Optional[str] = None
+    """Present only when the call supplied one."""
+    decision_id: Optional[str] = None
+    """Present only when the call supplied one."""
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedGuard:
+    """A guard call recorded by an :class:`ArcjetTestClient`."""
+
+    label: str
+    rules: tuple[RuleWithInput, ...]
+    metadata: Optional[Metadata] = None
+    correlation_id: Optional[str] = None
+
+
+@dataclass(slots=True)
+class ArcjetTestClient:
+    """An in-memory client that records calls instead of sending them.
+
+    Satisfies both :class:`~arcjet.guard.ArcjetGuard` and
+    :class:`~arcjet.guard.ArcjetGuardSync` structurally by offering ``guard``,
+    ``guard_sync``, ``capture``, ``flush`` and ``flush_sync``, so either free
+    call reaches it.  That is the one place the sync/async split is bridged: a
+    real client can only be one or the other, but a recorder has no I/O to make
+    the distinction meaningful.
+    """
+
+    captures: list[RecordedCapture] = field(default_factory=list)
+    """Captured events, in call order."""
+    guards: list[RecordedGuard] = field(default_factory=list)
+    """Guard calls, in call order."""
+
+    # Named to match the real clients, so `_registry._diagnose` finds it and
+    # stays quiet rather than falling back to a logger.
+    _diagnose: Any = field(default=_ignore, repr=False)
+
+    def unregister(self) -> None:
+        """Unregister this client.
+
+        Safe to call twice, so it also works from a teardown that runs after a
+        failing test.  ``with`` calls this on the way out.
+        """
+        if registered_client() is self:
+            unregister_arcjet()
+
+    def __enter__(self) -> ArcjetTestClient:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        # Unregisters and nothing else. There is no transport and no delivery
+        # queue, so there is nothing to drain — which is why this is a plain
+        # context manager rather than an async one that would imply otherwise.
+        self.unregister()
+
+    def capture(
+        self,
+        *,
+        action: str,
+        correlation_id: Optional[str] = None,
+        decision_id: Optional[str] = None,
+        occurred_at: Optional[datetime] = None,
+        metadata: Optional[Metadata] = None,
+    ) -> None:
+        """Record a capture, normalized exactly as the real client would.
+
+        Going through :func:`normalize_capture_event` is what makes a test
+        honest: a ``capture()`` the real client would drop is not recorded here
+        either, and the warnings it would have attached are on the record.
+        """
+        event = normalize_capture_event(
+            action=action,
+            correlation_id=correlation_id,
+            decision_id=decision_id,
+            occurred_at=occurred_at,
+            metadata=metadata,
+            diagnose=_ignore,
+        )
+        if event is None:
+            return
+
+        self.captures.append(
+            RecordedCapture(
+                action=event.action,
+                correlation_id=event.correlation_id or None,
+                decision_id=event.decision_id or None,
+                occurred_at=datetime.fromtimestamp(
+                    event.occurred_at_unix_ms / 1000, tz=timezone.utc
+                ),
+                metadata=_decode_metadata(event.metadata_json),
+                warnings=tuple(
+                    ArcjetWarning(code=w.code, message=w.message)
+                    for w in event.local_warnings
+                ),
+            )
+        )
+
+    async def guard(
+        self,
+        rules: Sequence[RuleWithInput],
+        *,
+        label: str,
+        metadata: Optional[Metadata] = None,
+        correlation_id: Optional[str] = None,
+    ) -> Decision:
+        """Record the guard call and answer fail-open.
+
+        A fail-open ALLOW rather than a plain one, because no rule was
+        evaluated and a plain ALLOW would claim otherwise.  Note this means the
+        decision reports an error, so helpers that fail closed on an errored
+        decision will deny against this client.
+        """
+        return self._record_guard(rules, label, metadata, correlation_id)
+
+    def guard_sync(
+        self,
+        rules: Sequence[RuleWithInput],
+        *,
+        label: str,
+        metadata: Optional[Metadata] = None,
+        correlation_id: Optional[str] = None,
+    ) -> Decision:
+        """The blocking counterpart of :meth:`guard`."""
+        return self._record_guard(rules, label, metadata, correlation_id)
+
+    def _record_guard(
+        self,
+        rules: Sequence[RuleWithInput],
+        label: str,
+        metadata: Optional[Metadata],
+        correlation_id: Optional[str],
+    ) -> Decision:
+        self.guards.append(
+            RecordedGuard(
+                label=label,
+                rules=tuple(rules),
+                metadata=metadata,
+                correlation_id=correlation_id,
+            )
+        )
+        return _make_error_decision(
+            "guard() was called on the Arcjet test client; no rules ran"
+        )
+
+    async def flush(self, timeout_ms: Optional[int] = None) -> None:
+        """Resolve immediately — there is no queue to drain."""
+
+    def flush_sync(self, timeout_ms: Optional[int] = None) -> None:
+        """Return immediately — there is no queue to drain."""
+
+
+def register_test_client() -> ArcjetTestClient:
+    """Register an in-memory client that records guard and capture calls.
+
+    The one place launching and registering are a single act — a test that
+    wanted them apart would use ``launch_arcjet()`` directly.
+
+    Raises:
+        RuntimeError: If a client is already registered.  In an application a
+            second registration warns and carries on, because it should be
+            survivable; in a test it means an earlier test leaked one, and every
+            assertion here would silently read the wrong recorder.
+
+    Returns:
+        The client, which is also a context manager, so ``with`` unregisters it.
+    """
+    incumbent = registered_client()
+    if incumbent is not None:
+        raise RuntimeError(
+            "An Arcjet client is already registered. Call unregister_arcjet() "
+            "first — an earlier test probably left one behind."
+        )
+
+    client = ArcjetTestClient()
+    register_arcjet(client)  # type: ignore[arg-type]  # structural test double
+    return client
+
+
+def _decode_metadata(metadata_json: Mapping[str, str]) -> Metadata:
+    """Decode the wire form back to what a test would assert against.
+
+    Takes a ``Mapping`` rather than a ``dict`` because the wire event carries a
+    protobuf map container, not a plain dict.
+    """
+    decoded: dict[str, Any] = {}
+    for key, value in metadata_json.items():
+        try:
+            decoded[key] = json.loads(value)
+        except ValueError:
+            # Unreachable via `capture()`, which encodes these itself. Kept so a
+            # malformed record degrades to a visible raw string in an assertion
+            # rather than an exception from the recorder.
+            decoded[key] = value
+    return decoded

--- a/src/arcjet/guard/testing.py
+++ b/src/arcjet/guard/testing.py
@@ -43,7 +43,7 @@ from arcjet._metadata import Metadata
 
 from ._capture import normalize_capture_event
 from ._client import _make_error_decision
-from ._registry import register_arcjet, registered_client, unregister_arcjet
+from ._registry import register_arcjet_for_testing, unregister_arcjet_if
 from ._rules import RuleWithInput
 from ._types import ArcjetWarning, Decision
 
@@ -117,11 +117,11 @@ class ArcjetTestClient:
     def unregister(self) -> None:
         """Unregister this client.
 
-        Safe to call twice, so it also works from a teardown that runs after a
-        failing test.  ``with`` calls this on the way out.
+        Compare-and-clear, so a stale handle cannot unregister a client that
+        replaced this one.  Safe to call twice, so it also works from a teardown
+        that runs after a failing test.  ``with`` calls this on the way out.
         """
-        if registered_client() is self:
-            unregister_arcjet()
+        unregister_arcjet_if(self)  # type: ignore[arg-type]  # structural double
 
     def __enter__(self) -> ArcjetTestClient:
         return self
@@ -248,15 +248,10 @@ def register_test_client() -> ArcjetTestClient:
     Returns:
         The client, which is also a context manager, so ``with`` unregisters it.
     """
-    incumbent = registered_client()
-    if incumbent is not None:
-        raise RuntimeError(
-            "An Arcjet client is already registered. Call unregister_arcjet() "
-            "first — an earlier test probably left one behind."
-        )
-
     client = ArcjetTestClient()
-    register_arcjet(client)  # type: ignore[arg-type]  # structural test double
+    # Checked and set under one lock rather than here, so two concurrent calls
+    # cannot both succeed while only one of them is actually registered.
+    register_arcjet_for_testing(client)  # type: ignore[arg-type]  # structural double
     return client
 
 

--- a/tests/unit/guard/test_registry.py
+++ b/tests/unit/guard/test_registry.py
@@ -1,0 +1,297 @@
+"""Unit tests for optional client registration.
+
+Registration is process-wide, so every test here unregisters afterwards via the
+autouse fixture — a leaked client changes the meaning of every test after it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional, Sequence
+
+import pytest
+
+from arcjet.guard._diagnostics import (
+    CLIENT_ALREADY_REGISTERED,
+    CLIENT_FLAVOUR_MISMATCH,
+)
+from arcjet.guard._registry import (
+    capture,
+    flush,
+    flush_sync,
+    guard,
+    guard_sync,
+    register_arcjet,
+    registered_client,
+    unregister_arcjet,
+)
+from arcjet.guard._types import Decision, RuleResultError
+
+
+class _RecorderBase:
+    """Records what was called, and what the registry reported to it.
+
+    Deliberately not a subclass of either real client: registration is
+    structural, and this is what proves it.
+    """
+
+    def __init__(self) -> None:
+        self.guards: list[str] = []
+        self.captures: list[str] = []
+        self.flushes: list[Optional[int]] = []
+        self.diagnostics: list[str] = []
+
+    def _diagnose(self, code: str, count: int = 1) -> None:
+        self.diagnostics.append(code)
+
+    def capture(self, *, action: str, **kwargs: Any) -> None:
+        self.captures.append(action)
+
+    def _record(self, label: str) -> Decision:
+        self.guards.append(label)
+        return Decision(conclusion="ALLOW", id="stub", results=(), reason="ERROR")
+
+
+class AsyncRecorder(_RecorderBase):
+    """Shaped like ``ArcjetGuard`` — awaitable ``guard`` and ``flush``."""
+
+    async def guard(self, rules: Sequence[Any], **kwargs: Any) -> Decision:
+        return self._record(str(kwargs.get("label")))
+
+    async def flush(self, timeout_ms: Optional[int] = None) -> None:
+        self.flushes.append(timeout_ms)
+
+
+class SyncRecorder(_RecorderBase):
+    """Shaped like ``ArcjetGuardSync`` — blocking ``guard`` and ``flush``."""
+
+    def guard(self, rules: Sequence[Any], **kwargs: Any) -> Decision:
+        return self._record(str(kwargs.get("label")))
+
+    def flush(self, timeout_ms: Optional[int] = None) -> None:
+        self.flushes.append(timeout_ms)
+
+
+def async_recorder() -> Any:
+    return AsyncRecorder()
+
+
+def sync_recorder() -> Any:
+    return SyncRecorder()
+
+
+@pytest.fixture(autouse=True)
+def _clear_registration():
+    unregister_arcjet()
+    try:
+        yield
+    finally:
+        unregister_arcjet()
+
+
+class TestRegisterArcjet:
+    def test_launching_alone_registers_nothing(self) -> None:
+        assert registered_client() is None
+
+    def test_routes_the_free_calls_to_the_client(self) -> None:
+        client = async_recorder()
+        register_arcjet(client)
+
+        asyncio.run(guard([], label="test"))
+        capture(action="test.done")
+        asyncio.run(flush(50))
+
+        assert client.guards == ["test"]
+        assert client.captures == ["test.done"]
+        assert client.flushes == [50]
+
+    def test_keeps_the_incumbent_when_a_second_registers(self) -> None:
+        first = async_recorder()
+        register_arcjet(first)
+        register_arcjet(async_recorder())
+
+        assert registered_client() is first
+
+    def test_reports_the_refusal_on_the_incumbents_channel(self) -> None:
+        first = async_recorder()
+        register_arcjet(first)
+        register_arcjet(async_recorder())
+
+        # The warning belongs to whoever registered first: it is their telemetry
+        # a silent takeover would have redirected.
+        assert first.diagnostics == [CLIENT_ALREADY_REGISTERED]
+
+    def test_re_registering_the_same_client_is_silent(self) -> None:
+        client = async_recorder()
+        register_arcjet(client)
+        register_arcjet(client)
+
+        assert registered_client() is client
+        # A module imported twice must not look like a takeover attempt.
+        assert client.diagnostics == []
+
+    def test_a_client_without_a_diagnostics_channel_does_not_raise(self) -> None:
+        class _Bare:
+            async def guard(self, rules, **kwargs): ...
+            def capture(self, **kwargs): ...
+            async def flush(self, timeout_ms=None): ...
+
+        register_arcjet(_Bare())  # type: ignore[arg-type]
+        register_arcjet(_Bare())  # type: ignore[arg-type]
+
+
+class TestUnregisterArcjet:
+    def test_clears_the_registration(self) -> None:
+        register_arcjet(async_recorder())
+        unregister_arcjet()
+
+        assert registered_client() is None
+
+    def test_is_safe_with_nothing_registered(self) -> None:
+        unregister_arcjet()
+        unregister_arcjet()
+
+
+class TestNothingRegistered:
+    def test_guard_fails_open_rather_than_raising(self) -> None:
+        decision = asyncio.run(guard([], label="test"))
+
+        # Both halves matter. A plain ALLOW would satisfy the first assertion
+        # too, and that is the actual bug worth catching: a silent bypass that
+        # looks exactly like a guard which ran and permitted the call.
+        assert decision.conclusion == "ALLOW"
+        assert decision.has_failed_open()
+
+    def test_guard_sync_fails_open_rather_than_raising(self) -> None:
+        decision = guard_sync([], label="test")
+
+        assert decision.conclusion == "ALLOW"
+        assert decision.has_failed_open()
+
+    def test_the_fail_open_decision_says_why(self) -> None:
+        decision = asyncio.run(guard([], label="test"))
+
+        result = decision.results[0]
+        assert isinstance(result, RuleResultError)
+        assert "no registered" in result.message
+
+    def test_capture_drops_the_event_without_raising(self) -> None:
+        capture(action="test.done")
+
+    def test_flush_returns(self) -> None:
+        asyncio.run(flush())
+        flush_sync()
+
+
+class TestSyncAsyncFlavour:
+    """The failure mode Python has and JavaScript does not.
+
+    ``register_arcjet`` erases which flavour it took, so a mismatch is not
+    statically catchable — which is exactly why it has to degrade predictably
+    and say so.
+    """
+
+    def test_async_guard_reaches_an_async_client(self) -> None:
+        client = async_recorder()
+        register_arcjet(client)
+
+        asyncio.run(guard([], label="ok"))
+
+        assert client.guards == ["ok"]
+        assert client.diagnostics == []
+
+    def test_sync_guard_reaches_a_sync_client(self) -> None:
+        client = sync_recorder()
+        register_arcjet(client)
+
+        guard_sync([], label="ok")
+
+        assert client.guards == ["ok"]
+        assert client.diagnostics == []
+
+    def test_async_guard_with_a_sync_client_fails_open(self) -> None:
+        client = sync_recorder()
+        register_arcjet(client)
+
+        decision = asyncio.run(guard([], label="test"))
+
+        assert decision.has_failed_open()
+        assert client.guards == []
+        assert client.diagnostics == [CLIENT_FLAVOUR_MISMATCH]
+
+    def test_sync_guard_with_an_async_client_fails_open(self) -> None:
+        client = async_recorder()
+        register_arcjet(client)
+
+        decision = guard_sync([], label="test")
+
+        # The important half: it must not return a coroutine dressed up as a
+        # decision, which is what calling through blindly would produce.
+        assert decision.has_failed_open()
+        assert client.guards == []
+        assert client.diagnostics == [CLIENT_FLAVOUR_MISMATCH]
+
+    def test_flush_flavour_mismatch_is_reported(self) -> None:
+        client = sync_recorder()
+        register_arcjet(client)
+
+        asyncio.run(flush())
+
+        assert client.flushes == []
+        assert client.diagnostics == [CLIENT_FLAVOUR_MISMATCH]
+
+    def test_capture_works_with_either_flavour(self) -> None:
+        # One free function for both, because capture() queues and returns on
+        # each of them.
+        for client in (async_recorder(), sync_recorder()):
+            unregister_arcjet()
+            register_arcjet(client)
+
+            capture(action="either.works")
+
+            assert client.captures == ["either.works"]
+
+    def test_nothing_registered_is_silent_but_a_mismatch_is_not(self) -> None:
+        # Nothing registered is the ordinary unconfigured case; a registered
+        # client of the wrong flavour is a wiring mistake, and there is a
+        # configured logger on it to report to.
+        asyncio.run(guard([], label="test"))  # no client, no channel, no line
+
+        client = sync_recorder()
+        register_arcjet(client)
+        asyncio.run(guard([], label="test"))
+
+        assert client.diagnostics == [CLIENT_FLAVOUR_MISMATCH]
+
+
+class TestThreadVisibility:
+    def test_a_registration_is_visible_from_a_worker_thread(self) -> None:
+        """The reason this is a module global and not a ContextVar.
+
+        A ContextVar set at startup returns None in a new thread, so this test
+        is what fails if anyone 'modernizes' the registry onto one. Flask,
+        Django and every other WSGI server run handlers exactly this way.
+        """
+        import threading
+
+        client = sync_recorder()
+        register_arcjet(client)
+
+        seen: list[Any] = []
+        thread = threading.Thread(target=lambda: seen.append(registered_client()))
+        thread.start()
+        thread.join()
+
+        assert seen == [client]
+
+    def test_capture_from_a_worker_thread_reaches_the_client(self) -> None:
+        import threading
+
+        client = sync_recorder()
+        register_arcjet(client)
+
+        thread = threading.Thread(target=lambda: capture(action="from.thread"))
+        thread.start()
+        thread.join()
+
+        assert client.captures == ["from.thread"]

--- a/tests/unit/guard/test_registry.py
+++ b/tests/unit/guard/test_registry.py
@@ -7,6 +7,7 @@ autouse fixture — a leaked client changes the meaning of every test after it.
 from __future__ import annotations
 
 import asyncio
+import inspect
 from typing import Any, Optional, Sequence
 
 import pytest
@@ -295,3 +296,52 @@ class TestThreadVisibility:
         thread.join()
 
         assert client.captures == ["from.thread"]
+
+
+class TestNamespaceShape:
+    """Pins how the free calls are reached, because one spelling is a trap.
+
+    ``guard`` names both the subpackage and a function inside it. That is
+    survivable — ``arcjet.guard.guard`` stutters but resolves, and
+    ``from arcjet.guard import guard`` is the spelling the docs use. What is not
+    survivable is a *top-level* ``arcjet.guard`` function: it would collide with
+    the submodule of the same name and win or lose depending on whether
+    ``import arcjet.guard`` had run yet, which is an order-dependent bug in
+    somebody else's application.
+    """
+
+    def test_the_free_calls_are_importable_from_the_subpackage(self) -> None:
+        from arcjet.guard import capture as pkg_capture
+        from arcjet.guard import flush as pkg_flush
+        from arcjet.guard import flush_sync as pkg_flush_sync
+        from arcjet.guard import guard as pkg_guard
+        from arcjet.guard import guard_sync as pkg_guard_sync
+
+        for fn in (
+            pkg_guard,
+            pkg_guard_sync,
+            pkg_capture,
+            pkg_flush,
+            pkg_flush_sync,
+        ):
+            assert callable(fn)
+
+    def test_the_top_level_arcjet_namespace_does_not_define_guard(self) -> None:
+        import arcjet
+        import arcjet.guard
+
+        # `from arcjet import guard` must keep meaning the module. If a function
+        # named `guard` is ever added to arcjet/__init__.py, this fails — which
+        # is the point.
+        assert inspect.ismodule(arcjet.guard)
+        assert "guard" not in getattr(arcjet, "__all__", ())
+
+    def test_async_and_sync_pairs_are_distinct_callables(self) -> None:
+        # The pairing is the whole reason both spellings exist; aliasing one to
+        # the other would silently reintroduce the blocking-in-async problem.
+        assert guard is not guard_sync
+        assert flush is not flush_sync
+        assert inspect.iscoroutinefunction(guard)
+        assert not inspect.iscoroutinefunction(guard_sync)
+        assert inspect.iscoroutinefunction(flush)
+        assert not inspect.iscoroutinefunction(flush_sync)

--- a/tests/unit/guard/test_registry.py
+++ b/tests/unit/guard/test_registry.py
@@ -326,6 +326,15 @@ class TestNamespaceShape:
         ):
             assert callable(fn)
 
+    def test_registered_client_is_not_public(self) -> None:
+        import arcjet.guard
+
+        # Internal on purpose: the ADR does not define it, and the JavaScript
+        # SDK tests that its equivalent stays unexported. Publishing it would
+        # make removing it a breaking change.
+        assert not hasattr(arcjet.guard, "registered_client")
+        assert "registered_client" not in arcjet.guard.__all__
+
     def test_the_top_level_arcjet_namespace_does_not_define_guard(self) -> None:
         import arcjet
         import arcjet.guard
@@ -345,3 +354,104 @@ class TestNamespaceShape:
         assert not inspect.iscoroutinefunction(guard_sync)
         assert inspect.iscoroutinefunction(flush)
         assert not inspect.iscoroutinefunction(flush_sync)
+
+
+class TestAtomicRegistryOperations:
+    """The test client's register and teardown must be indivisible.
+
+    Honest note on what these can and cannot prove. A genuine TOCTOU
+    reproduction is not reliably expressible here — the window between a check
+    and a following mutation is a couple of bytecodes, and threads racing on a
+    barrier do not land inside it dependably. Tests written that way passed
+    against the buggy implementation, so they were decoration.
+
+    What is pinned instead is the property that makes the race impossible: both
+    operations do their check *and* their mutation inside the registry lock, so
+    there is no window to land in. If someone reintroduces a check-then-act by
+    composing the public helpers, the atomicity tests below fail.
+    """
+
+    def test_test_registration_happens_inside_the_lock(self) -> None:
+        import threading
+
+        from arcjet.guard._registry import _lock, register_arcjet_for_testing
+
+        finished = threading.Event()
+
+        def attempt() -> None:
+            try:
+                register_arcjet_for_testing(sync_recorder())
+            finally:
+                finished.set()
+
+        with _lock:
+            worker = threading.Thread(target=attempt)
+            worker.start()
+            # Blocked: the occupancy check is inside the critical section, not
+            # before it.
+            assert not finished.wait(0.2)
+
+        worker.join(timeout=2)
+        assert finished.is_set()
+        unregister_arcjet()
+
+    def test_compare_and_clear_happens_inside_the_lock(self) -> None:
+        import threading
+
+        from arcjet.guard._registry import _lock, unregister_arcjet_if
+
+        client = sync_recorder()
+        register_arcjet(client)
+        finished = threading.Event()
+
+        def attempt() -> None:
+            try:
+                unregister_arcjet_if(client)
+            finally:
+                finished.set()
+
+        with _lock:
+            worker = threading.Thread(target=attempt)
+            worker.start()
+            assert not finished.wait(0.2)
+
+        worker.join(timeout=2)
+        assert finished.is_set()
+        assert registered_client() is None
+
+    def test_a_second_test_client_is_refused(self) -> None:
+        from arcjet.guard.testing import register_test_client
+
+        first = register_test_client()
+        try:
+            with pytest.raises(RuntimeError, match="already registered"):
+                register_test_client()
+        finally:
+            first.unregister()
+
+    def test_a_stale_client_cannot_clear_its_replacement(self) -> None:
+        from arcjet.guard.testing import register_test_client
+
+        first = register_test_client()
+        first.unregister()
+
+        second = register_test_client()
+        try:
+            # The stale handle must not clear a slot it no longer owns.
+            first.unregister()
+
+            assert registered_client() is second
+        finally:
+            second.unregister()
+
+    def test_compare_and_clear_ignores_a_client_that_does_not_hold_the_slot(
+        self,
+    ) -> None:
+        from arcjet.guard._registry import unregister_arcjet_if
+
+        holder = sync_recorder()
+        register_arcjet(holder)
+
+        unregister_arcjet_if(sync_recorder())
+
+        assert registered_client() is holder

--- a/tests/unit/guard/test_registry.py
+++ b/tests/unit/guard/test_registry.py
@@ -14,7 +14,7 @@ import pytest
 
 from arcjet.guard._diagnostics import (
     CLIENT_ALREADY_REGISTERED,
-    CLIENT_FLAVOUR_MISMATCH,
+    CLIENT_FLAVOR_MISMATCH,
 )
 from arcjet.guard._registry import (
     capture,
@@ -184,10 +184,10 @@ class TestNothingRegistered:
         flush_sync()
 
 
-class TestSyncAsyncFlavour:
+class TestSyncAsyncFlavor:
     """The failure mode Python has and JavaScript does not.
 
-    ``register_arcjet`` erases which flavour it took, so a mismatch is not
+    ``register_arcjet`` erases which flavor it took, so a mismatch is not
     statically catchable — which is exactly why it has to degrade predictably
     and say so.
     """
@@ -218,7 +218,7 @@ class TestSyncAsyncFlavour:
 
         assert decision.has_failed_open()
         assert client.guards == []
-        assert client.diagnostics == [CLIENT_FLAVOUR_MISMATCH]
+        assert client.diagnostics == [CLIENT_FLAVOR_MISMATCH]
 
     def test_sync_guard_with_an_async_client_fails_open(self) -> None:
         client = async_recorder()
@@ -230,18 +230,18 @@ class TestSyncAsyncFlavour:
         # decision, which is what calling through blindly would produce.
         assert decision.has_failed_open()
         assert client.guards == []
-        assert client.diagnostics == [CLIENT_FLAVOUR_MISMATCH]
+        assert client.diagnostics == [CLIENT_FLAVOR_MISMATCH]
 
-    def test_flush_flavour_mismatch_is_reported(self) -> None:
+    def test_flush_flavor_mismatch_is_reported(self) -> None:
         client = sync_recorder()
         register_arcjet(client)
 
         asyncio.run(flush())
 
         assert client.flushes == []
-        assert client.diagnostics == [CLIENT_FLAVOUR_MISMATCH]
+        assert client.diagnostics == [CLIENT_FLAVOR_MISMATCH]
 
-    def test_capture_works_with_either_flavour(self) -> None:
+    def test_capture_works_with_either_flavor(self) -> None:
         # One free function for both, because capture() queues and returns on
         # each of them.
         for client in (async_recorder(), sync_recorder()):
@@ -254,7 +254,7 @@ class TestSyncAsyncFlavour:
 
     def test_nothing_registered_is_silent_but_a_mismatch_is_not(self) -> None:
         # Nothing registered is the ordinary unconfigured case; a registered
-        # client of the wrong flavour is a wiring mistake, and there is a
+        # client of the wrong flavor is a wiring mistake, and there is a
         # configured logger on it to report to.
         asyncio.run(guard([], label="test"))  # no client, no channel, no line
 
@@ -262,7 +262,7 @@ class TestSyncAsyncFlavour:
         register_arcjet(client)
         asyncio.run(guard([], label="test"))
 
-        assert client.diagnostics == [CLIENT_FLAVOUR_MISMATCH]
+        assert client.diagnostics == [CLIENT_FLAVOR_MISMATCH]
 
 
 class TestThreadVisibility:

--- a/tests/unit/guard/test_testing.py
+++ b/tests/unit/guard/test_testing.py
@@ -171,7 +171,7 @@ class TestRecordingGuards:
             assert arcjet.guards[0].metadata == {"a": 1}
             assert arcjet.guards[0].correlation_id == "corr_1"
 
-    def test_both_flush_flavours_return(self) -> None:
+    def test_both_flush_flavors_return(self) -> None:
         with register_test_client():
             asyncio.run(flush())
             flush_sync()

--- a/tests/unit/guard/test_testing.py
+++ b/tests/unit/guard/test_testing.py
@@ -1,0 +1,193 @@
+"""Unit tests for the in-memory test client.
+
+Also the worked example of the pattern the docs recommend: a ``with`` block, or
+a fixture wrapping one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from arcjet.guard._registry import (
+    capture,
+    flush,
+    flush_sync,
+    guard,
+    guard_sync,
+    register_arcjet,
+    registered_client,
+    unregister_arcjet,
+)
+from arcjet.guard.testing import ArcjetTestClient, register_test_client
+
+
+@pytest.fixture(autouse=True)
+def _clear_registration():
+    unregister_arcjet()
+    try:
+        yield
+    finally:
+        unregister_arcjet()
+
+
+class TestRegisterTestClient:
+    def test_registers_itself_so_free_calls_reach_it(self) -> None:
+        with register_test_client() as arcjet:
+            assert registered_client() is arcjet
+
+    def test_the_with_block_unregisters_on_the_way_out(self) -> None:
+        with register_test_client():
+            pass
+
+        assert registered_client() is None
+
+    def test_it_unregisters_even_when_the_body_raises(self) -> None:
+        with pytest.raises(ValueError):
+            with register_test_client():
+                raise ValueError("boom")
+
+        # The whole reason to prefer `with` over a manual call.
+        assert registered_client() is None
+
+    def test_raises_when_a_client_is_already_registered(self) -> None:
+        with register_test_client():
+            # A leak from an earlier test would otherwise have this test assert
+            # against the previous test's recorder.
+            with pytest.raises(RuntimeError, match="already registered"):
+                register_test_client()
+
+    def test_unregister_is_safe_to_call_twice(self) -> None:
+        arcjet = register_test_client()
+        arcjet.unregister()
+        arcjet.unregister()
+
+        assert registered_client() is None
+
+    def test_unregister_does_not_clear_somebody_elses_client(self) -> None:
+        arcjet = register_test_client()
+        arcjet.unregister()
+
+        class _Other:
+            async def guard(self, rules, **kwargs): ...
+            def capture(self, **kwargs): ...
+            async def flush(self, timeout_ms=None): ...
+
+        other = _Other()
+        register_arcjet(other)  # type: ignore[arg-type]
+        arcjet.unregister()
+
+        assert registered_client() is other
+
+
+class TestRecordingCaptures:
+    def test_records_a_capture_made_through_the_free_function(self) -> None:
+        with register_test_client() as arcjet:
+            capture(action="refund.issued", metadata={"invoice": "inv_1"})
+
+            assert len(arcjet.captures) == 1
+            assert arcjet.captures[0].action == "refund.issued"
+            assert arcjet.captures[0].metadata == {"invoice": "inv_1"}
+
+    def test_records_captures_in_call_order(self) -> None:
+        with register_test_client() as arcjet:
+            capture(action="first")
+            capture(action="second")
+
+            assert [c.action for c in arcjet.captures] == ["first", "second"]
+
+    def test_preserves_nested_metadata_through_the_wire_encoding(self) -> None:
+        with register_test_client() as arcjet:
+            capture(
+                action="order.placed", metadata={"items": [1, 2], "user": {"id": "u1"}}
+            )
+
+            assert arcjet.captures[0].metadata == {
+                "items": [1, 2],
+                "user": {"id": "u1"},
+            }
+
+    def test_keeps_ids_only_when_supplied(self) -> None:
+        with register_test_client() as arcjet:
+            capture(action="with", correlation_id="corr_1", decision_id="dec_1")
+            capture(action="without")
+
+            assert arcjet.captures[0].correlation_id == "corr_1"
+            assert arcjet.captures[0].decision_id == "dec_1"
+            assert arcjet.captures[1].correlation_id is None
+            assert arcjet.captures[1].decision_id is None
+
+    def test_records_occurred_at_when_supplied(self) -> None:
+        occurred_at = datetime(2026, 8, 4, 12, 0, 0, tzinfo=timezone.utc)
+
+        with register_test_client() as arcjet:
+            capture(action="backfilled", occurred_at=occurred_at)
+
+            assert arcjet.captures[0].occurred_at == occurred_at
+
+    def test_drops_an_invalid_event_exactly_as_the_real_client_would(self) -> None:
+        with register_test_client() as arcjet:
+            # An empty action is rejected by the same validation the real client
+            # runs. Recording the raw input instead would let this test pass
+            # while the real client silently dropped the event in production.
+            capture(action="")
+
+            assert arcjet.captures == []
+
+    def test_surfaces_encoding_warnings_on_the_recorded_event(self) -> None:
+        with register_test_client() as arcjet:
+            capture(action="lossy", metadata={"ok": "kept", "bad": {1, 2, 3}})  # type: ignore[dict-item]
+
+            recorded = arcjet.captures[0]
+            assert recorded.action == "lossy"
+            assert recorded.metadata == {"ok": "kept"}
+            assert recorded.warnings, "the dropped key should be reported"
+
+
+class TestRecordingGuards:
+    def test_records_an_async_guard_and_answers_fail_open(self) -> None:
+        with register_test_client() as arcjet:
+            decision = asyncio.run(guard([], label="tools.weather"))
+
+            assert [g.label for g in arcjet.guards] == ["tools.weather"]
+            # Fail-open rather than a plain ALLOW: no rule ran, and a plain
+            # ALLOW would claim policy was evaluated.
+            assert decision.conclusion == "ALLOW"
+            assert decision.has_failed_open()
+
+    def test_records_a_sync_guard_too(self) -> None:
+        with register_test_client() as arcjet:
+            decision = guard_sync([], label="tools.weather")
+
+            assert [g.label for g in arcjet.guards] == ["tools.weather"]
+            assert decision.has_failed_open()
+
+    def test_records_the_metadata_and_correlation_id(self) -> None:
+        with register_test_client() as arcjet:
+            guard_sync([], label="x", metadata={"a": 1}, correlation_id="corr_1")
+
+            assert arcjet.guards[0].metadata == {"a": 1}
+            assert arcjet.guards[0].correlation_id == "corr_1"
+
+    def test_both_flush_flavours_return(self) -> None:
+        with register_test_client():
+            asyncio.run(flush())
+            flush_sync()
+
+
+class TestFixturePattern:
+    """The shape the docs recommend, exercised so it cannot rot."""
+
+    @pytest.fixture
+    def arcjet(self):
+        with register_test_client() as client:
+            yield client
+
+    def test_a_fixture_wrapping_the_context_manager_works(
+        self, arcjet: ArcjetTestClient
+    ) -> None:
+        capture(action="from.fixture")
+
+        assert arcjet.captures[0].action == "from.fixture"


### PR DESCRIPTION
See ADR: https://github.com/arcjet/arcjet/blob/main/docs/adrs/2026-07-24-unified-arcjet-client-registration-and-lifecycle.md

Python port of https://github.com/arcjet/arcjet-js/pull/6206.

Note: It is only added to Guard here as having a single client is happening elsewhere

```python
from arcjet.guard import launch_arcjet, register_arcjet

arcjet = launch_arcjet(...)

# Stored in a module-level global
register_arcjet(arcjet)
```

```python
from arcjet.guard import capture, guard

# ... later

capture(...)  # Pulls the client off the module global
```

```python
from arcjet.guard import capture
from arcjet.guard.testing import register_test_client


async def test_refund_captures_an_event():
    with register_test_client() as arcjet:
        await refund("inv_1")

        assert arcjet.captures[0].action == "refund.issued"
```

## Where this differs from the JavaScript SDK

**No version stamp on the registration.** JS stamps its slot because `Symbol.for`
is realm-wide, so every copy of the package shares one slot and a 1.9 copy can
read a record 2.0 wrote. Python's import cache gives exactly one module object
per name, and a vendored second copy is a different module with its own global
that cannot see the first — the cross-version read is unrepresentable, so JS's
`AJ3006` has no counterpart here.

**A module-level global, not a `ContextVar`.** A context variable set at startup
is invisible inside worker threads, which is how Flask, Django and every other
WSGI server run request handlers, so registration would work in development and
silently do nothing in production. There is a cross-thread visibility test so
nobody migrates it later. `ContextVar` remains the right answer for ambient
correlation context, which the ADR defers.

**`guard` and `flush` come in pairs.** `capture()` is one function because it
queues and returns on both clients. `guard`/`flush` cannot be, so they mirror
`launch_arcjet` / `launch_arcjet_sync`:

| Registered client | Guard | Flush |
| --- | --- | --- |
| `launch_arcjet()` | `await guard(...)` | `await flush()` |
| `launch_arcjet_sync()` | `guard_sync(...)` | `flush_sync()` |

`register_arcjet()` accepts either flavour and does not record which, so calling
the wrong one is **not** statically catchable. It fails open and reports the new
`AJ3007` on the registered client's logger. Dispatch is on
`inspect.iscoroutinefunction` rather than `isinstance`, which keeps registration
structural so test doubles need no subclassing.

`with` replaces JS's `using` for the test client, with none of the Node 24 /
`esnext.disposable` caveats, and drops into a fixture:

```python
@pytest.fixture
def arcjet():
    with register_test_client() as client:
        yield client
```

## Diagnostic codes

`AJ3004` (double registration) keeps its JS meaning. `AJ3007` is new, for the
sync/async mismatch. `AJ3005` is documented as permanently retired — it briefly
meant "no client is registered" in JS and was withdrawn pre-release. The
allocation table lives in `_diagnostics.py` so a later codegen pass has a written
source rather than archaeology across three repos.
