### PR TITLE
docs: clarify pytest version hold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,9 @@ dev = [
   "langchain-core>=1,<2",                  # For testing integration with LangChain
   "pyright==1.1.411",
   "hypothesis>=6.100.0",
-  "pytest==9.0.3",                         # Held <9.1: 9.1 cut the unraisableexception plugin's gc.collect() passes 5→1, deferring wasmtime's __del__ finalizers and corrupting its internal slab under the concurrency tests (wasmtime-py#322). Bump once wasmtime object lifecycle is fixed.
+  # Held <9.1 while bytecodealliance/wasmtime-py#254 remains unresolved; see
+  # tests/analyze/test_detect_bot.py::TestDetectBotThreadSafety and arcjet-py#185.
+  "pytest==9.0.3",
   "pytest-cov>=7.0.0",
   "ruff==0.15.22",
   "tomli>=2.0.0; python_version < '3.11'",


### PR DESCRIPTION
Clarifies the pytest 9.0.3 hold by referencing the concurrency regression coverage, the prior pytest 9.1 verification in #185, and the still-open upstream Wasmtime thread-safety issue.

No dependency versions change.