### PR TITLE
chore(release): stage 0.10.0b1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,11 +163,12 @@ jobs:
       - name: Build
         # Build every workspace member (arcjet and arcjet-sensitive-info-rampart).
         run: uv build --all-packages
-      # Publish each distribution separately: PyPI trusted publishing mints a
-      # project-scoped token per OIDC exchange, so one `uv publish` run cannot
-      # upload to two different projects. `arcjet-*` matches only the core
-      # package (hyphen); `arcjet_sensitive_info_rampart-*` matches only the
-      # backend (underscore).
+      # Publish each distribution with its own command so the upload order is
+      # explicit. Trusted publishing needs no per-package setup — each `uv
+      # publish` exchanges the workflow's OIDC token for a short-lived PyPI key
+      # automatically — so the split is about ordering, not authentication.
+      # `arcjet-*` matches only the core package (hyphen);
+      # `arcjet_sensitive_info_rampart-*` matches only the backend (underscore).
       #
       # Publish in dependency order — `arcjet` first, then the backend that
       # pins it. PyPI does not validate dependencies at upload time, so either

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,17 @@ on:
       # Publish on any tag starting with a `v`, e.g., v1.2.3
       - v*
 
+permissions:
+  # Reading the repository is the only default permission either job needs.
+  contents: read
+
+# Never run two releases at once: the two distributions are published in
+# sequence, so interleaved runs could upload them out of order. Queue instead
+# of cancelling so an in-flight release always finishes.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   # Runs without approval so the pypi environment reviewer can see, before
   # approving, that the pushed tag actually matches the version declared in
@@ -28,7 +39,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
-      - name: Assert the tag matches the project version
+      - name: Assert the package versions match the tag
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
@@ -40,21 +51,91 @@ jobs:
               exit 1
               ;;
           esac
+          # Every distribution's version must equal the tag being released: the
+          # workspace ships in lockstep, since `arcjet-sensitive-info-rampart`
+          # imports private `arcjet` modules. Report every mismatch at once so a
+          # re-tag fixes all of them in one pass.
           expected="${TAG_NAME#v}"
-          actual="$(uv version --short)"
-          if [ "$actual" != "$expected" ]; then
-            echo "::error::pyproject.toml version '$actual' does not match tag '$TAG_NAME'; bump the version and re-tag."
+          mismatched=""
+          for package in arcjet arcjet-sensitive-info-rampart; do
+            actual="$(uv version --short --package "$package")"
+            if [ "$actual" != "$expected" ]; then
+              mismatched="$mismatched $package==$actual"
+            fi
+          done
+          if [ -n "$mismatched" ]; then
+            for entry in $mismatched; do echo "$entry"; done
+            echo "::error::These package versions do not match tag '$TAG_NAME'; bump every package to '$expected' and re-tag."
             exit 1
           fi
+      # The two distributions pin each other exactly, and `uv version` bumps
+      # versions without touching dependency pins — so a release whose versions
+      # match the tag can still carry a stale pin, which publishes a pair that
+      # cannot be installed together. Fail before the publish is approved.
+      - name: Assert the packages pin each other at the tag version
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          python3 - "${TAG_NAME#v}" <<'PY'
+          import sys
+          import tomllib
+
+          version = sys.argv[1]
+          failed = False
+
+          def check(path, requirements, expected):
+              global failed
+              for requirement in requirements:
+                  if requirement.replace(" ", "").startswith(f"{expected}=="):
+                      if requirement.replace(" ", "") != f"{expected}=={version}":
+                          print(
+                              f"::error file={path}::'{requirement}' does not pin "
+                              f"{expected} to '{version}'; update the pin to match."
+                          )
+                          failed = True
+                      return
+              print(f"::error file={path}::no exact `{expected}==` pin found.")
+              failed = True
+
+          with open("sensitive-info-rampart/pyproject.toml", "rb") as handle:
+              backend_project = tomllib.load(handle)
+          check(
+              "sensitive-info-rampart/pyproject.toml",
+              backend_project["project"]["dependencies"],
+              "arcjet",
+          )
+
+          with open("pyproject.toml", "rb") as handle:
+              core_project = tomllib.load(handle)
+          check(
+              "pyproject.toml",
+              core_project["project"]["optional-dependencies"]["sensitive-info-rampart"],
+              "arcjet-sensitive-info-rampart",
+          )
+
+          sys.exit(1 if failed else 0)
+          PY
       - name: Summarize the release request
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+          # Name every distribution being published, so the environment reviewer
+          # approves a concrete list rather than a single unlabelled version.
           {
             echo "## Release request"
             echo "- tag: \`$TAG_NAME\`"
-            echo "- project version: \`$(uv version --short)\`"
-            echo "- commit: \`$GITHUB_SHA\`"
+            echo "- ref: \`$GITHUB_REF_NAME\` (\`$GITHUB_SHA\`)"
+            echo
+            echo "<details><summary>Versions</summary>"
+            echo
+            echo '```'
+            for package in arcjet arcjet-sensitive-info-rampart; do
+              echo "$package==$(uv version --short --package "$package")"
+            done
+            echo '```'
+            echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"
 
   pypi:
@@ -87,7 +168,18 @@ jobs:
       # upload to two different projects. `arcjet-*` matches only the core
       # package (hyphen); `arcjet_sensitive_info_rampart-*` matches only the
       # backend (underscore).
-      - name: Publish arcjet-sensitive-info-rampart
-        run: uv publish dist/arcjet_sensitive_info_rampart-*
+      #
+      # Publish in dependency order — `arcjet` first, then the backend that
+      # pins it. PyPI does not validate dependencies at upload time, so either
+      # order uploads cleanly, but the order decides how bad a half-published
+      # release is. If the second upload fails here, the missing distribution
+      # was never uploaded and can be retried at the same version, and plain
+      # `pip install arcjet` still works because the backend is only reachable
+      # through an extra. Publishing the backend first inverts both: its `arcjet`
+      # pin would name a version that does not exist on PyPI, and PyPI does not
+      # allow re-uploading a version, so recovering means burning a version
+      # number on both packages.
       - name: Publish arcjet
         run: uv publish dist/arcjet-*
+      - name: Publish arcjet-sensitive-info-rampart
+        run: uv publish dist/arcjet_sensitive_info_rampart-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,15 @@ permissions:
   # Reading the repository is the only default permission either job needs.
   contents: read
 
-# Never run two releases at once: the two distributions are published in
-# sequence, so interleaved runs could upload them out of order. Queue instead
-# of cancelling so an in-flight release always finishes.
+# One release at a time: the distributions upload in sequence, so runs must not
+# interleave. Queue rather than cancel so an in-flight release always finishes.
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  # Runs without approval so the pypi environment reviewer can see, before
-  # approving, that the pushed tag actually matches the version declared in
-  # pyproject.toml.
+  # Runs without approval so the pypi environment reviewer can check the tag,
+  # versions, and pins before approving the gated publish job.
   preflight:
     name: Preflight
     runs-on: ubuntu-latest
@@ -51,10 +49,8 @@ jobs:
               exit 1
               ;;
           esac
-          # Every distribution's version must equal the tag being released: the
-          # workspace ships in lockstep, since `arcjet-sensitive-info-rampart`
-          # imports private `arcjet` modules. Report every mismatch at once so a
-          # re-tag fixes all of them in one pass.
+          # The distributions ship in lockstep, so every version must equal the
+          # tag. Report all mismatches at once so one re-tag fixes them.
           expected="${TAG_NAME#v}"
           mismatched=""
           for package in arcjet arcjet-sensitive-info-rampart; do
@@ -68,10 +64,8 @@ jobs:
             echo "::error::These package versions do not match tag '$TAG_NAME'; bump every package to '$expected' and re-tag."
             exit 1
           fi
-      # The two distributions pin each other exactly, and `uv version` bumps
-      # versions without touching dependency pins — so a release whose versions
-      # match the tag can still carry a stale pin, which publishes a pair that
-      # cannot be installed together. Fail before the publish is approved.
+      # `uv version` does not touch dependency pins, so matching versions are not
+      # enough: a stale pin publishes a pair that cannot install together.
       - name: Assert the packages pin each other at the tag version
         env:
           TAG_NAME: ${{ github.ref_name }}
@@ -121,8 +115,7 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # Name every distribution being published, so the environment reviewer
-          # approves a concrete list rather than a single unlabelled version.
+          # Name each distribution so the reviewer approves a concrete list.
           {
             echo "## Release request"
             echo "- tag: \`$TAG_NAME\`"
@@ -163,23 +156,14 @@ jobs:
       - name: Build
         # Build every workspace member (arcjet and arcjet-sensitive-info-rampart).
         run: uv build --all-packages
-      # Publish each distribution with its own command so the upload order is
-      # explicit. Trusted publishing needs no per-package setup — each `uv
-      # publish` exchanges the workflow's OIDC token for a short-lived PyPI key
-      # automatically — so the split is about ordering, not authentication.
-      # `arcjet-*` matches only the core package (hyphen);
-      # `arcjet_sensitive_info_rampart-*` matches only the backend (underscore).
+      # Separate commands make the upload order explicit; trusted publishing
+      # needs no per-package setup. `arcjet-*` is the core package (hyphen),
+      # `arcjet_sensitive_info_rampart-*` the backend (underscore).
       #
-      # Publish in dependency order — `arcjet` first, then the backend that
-      # pins it. PyPI does not validate dependencies at upload time, so either
-      # order uploads cleanly, but the order decides how bad a half-published
-      # release is. If the second upload fails here, the missing distribution
-      # was never uploaded and can be retried at the same version, and plain
-      # `pip install arcjet` still works because the backend is only reachable
-      # through an extra. Publishing the backend first inverts both: its `arcjet`
-      # pin would name a version that does not exist on PyPI, and PyPI does not
-      # allow re-uploading a version, so recovering means burning a version
-      # number on both packages.
+      # Dependency order matters when the second upload fails: this way the
+      # missing one can be retried at the same version, whereas backend-first
+      # strands it pinning a version absent from PyPI, and PyPI does not allow
+      # re-uploading a version.
       - name: Publish arcjet
         run: uv publish dist/arcjet-*
       - name: Publish arcjet-sensitive-info-rampart

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,13 +101,12 @@ breaking changes.
 
 ## Releasing
 
-This repository publishes **two** distributions from one uv workspace: the core
-`arcjet` package and the `arcjet-sensitive-info-rampart` backend in
-`sensitive-info-rampart/`. The backend imports private core modules, so the two
-pin each other exactly (`==`) and are always released together at the same
-version. `uv version` updates versions but **not** dependency pins, so the two
-`==` pins are edited by hand. The release workflow's preflight job fails the
-release if the versions or either pin are out of lockstep.
+This repository publishes **two** distributions from one uv workspace: `arcjet`
+and the `arcjet-sensitive-info-rampart` backend in `sensitive-info-rampart/`.
+The backend imports private core modules, so both are released together at the
+same version and pin each other exactly (`==`). `uv version` does not update
+dependency pins, so those are edited by hand; preflight fails the release if any
+version or pin is out of lockstep.
 
 1. Create a new branch, e.g. `git checkout -b release-0.10.0`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,13 +101,55 @@ breaking changes.
 
 ## Releasing
 
-1. Create a new branch `git checkout -b release-0.1.0`
-2. Bump the version using `uv version --bump` e.g. `uv version --bump patch`.
-3. Commit and push the changes to GitHub, then open a PR.
-4. Once merged to `main`, create a new Git tag with the new version e.g. `git
-   tag -a v0.1.0 -m v0.1.0`
-5. Push the tag to GitHub e.g. `git push --tags`
-6. The release workflow will be triggered automatically and must be approved by
-   another member of the team.
-7. Once approved, the package will be pushed to PyPI
-8. Create a new release in GitHub and link the release to the newly created tag.
+This repository publishes **two** distributions from one uv workspace: the core
+`arcjet` package and the `arcjet-sensitive-info-rampart` backend in
+`sensitive-info-rampart/`. The backend imports private core modules, so the two
+pin each other exactly (`==`) and are always released together at the same
+version. `uv version` updates versions but **not** dependency pins, so the two
+`==` pins are edited by hand. The release workflow's preflight job fails the
+release if the versions or either pin are out of lockstep.
+
+1. Create a new branch, e.g. `git checkout -b release-0.10.0`.
+
+2. Bump both versions to the same value:
+
+   ```sh
+   # Core package.
+   uv version --bump minor            # or: patch, major
+   # Backend, in lockstep.
+   uv version --package arcjet-sensitive-info-rampart --bump minor
+   ```
+
+   For a prerelease, bump a release component and the prerelease component
+   together; add `--dry-run` to preview any of these:
+
+   ```sh
+   uv version --bump minor --bump beta   # 0.9.0  -> 0.10.0b1
+   uv version --bump beta                # 0.10.0b1 -> 0.10.0b2
+   uv version --bump stable              # 0.10.0b1 -> 0.10.0
+   ```
+
+3. Update both `==` pins to the new version by hand:
+
+   - `sensitive-info-rampart/pyproject.toml` → `"arcjet==<version>"`
+   - `pyproject.toml` → `sensitive-info-rampart = ["arcjet-sensitive-info-rampart==<version>"]`
+
+4. Run `uv lock`, then `make check` and `make test`.
+
+5. Commit and push the changes to GitHub, then open a PR.
+
+6. Once merged to `main`, tag the merge commit with the version, e.g.
+   `git tag -a v0.10.0 -m v0.10.0`. The tag must match the version in
+   `pyproject.toml` exactly, including any prerelease suffix (`v0.10.0b1`).
+
+7. Push the tag, e.g. `git push origin v0.10.0`.
+
+8. The release workflow is triggered automatically. Its preflight job runs
+   without approval so the reviewer can confirm the tag, versions, and pins
+   before approving; the publish job must then be approved by another member of
+   the team.
+
+9. Once approved, both distributions are published to PyPI.
+
+10. Create a new release in GitHub and link it to the new tag. Tick
+    **Set as a pre-release** for prerelease versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Arcjet", email = "support@arcjet.com" }]
 license = "Apache-2.0"
-# Ship the license in the built artifacts (PEP 639); without this the wheel and
-# sdist carry the license only as metadata, not as a file.
 license-files = ["LICENSE"]
 dependencies = [
   "connect-python>=0.8.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcjet"
-version = "0.9.0"
+version = "0.10.0b1"
 description = "Arcjet Python SDK. Runtime security for AI applications. Prompt injection detection, bot protection, rate limiting, sensitive data detection, and WAF for Python apps."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -45,9 +45,11 @@ keywords = [
 # runtime deps and the bundled model ship in the separate
 # `arcjet-sensitive-info-rampart` distribution, so they are only installed when
 # this extra is requested.
-# Pinned to the matching minor: the backend imports private core modules, so
-# the two are released in lockstep (see the reciprocal bound in that package).
-sensitive-info-rampart = ["arcjet-sensitive-info-rampart>=0.9.0,<0.10.0"]
+# Pinned to the exact matching version: the backend imports private core
+# modules, so the two are released in lockstep and must never resolve to
+# different versions (see the reciprocal pin in that package). Bump both
+# together every release.
+sensitive-info-rampart = ["arcjet-sensitive-info-rampart==0.10.0b1"]
 langchain = ["langchain-core>=1,<2"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = "Arcjet Python SDK. Runtime security for AI applications. Prompt i
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Arcjet", email = "support@arcjet.com" }]
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+# Ship the license in the built artifacts (PEP 639); without this the wheel and
+# sdist carry the license only as metadata, not as a file.
+license-files = ["LICENSE"]
 dependencies = [
   "connect-python>=0.8.1",
   "pyqwest>=0.8.0,<0.9.0",

--- a/sensitive-info-rampart/pyproject.toml
+++ b/sensitive-info-rampart/pyproject.toml
@@ -5,13 +5,8 @@ description = "On-device Rampart NER model backend for Arcjet sensitive informat
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Arcjet", email = "support@arcjet.com" }]
-# Compound: the archives bundle the CC BY 4.0 Rampart model (NOTICE attributes it).
 license = "Apache-2.0 AND CC-BY-4.0"
-license-files = [
-  "LICENSE",
-  "NOTICE",
-  "src/arcjet_sensitive_info_rampart/models/rampart/LICENSE",
-]
+license-files = ["LICENSE", "NOTICE"]
 dependencies = [
   # Imports private modules (`arcjet._sensitive_info_backend`, `arcjet._analyze`),
   # so it is coupled to the core version — release the two in lockstep. The

--- a/sensitive-info-rampart/pyproject.toml
+++ b/sensitive-info-rampart/pyproject.toml
@@ -5,16 +5,8 @@ description = "On-device Rampart NER model backend for Arcjet sensitive informat
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Arcjet", email = "support@arcjet.com" }]
-# Covers the distribution as a whole, not just our own code: the wheel bundles
-# the third-party Rampart model under CC BY 4.0, so declaring bare `Apache-2.0`
-# would hide the attribution obligation a consumer takes on. Our source is
-# Apache-2.0; the bundled model in `models/rampart/` is CC BY 4.0.
+# Compound: the archives bundle the CC BY 4.0 Rampart model (NOTICE attributes it).
 license = "Apache-2.0 AND CC-BY-4.0"
-# Ship every legal file in the built artifacts (PEP 639). NOTICE is required
-# rather than decorative: it carries the CC BY 4.0 attribution for the bundled
-# model, and README.md points readers at it. The model's own license text is
-# declared too so it lands in the standard `.dist-info/licenses/` location that
-# license scanners read, backing the `CC-BY-4.0` half of the expression above.
 license-files = [
   "LICENSE",
   "NOTICE",

--- a/sensitive-info-rampart/pyproject.toml
+++ b/sensitive-info-rampart/pyproject.toml
@@ -5,7 +5,21 @@ description = "On-device Rampart NER model backend for Arcjet sensitive informat
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Arcjet", email = "support@arcjet.com" }]
-license = { text = "Apache-2.0" }
+# Covers the distribution as a whole, not just our own code: the wheel bundles
+# the third-party Rampart model under CC BY 4.0, so declaring bare `Apache-2.0`
+# would hide the attribution obligation a consumer takes on. Our source is
+# Apache-2.0; the bundled model in `models/rampart/` is CC BY 4.0.
+license = "Apache-2.0 AND CC-BY-4.0"
+# Ship every legal file in the built artifacts (PEP 639). NOTICE is required
+# rather than decorative: it carries the CC BY 4.0 attribution for the bundled
+# model, and README.md points readers at it. The model's own license text is
+# declared too so it lands in the standard `.dist-info/licenses/` location that
+# license scanners read, backing the `CC-BY-4.0` half of the expression above.
+license-files = [
+  "LICENSE",
+  "NOTICE",
+  "src/arcjet_sensitive_info_rampart/models/rampart/LICENSE",
+]
 dependencies = [
   # Imports private modules (`arcjet._sensitive_info_backend`, `arcjet._analyze`),
   # so it is coupled to the core version — release the two in lockstep. The

--- a/sensitive-info-rampart/pyproject.toml
+++ b/sensitive-info-rampart/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcjet-sensitive-info-rampart"
-version = "0.9.0"
+version = "0.10.0b1"
 description = "On-device Rampart NER model backend for Arcjet sensitive information detection."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,9 +9,9 @@ license = { text = "Apache-2.0" }
 dependencies = [
   # Imports private modules (`arcjet._sensitive_info_backend`, `arcjet._analyze`),
   # so it is coupled to the core version — release the two in lockstep. The
-  # upper bound keeps an older backend from resolving against a newer core whose
-  # private internals it may not match; bump both together each minor release.
-  "arcjet>=0.9.0,<0.10.0",
+  # exact pin keeps this backend from ever resolving against a core whose
+  # private internals it may not match; bump both together every release.
+  "arcjet==0.10.0b1",
   "numpy>=1.24",
   # 1.23+ dropped CPython 3.10 wheels; the SDK still supports 3.10.
   "onnxruntime>=1.17,<1.23",

--- a/uv.lock
+++ b/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "arcjet"
-version = "0.9.0"
+version = "0.10.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "connect-python" },
@@ -117,7 +117,7 @@ dev = [
 
 [[package]]
 name = "arcjet-sensitive-info-rampart"
-version = "0.9.0"
+version = "0.10.0b1"
 source = { editable = "sensitive-info-rampart" }
 dependencies = [
     { name = "arcjet" },


### PR DESCRIPTION
Stage the `0.10.0b1` release.

Includes some fixups to the contibuting and release workflow (will be tested in this process) as well as a license tweak caught by Codex during a review (`license` that isn't a string deprecated)

I've also made it explicit that the rampart package is mixed license