### PR TITLE
fix(guard): make a guarded LangChain tool behave the same as the tool it wraps

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,8 +977,14 @@ guarded_send_email = guard_tool(
 )
 ```
 
-The wrapper preserves the tool schema and delegates through `invoke()` or
-`ainvoke()`.
+The guarded tool advertises the same schema as the tool it wraps and delegates
+to it, so the model is told what it would have been told without the guard.
+`invoke()`, `ainvoke()`, `run()` and `arun()` are all checkpoints.
+
+The guarded tool is a wrapper, not an instance of the wrapped tool's class, so
+application code that branches on a tool's concrete type sees the wrapper. The
+one exception is a `Tool` built from a bare function, which is wrapped by a
+`Tool` subclass because LangChain advertises that shape by concrete class.
 
 The core `guard()` API and the LangChain helper have intentionally different
 defaults when evaluation is unavailable:
@@ -989,8 +995,8 @@ defaults when evaluation is unavailable:
 | `guard_tool()` | Block (fail closed) | Set `on_guard_error="allow"` |
 
 For `guard_tool()`, unavailable means either that the pre-execution checkpoint
-raised while normalizing arguments, resolving the actor or policy inputs, or
-calling Guard, or that Guard returned an `ALLOW` decision whose
+raised while resolving the actor or policy inputs, or calling Guard, or that
+Guard returned an `ALLOW` decision whose
 `has_failed_open()` is `True`. The latter can result from a deadline, response
 parse failure, local rule failure, missing decision, or server-returned rule
 error—not only an Arcjet Cloud outage.

--- a/src/arcjet/guard/langchain.py
+++ b/src/arcjet/guard/langchain.py
@@ -23,6 +23,8 @@ from langchain_core.tools import BaseTool, ToolException
 from langchain_core.tools.simple import Tool as SimpleTool
 from pydantic import BaseModel, PrivateAttr
 
+from arcjet._logging import logger
+
 from ._client import ArcjetGuard, ArcjetGuardSync
 from ._policy_input import PolicyInputMap
 from ._rules import RuleWithInput
@@ -68,21 +70,22 @@ class ArcjetToolUnavailableError(ToolException):
         self.__cause__ = cause
 
 
-class _InvalidArguments(Exception):
-    """The wrapped tool's own validation rejected this call's arguments.
-
-    Not an Arcjet failure, and never surfaced to the caller: the tool is handed
-    the call so it raises, or applies ``handle_validation_error``, exactly as
-    it would have without a checkpoint in front of it.  No effect can run
-    either way, because the tool rejects the call before reaching its body.
-    """
-
-
 def _unwrap_tool_call(value: Any) -> tuple[Any, str | None]:
     """A ToolCall-shaped input split into its arguments and its id."""
     if isinstance(value, dict) and value.get("type") == "tool_call":
         return value.get("args", {}), value.get("id")
     return value, None
+
+
+def _has_derivable_schema(tool: BaseTool) -> bool:
+    """Whether ``tool_call_schema`` describes this tool's actual arguments.
+
+    A ``Tool`` built from a bare function declares no schema, so the property
+    falls back to introspecting ``Tool._run(*args, config, **kwargs)`` and
+    reports that signature instead. LangChain works around this with the same
+    concrete-class check when it advertises such a tool.
+    """
+    return not (isinstance(tool, SimpleTool) and not tool.args_schema)
 
 
 def _arguments(tool: BaseTool, raw: Any, tool_call_id: str | None) -> Mapping[str, Any]:
@@ -93,31 +96,46 @@ def _arguments(tool: BaseTool, raw: Any, tool_call_id: str | None) -> Mapping[st
     every tool, and regenerating it drops the author's field validators, which
     would show a resolver a different value than the tool runs with.
 
-    Two things are then corrected.  The input is copied first, because
-    ``_parse_input`` writes into the mapping it is given and that mapping is
-    usually the ``args`` of a ``ToolCall`` living in message history.  And the
-    result is narrowed to what the model can actually supply: ``_parse_input``
-    re-adds arguments the framework injects — credentials, graph state, the
-    tool call id — that ``tool_call_schema`` deliberately hides, and a policy
-    resolver must not be handed those.
+    The input is copied first, because ``_parse_input`` writes into the mapping
+    it is given and that mapping is usually the ``args`` of a ``ToolCall``
+    living in message history.
+
+    Raises whatever the tool's own validation raises. Callers treat resolving
+    arguments as best-effort and evaluate policy regardless — a call whose
+    arguments cannot be read is still a call.
     """
     if isinstance(raw, Mapping):
         raw = dict(raw)
 
-    try:
-        parsed = tool._parse_input(raw, tool_call_id)
-    except Exception as exc:
-        raise _InvalidArguments from exc
+    parsed = tool._parse_input(raw, tool_call_id)
+    if not isinstance(parsed, dict):
+        # A bare string comes back unchanged. LangChain binds it to the
+        # schema's first field whatever the field count, so key it the same way
+        # rather than inventing a name the tool will never use.
+        names = list(tool.args)
+        return {names[0]: parsed} if names else {"input": parsed}
 
-    visible = tool.args
-    if isinstance(parsed, dict):
-        return {key: value for key, value in parsed.items() if key in visible}
+    # `_parse_input` re-adds arguments the framework injects — credentials,
+    # graph state, the tool call id — that `tool_call_schema` hides from the
+    # model. A policy resolver must not be handed those. Only that schema
+    # identifies them, so filtering happens only when it can say so; the
+    # alternative, `tool.args`, names a different key-space for a tool whose
+    # arguments the model supplies positionally.
+    schema = tool.tool_call_schema
+    if (
+        _has_derivable_schema(tool)
+        and isinstance(schema, type)
+        and issubclass(schema, BaseModel)
+    ):
+        visible = set(schema.model_fields)
+        parsed = {key: value for key, value in parsed.items() if key in visible}
 
-    # A bare string comes back out of _parse_input unchanged. LangChain binds
-    # it to the schema's first field whatever the field count, so key it the
-    # same way rather than inventing a name the tool will never use.
-    names = list(visible)
-    return {names[0]: parsed} if names else {"input": parsed}
+    # Nested models come back as instances. Resolvers are documented to take a
+    # `Mapping[str, Any]`, so hand them data rather than model objects.
+    return {
+        key: value.model_dump() if isinstance(value, BaseModel) else value
+        for key, value in parsed.items()
+    }
 
 
 def _check_decision(
@@ -177,14 +195,35 @@ class _GuardMixin:
     _arcjet: _Policy
     _arcjet_tool: BaseTool
 
+    def get_input_schema(self, config: RunnableConfig | None = None) -> Any:
+        if self._arcjet_owns_schema():
+            return cast(BaseTool, super()).get_input_schema(config)
+        return self._arcjet_tool.get_input_schema(config)
+
+    @property
+    def tool_call_schema(self) -> Any:
+        if self._arcjet_owns_schema():
+            return cast(Any, BaseTool.tool_call_schema).fget(self)
+        return self._arcjet_tool.tool_call_schema
+
+    def _arcjet_owns_schema(self) -> bool:
+        """Whether this wrapper's own ``args_schema`` should be believed.
+
+        The wrapper is handed a copy of the wrapped tool's ``args_schema`` and
+        normally has nothing to add, so the derivation is forwarded to the tool
+        that owns it — which is the only way a tool declaring no schema gets
+        one, since it is derived from a ``_run`` this wrapper does not have.
+        Reassigning it is how an application narrows what a model may send, so
+        a schema that is no longer the wrapped tool's wins instead.
+        """
+        return cast(BaseTool, self).args_schema is not self._arcjet_tool.args_schema
+
     def invoke(
         self, input: Any, config: RunnableConfig | None = None, **kwargs: Any
     ) -> Any:
         raw, tool_call_id = _unwrap_tool_call(input)
         try:
             self._arcjet_evaluate(raw, tool_call_id, config)
-        except _InvalidArguments:
-            pass
         except ArcjetToolDeniedError as exc:
             return _handle_tool_exception(cast(BaseTool, self), exc, tool_call_id)
         return self._arcjet_tool.invoke(input, config, **kwargs)
@@ -195,8 +234,6 @@ class _GuardMixin:
         raw, tool_call_id = _unwrap_tool_call(input)
         try:
             await self._arcjet_evaluate_async(raw, tool_call_id, config)
-        except _InvalidArguments:
-            pass
         except ArcjetToolDeniedError as exc:
             return _handle_tool_exception(cast(BaseTool, self), exc, tool_call_id)
         return await self._arcjet_tool.ainvoke(input, config, **kwargs)
@@ -205,8 +242,6 @@ class _GuardMixin:
         tool_call_id = kwargs.get("tool_call_id")
         try:
             self._arcjet_evaluate(tool_input, tool_call_id, kwargs.get("config"))
-        except _InvalidArguments:
-            pass
         except ArcjetToolDeniedError as exc:
             return _handle_tool_exception(cast(BaseTool, self), exc, tool_call_id)
         return self._arcjet_tool.run(tool_input, *args, **kwargs)
@@ -217,8 +252,6 @@ class _GuardMixin:
             await self._arcjet_evaluate_async(
                 tool_input, tool_call_id, kwargs.get("config")
             )
-        except _InvalidArguments:
-            pass
         except ArcjetToolDeniedError as exc:
             return _handle_tool_exception(cast(BaseTool, self), exc, tool_call_id)
         return await self._arcjet_tool.arun(tool_input, *args, **kwargs)
@@ -239,7 +272,7 @@ class _GuardMixin:
                 inputs=self._arcjet_inputs(raw, tool_call_id, resolved),
             )
             _check_decision(decision, self._arcjet.action, self._arcjet.on_guard_error)
-        except (ArcjetToolDeniedError, ArcjetToolUnavailableError, _InvalidArguments):
+        except (ArcjetToolDeniedError, ArcjetToolUnavailableError):
             raise
         except Exception as exc:
             if self._arcjet.on_guard_error == "deny":
@@ -261,7 +294,7 @@ class _GuardMixin:
                 inputs=await self._arcjet_inputs_async(raw, tool_call_id, resolved),
             )
             _check_decision(decision, self._arcjet.action, self._arcjet.on_guard_error)
-        except (ArcjetToolDeniedError, ArcjetToolUnavailableError, _InvalidArguments):
+        except (ArcjetToolDeniedError, ArcjetToolUnavailableError):
             raise
         except Exception as exc:
             if self._arcjet.on_guard_error == "deny":
@@ -285,7 +318,20 @@ class _GuardMixin:
             return resolver
         # Parsed only here, because a resolver is the only thing that reads the
         # arguments: a tool with no resolver configured is never parsed at all.
-        arguments = _arguments(self._arcjet_tool, raw, tool_call_id)
+        try:
+            arguments = _arguments(self._arcjet_tool, raw, tool_call_id)
+        except Exception:
+            # The tool will reject these arguments itself, or accept them in a
+            # shape this could not read. Either way the checkpoint still has to
+            # run: skipping it would let a call the tool does accept through
+            # unevaluated. Policy sees no inputs, which is weaker than usual
+            # and still a decision.
+            logger.warning(
+                "arcjet: could not read the arguments of a call to %r; "
+                "evaluating policy without them",
+                self._arcjet.action,
+            )
+            return None
         return cast(_InputsFn, resolver)(arguments, config)
 
     def _arcjet_actor(self, config: RunnableConfig) -> str | None:
@@ -318,10 +364,11 @@ class _GuardMixin:
             return cast("PolicyInputMap | None", await value)
         return cast("PolicyInputMap | None", value)
 
-    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Any:
         # The Arcjet client owns a connection pool and a lock, so it is shared
         # with the copy rather than duplicated: copying a client is not
         # meaningful, and `copy.deepcopy` cannot do it at all.
+        memo = {} if memo is None else memo
         guard = self._arcjet.guard
         memo[id(guard)] = guard
         return BaseModel.__deepcopy__(cast(BaseModel, self), memo)
@@ -350,17 +397,6 @@ class _GuardedTool(_GuardMixin, BaseTool):
     _arcjet: _Policy = PrivateAttr()
     _arcjet_tool: BaseTool = PrivateAttr()
 
-    def get_input_schema(self, config: RunnableConfig | None = None) -> Any:
-        return self._arcjet_tool.get_input_schema(config)
-
-    @property
-    def tool_call_schema(self) -> Any:
-        return self._arcjet_tool.tool_call_schema
-
-    @property
-    def args(self) -> dict[str, Any]:
-        return self._arcjet_tool.args
-
     def _run(self, *args: Any, **kwargs: Any) -> Any:
         raise RuntimeError("Guarded tools delegate to the tool they wrap")
 
@@ -377,9 +413,11 @@ class _GuardedSimpleTool(_GuardMixin, SimpleTool):
     _arcjet: _Policy = PrivateAttr()
     _arcjet_tool: BaseTool = PrivateAttr()
 
-    @property
-    def args(self) -> dict[str, Any]:
-        return self._arcjet_tool.args
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("Guarded tools delegate to the tool they wrap")
+
+    async def _arun(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("Guarded tools delegate to the tool they wrap")
 
 
 def guard_tool(
@@ -396,8 +434,13 @@ def guard_tool(
 
     The guarded tool evaluates policy and then hands the call to *tool*, which
     is left untouched and keeps running its own code — so anything the tool's
-    class overrides still applies, and the model is told exactly what the
-    unguarded tool advertised.
+    class overrides still applies, and the model is told what the unguarded
+    tool advertised.
+
+    The result is a wrapper, not an instance of *tool*'s class, so application
+    code that branches on a tool's concrete type sees the wrapper.  A ``Tool``
+    built from a bare function is the exception: LangChain advertises that
+    shape by concrete class, so the wrapper is a ``Tool`` too.
 
     Unlike the core Guard client, which returns a fail-open ``ALLOW`` decision
     when evaluation is degraded, this helper fails closed by default. With

--- a/src/arcjet/guard/langchain.py
+++ b/src/arcjet/guard/langchain.py
@@ -21,7 +21,7 @@ from langchain_core.messages import ToolMessage
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool, ToolException
 from langchain_core.tools.simple import Tool as SimpleTool
-from pydantic import BaseModel, PrivateAttr
+from pydantic import BaseModel, PrivateAttr, ValidationError
 
 from arcjet._logging import logger
 
@@ -184,6 +184,17 @@ class _Policy:
     on_guard_error: OnGuardError
 
 
+class _UnreadableArguments(Exception):
+    """The call's arguments could not be read, and the tool may still run.
+
+    Distinct from arguments the tool's own schema rejects: those stop the tool
+    before its body, so an input rule has no effect to protect. This means the
+    rule was configured, could not see what it was meant to evaluate, and the
+    call would otherwise proceed — an unevaluated policy, which is what
+    ``on_guard_error`` governs.
+    """
+
+
 class _GuardMixin:
     """The checkpoint, in front of a tool this wrapper delegates to.
 
@@ -265,13 +276,29 @@ class _GuardMixin:
             )
         resolved = config if config is not None else cast(RunnableConfig, {})
         try:
+            actor = self._arcjet_actor(resolved)
+            readable = True
+            try:
+                inputs = self._arcjet_inputs(raw, tool_call_id, resolved)
+            except _UnreadableArguments:
+                inputs, readable = None, False
             decision = self._arcjet.guard.guard(
                 self._arcjet.rules,
                 label=self._arcjet.action,
-                actor=self._arcjet_actor(resolved),
-                inputs=self._arcjet_inputs(raw, tool_call_id, resolved),
+                actor=actor,
+                inputs=inputs,
             )
             _check_decision(decision, self._arcjet.action, self._arcjet.on_guard_error)
+            if not readable and self._arcjet.on_guard_error == "deny":
+                # Guard still saw the call, so the decision is on the record.
+                # The input rule was not evaluated, so the call does not run.
+                raise ArcjetToolUnavailableError(self._arcjet.action)
+            if not readable:
+                logger.warning(
+                    "arcjet: could not read the arguments of a call to %r; "
+                    "policy ran without them because on_guard_error is 'allow'",
+                    self._arcjet.action,
+                )
         except (ArcjetToolDeniedError, ArcjetToolUnavailableError):
             raise
         except Exception as exc:
@@ -287,13 +314,29 @@ class _GuardMixin:
             raise TypeError("An asynchronous LangChain invocation requires ArcjetGuard")
         resolved = config if config is not None else cast(RunnableConfig, {})
         try:
+            actor = await self._arcjet_actor_async(resolved)
+            readable = True
+            try:
+                inputs = await self._arcjet_inputs_async(raw, tool_call_id, resolved)
+            except _UnreadableArguments:
+                inputs, readable = None, False
             decision = await self._arcjet.guard.guard(
                 self._arcjet.rules,
                 label=self._arcjet.action,
-                actor=await self._arcjet_actor_async(resolved),
-                inputs=await self._arcjet_inputs_async(raw, tool_call_id, resolved),
+                actor=actor,
+                inputs=inputs,
             )
             _check_decision(decision, self._arcjet.action, self._arcjet.on_guard_error)
+            if not readable and self._arcjet.on_guard_error == "deny":
+                # Guard still saw the call, so the decision is on the record.
+                # The input rule was not evaluated, so the call does not run.
+                raise ArcjetToolUnavailableError(self._arcjet.action)
+            if not readable:
+                logger.warning(
+                    "arcjet: could not read the arguments of a call to %r; "
+                    "policy ran without them because on_guard_error is 'allow'",
+                    self._arcjet.action,
+                )
         except (ArcjetToolDeniedError, ArcjetToolUnavailableError):
             raise
         except Exception as exc:
@@ -320,18 +363,19 @@ class _GuardMixin:
         # arguments: a tool with no resolver configured is never parsed at all.
         try:
             arguments = _arguments(self._arcjet_tool, raw, tool_call_id)
-        except Exception:
-            # The tool will reject these arguments itself, or accept them in a
-            # shape this could not read. Either way the checkpoint still has to
-            # run: skipping it would let a call the tool does accept through
-            # unevaluated. Policy sees no inputs, which is weaker than usual
-            # and still a decision.
+        except ValidationError:
+            # The tool's own schema rejected these arguments, so the tool
+            # rejects the call too and its body never runs. Policy still gets a
+            # decision, without inputs — there is no effect for an input rule
+            # to protect, and the tool keeps its own `handle_validation_error`.
             logger.warning(
-                "arcjet: could not read the arguments of a call to %r; "
+                "arcjet: the arguments of a call to %r did not validate; "
                 "evaluating policy without them",
                 self._arcjet.action,
             )
             return None
+        except Exception as exc:
+            raise _UnreadableArguments from exc
         return cast(_InputsFn, resolver)(arguments, config)
 
     def _arcjet_actor(self, config: RunnableConfig) -> str | None:

--- a/src/arcjet/guard/langchain.py
+++ b/src/arcjet/guard/langchain.py
@@ -2,18 +2,26 @@
 
 Install ``arcjet[langchain]`` to use this module. Core Guard clients do not
 import LangChain.
+
+A guarded tool is a thin wrapper that evaluates policy and then hands the call
+to the tool it wraps.  It deliberately does **not** try to *be* the wrapped
+tool: everything the framework derives from a tool — its schema, its arguments
+— is asked of the wrapped tool rather than recomputed here, so a guarded tool
+advertises and executes exactly what the unguarded one did.
 """
 
 from __future__ import annotations
 
 import inspect
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 from langchain_core.messages import ToolMessage
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool, ToolException
-from pydantic import BaseModel
+from langchain_core.tools.simple import Tool as SimpleTool
+from pydantic import BaseModel, PrivateAttr
 
 from ._client import ArcjetGuard, ArcjetGuardSync
 from ._policy_input import PolicyInputMap
@@ -32,6 +40,14 @@ AsyncInputResolver = (
         [Mapping[str, Any], RunnableConfig], PolicyInputMap | Awaitable[PolicyInputMap]
     ]
 )
+
+# The callable halves of the aliases above. `callable()` narrows a union
+# containing a Mapping to something no type checker will call, so the call
+# sites name the shape they already know.
+_ActorFn = Callable[[RunnableConfig], "str | Awaitable[str]"]
+_InputsFn = Callable[
+    [Mapping[str, Any], RunnableConfig], "PolicyInputMap | Awaitable[PolicyInputMap]"
+]
 
 
 class ArcjetToolDeniedError(ToolException):
@@ -52,23 +68,56 @@ class ArcjetToolUnavailableError(ToolException):
         self.__cause__ = cause
 
 
-def _arguments(tool: BaseTool, value: Any) -> Mapping[str, Any]:
-    raw = value
+class _InvalidArguments(Exception):
+    """The wrapped tool's own validation rejected this call's arguments.
+
+    Not an Arcjet failure, and never surfaced to the caller: the tool is handed
+    the call so it raises, or applies ``handle_validation_error``, exactly as
+    it would have without a checkpoint in front of it.  No effect can run
+    either way, because the tool rejects the call before reaching its body.
+    """
+
+
+def _unwrap_tool_call(value: Any) -> tuple[Any, str | None]:
+    """A ToolCall-shaped input split into its arguments and its id."""
     if isinstance(value, dict) and value.get("type") == "tool_call":
-        raw = value.get("args", {})
-    schema = tool.tool_call_schema
-    if isinstance(schema, type) and issubclass(schema, BaseModel):
-        if isinstance(raw, str):
-            fields = schema.model_fields
-            if len(fields) != 1:
-                raise ValueError("String tool input requires a single-field schema")
-            raw = {next(iter(fields)): raw}
-        if not isinstance(raw, dict):
-            raise TypeError("Tool input must be a string or mapping")
-        return schema.model_validate(raw).model_dump()
-    if isinstance(raw, dict):
-        return raw
-    return {"input": raw}
+        return value.get("args", {}), value.get("id")
+    return value, None
+
+
+def _arguments(tool: BaseTool, raw: Any, tool_call_id: str | None) -> Mapping[str, Any]:
+    """The arguments the tool is about to receive, as the tool itself reads them.
+
+    Delegates to the tool's own ``_parse_input`` rather than re-deriving the
+    rule from ``tool_call_schema``: that schema is not the parsing contract for
+    every tool, and regenerating it drops the author's field validators, which
+    would show a resolver a different value than the tool runs with.
+
+    Two things are then corrected.  The input is copied first, because
+    ``_parse_input`` writes into the mapping it is given and that mapping is
+    usually the ``args`` of a ``ToolCall`` living in message history.  And the
+    result is narrowed to what the model can actually supply: ``_parse_input``
+    re-adds arguments the framework injects — credentials, graph state, the
+    tool call id — that ``tool_call_schema`` deliberately hides, and a policy
+    resolver must not be handed those.
+    """
+    if isinstance(raw, Mapping):
+        raw = dict(raw)
+
+    try:
+        parsed = tool._parse_input(raw, tool_call_id)
+    except Exception as exc:
+        raise _InvalidArguments from exc
+
+    visible = tool.args
+    if isinstance(parsed, dict):
+        return {key: value for key, value in parsed.items() if key in visible}
+
+    # A bare string comes back out of _parse_input unchanged. LangChain binds
+    # it to the schema's first field whatever the field count, so key it the
+    # same way rather than inventing a name the tool will never use.
+    names = list(visible)
+    return {names[0]: parsed} if names else {"input": parsed}
 
 
 def _check_decision(
@@ -80,7 +129,9 @@ def _check_decision(
         raise ArcjetToolUnavailableError(action)
 
 
-def _handle_tool_exception(tool: BaseTool, error: ToolException, value: Any) -> Any:
+def _handle_tool_exception(
+    tool: BaseTool, error: ToolException, tool_call_id: str | None
+) -> Any:
     handler = tool.handle_tool_error
     if isinstance(handler, str):
         content = handler
@@ -90,163 +141,245 @@ def _handle_tool_exception(tool: BaseTool, error: ToolException, value: Any) -> 
         content = cast(Callable[[ToolException], str], handler)(error)
     else:
         raise error
-    if isinstance(value, dict) and value.get("type") == "tool_call":
+    if tool_call_id is not None:
         return ToolMessage(
             content=cast(Any, content),
-            tool_call_id=str(value.get("id", "")),
+            tool_call_id=tool_call_id,
             name=tool.name,
             status="error",
         )
     return content
 
 
-class _GuardedTool(BaseTool):
-    _tool: BaseTool
-    _guard: ArcjetGuard | ArcjetGuardSync
-    _action: str
-    _actor: ActorResolver | AsyncActorResolver | None
-    _inputs: InputResolver | AsyncInputResolver | None
-    _rules: Sequence[RuleWithInput]
-    _on_guard_error: OnGuardError
+# ``repr=False`` because this holds the Arcjet client, whose own repr renders
+# the API key. A dataclass repr would put that key in any traceback captured
+# with locals, which is what pytest --showlocals and most error reporters do.
+@dataclass(frozen=True, slots=True, repr=False)
+class _Policy:
+    """What guarding one tool needs, held apart from the tool's own fields."""
 
-    def __init__(
-        self,
-        *,
-        guard: ArcjetGuard | ArcjetGuardSync,
-        tool: BaseTool,
-        action: str,
-        actor: ActorResolver | AsyncActorResolver | None,
-        inputs: InputResolver | AsyncInputResolver | None,
-        rules: Sequence[RuleWithInput],
-        on_guard_error: OnGuardError,
-    ) -> None:
-        super().__init__(
-            name=tool.name,
-            description=tool.description,
-            args_schema=tool.args_schema,
-            return_direct=tool.return_direct,
-            verbose=tool.verbose,
-            callbacks=tool.callbacks,
-            tags=tool.tags,
-            metadata=tool.metadata,
-            handle_tool_error=tool.handle_tool_error,
-            handle_validation_error=tool.handle_validation_error,
-            response_format=tool.response_format,
-        )
-        self._tool = tool
-        self._guard = guard
-        self._action = action
-        self._actor = actor
-        self._inputs = inputs
-        self._rules = tuple(rules)
-        self._on_guard_error = on_guard_error
+    guard: ArcjetGuard | ArcjetGuardSync
+    action: str
+    actor: ActorResolver | AsyncActorResolver | None
+    inputs: InputResolver | AsyncInputResolver | None
+    rules: tuple[RuleWithInput, ...]
+    on_guard_error: OnGuardError
+
+
+class _GuardMixin:
+    """The checkpoint, in front of a tool this wrapper delegates to.
+
+    Both wrapper classes below mix this in.  It holds no pydantic state of its
+    own — the concrete classes declare the private attributes — so it cannot
+    disturb the field definitions of the model it is mixed into.
+    """
+
+    _arcjet: _Policy
+    _arcjet_tool: BaseTool
 
     def invoke(
         self, input: Any, config: RunnableConfig | None = None, **kwargs: Any
     ) -> Any:
-        if not isinstance(self._guard, ArcjetGuardSync):
-            raise TypeError(
-                "A synchronous LangChain invocation requires ArcjetGuardSync"
-            )
-        resolved_config = config if config is not None else cast(RunnableConfig, {})
+        raw, tool_call_id = _unwrap_tool_call(input)
         try:
-            arguments = _arguments(self._tool, input)
-            actor = self._resolve_actor(resolved_config)
-            inputs = self._resolve_inputs(arguments, resolved_config)
-            decision = self._guard.guard(
-                self._rules,
-                label=self._action,
-                actor=actor,
-                inputs=inputs,
-            )
-            _check_decision(decision, self._action, self._on_guard_error)
+            self._arcjet_evaluate(raw, tool_call_id, config)
+        except _InvalidArguments:
+            pass
         except ArcjetToolDeniedError as exc:
-            return _handle_tool_exception(self, exc, input)
-        except Exception as exc:
-            if self._on_guard_error == "deny":
-                raise ArcjetToolUnavailableError(self._action, cause=exc) from exc
-        return self._tool.invoke(input, config=config, **kwargs)
+            return _handle_tool_exception(cast(BaseTool, self), exc, tool_call_id)
+        return self._arcjet_tool.invoke(input, config, **kwargs)
 
     async def ainvoke(
         self, input: Any, config: RunnableConfig | None = None, **kwargs: Any
     ) -> Any:
-        if not isinstance(self._guard, ArcjetGuard):
-            raise TypeError("An asynchronous LangChain invocation requires ArcjetGuard")
-        resolved_config = config if config is not None else cast(RunnableConfig, {})
+        raw, tool_call_id = _unwrap_tool_call(input)
         try:
-            arguments = _arguments(self._tool, input)
-            actor = await self._resolve_actor_async(resolved_config)
-            inputs = await self._resolve_inputs_async(arguments, resolved_config)
-            decision = await self._guard.guard(
-                self._rules,
-                label=self._action,
-                actor=actor,
-                inputs=inputs,
-            )
-            _check_decision(decision, self._action, self._on_guard_error)
+            await self._arcjet_evaluate_async(raw, tool_call_id, config)
+        except _InvalidArguments:
+            pass
         except ArcjetToolDeniedError as exc:
-            return _handle_tool_exception(self, exc, input)
+            return _handle_tool_exception(cast(BaseTool, self), exc, tool_call_id)
+        return await self._arcjet_tool.ainvoke(input, config, **kwargs)
+
+    def run(self, tool_input: Any, *args: Any, **kwargs: Any) -> Any:
+        tool_call_id = kwargs.get("tool_call_id")
+        try:
+            self._arcjet_evaluate(tool_input, tool_call_id, kwargs.get("config"))
+        except _InvalidArguments:
+            pass
+        except ArcjetToolDeniedError as exc:
+            return _handle_tool_exception(cast(BaseTool, self), exc, tool_call_id)
+        return self._arcjet_tool.run(tool_input, *args, **kwargs)
+
+    async def arun(self, tool_input: Any, *args: Any, **kwargs: Any) -> Any:
+        tool_call_id = kwargs.get("tool_call_id")
+        try:
+            await self._arcjet_evaluate_async(
+                tool_input, tool_call_id, kwargs.get("config")
+            )
+        except _InvalidArguments:
+            pass
+        except ArcjetToolDeniedError as exc:
+            return _handle_tool_exception(cast(BaseTool, self), exc, tool_call_id)
+        return await self._arcjet_tool.arun(tool_input, *args, **kwargs)
+
+    def _arcjet_evaluate(
+        self, raw: Any, tool_call_id: str | None, config: RunnableConfig | None
+    ) -> None:
+        if not isinstance(self._arcjet.guard, ArcjetGuardSync):
+            raise TypeError(
+                "A synchronous LangChain invocation requires ArcjetGuardSync"
+            )
+        resolved = config if config is not None else cast(RunnableConfig, {})
+        try:
+            decision = self._arcjet.guard.guard(
+                self._arcjet.rules,
+                label=self._arcjet.action,
+                actor=self._arcjet_actor(resolved),
+                inputs=self._arcjet_inputs(raw, tool_call_id, resolved),
+            )
+            _check_decision(decision, self._arcjet.action, self._arcjet.on_guard_error)
+        except (ArcjetToolDeniedError, ArcjetToolUnavailableError, _InvalidArguments):
+            raise
         except Exception as exc:
-            if self._on_guard_error == "deny":
-                raise ArcjetToolUnavailableError(self._action, cause=exc) from exc
-        return await self._tool.ainvoke(input, config=config, **kwargs)
+            if self._arcjet.on_guard_error == "deny":
+                raise ArcjetToolUnavailableError(
+                    self._arcjet.action, cause=exc
+                ) from exc
 
-    def _resolve_actor(self, config: RunnableConfig) -> str | None:
-        if self._actor is None or isinstance(self._actor, str):
-            return self._actor
-        value = self._actor(config)
+    async def _arcjet_evaluate_async(
+        self, raw: Any, tool_call_id: str | None, config: RunnableConfig | None
+    ) -> None:
+        if not isinstance(self._arcjet.guard, ArcjetGuard):
+            raise TypeError("An asynchronous LangChain invocation requires ArcjetGuard")
+        resolved = config if config is not None else cast(RunnableConfig, {})
+        try:
+            decision = await self._arcjet.guard.guard(
+                self._arcjet.rules,
+                label=self._arcjet.action,
+                actor=await self._arcjet_actor_async(resolved),
+                inputs=await self._arcjet_inputs_async(raw, tool_call_id, resolved),
+            )
+            _check_decision(decision, self._arcjet.action, self._arcjet.on_guard_error)
+        except (ArcjetToolDeniedError, ArcjetToolUnavailableError, _InvalidArguments):
+            raise
+        except Exception as exc:
+            if self._arcjet.on_guard_error == "deny":
+                raise ArcjetToolUnavailableError(
+                    self._arcjet.action, cause=exc
+                ) from exc
+
+    def _arcjet_resolve_actor(
+        self, config: RunnableConfig
+    ) -> str | None | Awaitable[str | None]:
+        actor = self._arcjet.actor
+        if not callable(actor):
+            return actor
+        return cast(_ActorFn, actor)(config)
+
+    def _arcjet_resolve_inputs(
+        self, raw: Any, tool_call_id: str | None, config: RunnableConfig
+    ) -> PolicyInputMap | None | Awaitable[PolicyInputMap | None]:
+        resolver = self._arcjet.inputs
+        if not callable(resolver):
+            return resolver
+        # Parsed only here, because a resolver is the only thing that reads the
+        # arguments: a tool with no resolver configured is never parsed at all.
+        arguments = _arguments(self._arcjet_tool, raw, tool_call_id)
+        return cast(_InputsFn, resolver)(arguments, config)
+
+    def _arcjet_actor(self, config: RunnableConfig) -> str | None:
+        value = self._arcjet_resolve_actor(config)
         if inspect.isawaitable(value):
+            _discard(value)
             raise TypeError("A synchronous actor resolver must not return an awaitable")
-        return value
+        return cast("str | None", value)
 
-    def _resolve_inputs(
-        self, arguments: Mapping[str, Any], config: RunnableConfig
+    def _arcjet_inputs(
+        self, raw: Any, tool_call_id: str | None, config: RunnableConfig
     ) -> PolicyInputMap | None:
-        if self._inputs is None or not callable(self._inputs):
-            return self._inputs
-        resolver = cast(
-            Callable[
-                [Mapping[str, Any], RunnableConfig],
-                PolicyInputMap | Awaitable[PolicyInputMap],
-            ],
-            self._inputs,
-        )
-        value = resolver(arguments, config)
+        value = self._arcjet_resolve_inputs(raw, tool_call_id, config)
         if inspect.isawaitable(value):
+            _discard(value)
             raise TypeError("A synchronous input resolver must not return an awaitable")
-        return value
+        return cast("PolicyInputMap | None", value)
 
-    async def _resolve_actor_async(self, config: RunnableConfig) -> str | None:
-        if self._actor is None or isinstance(self._actor, str):
-            return self._actor
-        resolver = cast(Callable[[RunnableConfig], str | Awaitable[str]], self._actor)
-        value = resolver(config)
+    async def _arcjet_actor_async(self, config: RunnableConfig) -> str | None:
+        value = self._arcjet_resolve_actor(config)
         if inspect.isawaitable(value):
-            return cast(str, await value)
-        return cast(str, value)
+            return cast("str | None", await value)
+        return cast("str | None", value)
 
-    async def _resolve_inputs_async(
-        self, arguments: Mapping[str, Any], config: RunnableConfig
+    async def _arcjet_inputs_async(
+        self, raw: Any, tool_call_id: str | None, config: RunnableConfig
     ) -> PolicyInputMap | None:
-        if self._inputs is None or not callable(self._inputs):
-            return self._inputs
-        resolver = cast(
-            Callable[
-                [Mapping[str, Any], RunnableConfig],
-                PolicyInputMap | Awaitable[PolicyInputMap],
-            ],
-            self._inputs,
-        )
-        value = resolver(arguments, config)
+        value = self._arcjet_resolve_inputs(raw, tool_call_id, config)
         if inspect.isawaitable(value):
-            return cast(PolicyInputMap, await value)
-        return cast(PolicyInputMap, value)
+            return cast("PolicyInputMap | None", await value)
+        return cast("PolicyInputMap | None", value)
 
-    def _run(self, *_args: Any, **_kwargs: Any) -> Any:
-        raise RuntimeError("Guarded tools delegate through invoke()")
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
+        # The Arcjet client owns a connection pool and a lock, so it is shared
+        # with the copy rather than duplicated: copying a client is not
+        # meaningful, and `copy.deepcopy` cannot do it at all.
+        guard = self._arcjet.guard
+        memo[id(guard)] = guard
+        return BaseModel.__deepcopy__(cast(BaseModel, self), memo)
 
-    async def _arun(self, *_args: Any, **_kwargs: Any) -> Any:
-        raise RuntimeError("Guarded tools delegate through ainvoke()")
+
+def _discard(value: Any) -> None:
+    """Close a coroutine that will never be awaited.
+
+    Dropping it instead leaves a ``RuntimeWarning`` to surface at an arbitrary
+    later garbage collection, which is a hard failure under ``-W error``.
+    """
+    close = getattr(value, "close", None)
+    if callable(close):
+        close()
+
+
+class _GuardedTool(_GuardMixin, BaseTool):
+    """Guards any tool, and asks that tool what its schema is.
+
+    ``args_schema`` is a cache of an answer, not the answer: a tool that
+    declares none has its schema derived from its own ``_run``, which this
+    wrapper does not have.  Forwarding the derivation keeps ``args``, the
+    provider conversions and ``bind_tools`` reading the tool that knows.
+    """
+
+    _arcjet: _Policy = PrivateAttr()
+    _arcjet_tool: BaseTool = PrivateAttr()
+
+    def get_input_schema(self, config: RunnableConfig | None = None) -> Any:
+        return self._arcjet_tool.get_input_schema(config)
+
+    @property
+    def tool_call_schema(self) -> Any:
+        return self._arcjet_tool.tool_call_schema
+
+    @property
+    def args(self) -> dict[str, Any]:
+        return self._arcjet_tool.args
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("Guarded tools delegate to the tool they wrap")
+
+
+class _GuardedSimpleTool(_GuardMixin, SimpleTool):
+    """Guards a ``Tool`` built from a bare function.
+
+    Such a tool has no schema to forward: LangChain advertises it through an
+    escape hatch in ``_format_tool_to_openai_function`` gated on the concrete
+    ``Tool`` class, so the wrapper has to be one for the model to be told the
+    same thing.  Leaving ``args_schema`` unset is the other half of that gate.
+    """
+
+    _arcjet: _Policy = PrivateAttr()
+    _arcjet_tool: BaseTool = PrivateAttr()
+
+    @property
+    def args(self) -> dict[str, Any]:
+        return self._arcjet_tool.args
 
 
 def guard_tool(
@@ -261,28 +394,55 @@ def guard_tool(
 ) -> BaseTool:
     """Wrap a LangChain tool with an Arcjet pre-execution checkpoint.
 
+    The guarded tool evaluates policy and then hands the call to *tool*, which
+    is left untouched and keeps running its own code — so anything the tool's
+    class overrides still applies, and the model is told exactly what the
+    unguarded tool advertised.
+
     Unlike the core Guard client, which returns a fail-open ``ALLOW`` decision
     when evaluation is degraded, this helper fails closed by default. With
     ``on_guard_error="deny"``, an exception from the pre-execution checkpoint
-    (argument normalization, actor or input resolution, or Guard itself) or a
-    decision whose ``has_failed_open()`` is true raises
-    :class:`ArcjetToolUnavailableError` without executing the tool. Set
-    ``on_guard_error="allow"`` to execute the tool in either case.
+    (actor or input resolution, or Guard itself) or a decision whose
+    ``has_failed_open()`` is true raises :class:`ArcjetToolUnavailableError`
+    without executing the tool. Set ``on_guard_error="allow"`` to execute the
+    tool in either case.
 
     A real ``DENY`` decision blocks execution regardless of ``on_guard_error``
     and is represented by :class:`ArcjetToolDeniedError`; the wrapped tool's
     ``handle_tool_error`` may convert it into a LangChain error result. It is
     distinct from an unavailable evaluation.
     """
-    return _GuardedTool(
+    wrapper: type[BaseTool]
+    if isinstance(tool, SimpleTool) and not tool.args_schema:
+        wrapper = _GuardedSimpleTool
+    else:
+        wrapper = _GuardedTool
+
+    values: dict[str, Any] = {}
+    for name in type(tool).model_fields:
+        if name not in wrapper.model_fields:
+            continue
+        value = getattr(tool, name)
+        # One level of copy on the containers. Sharing them would let a tag or
+        # a callback attached to either tool show up on the other, so an audit
+        # trail could record executions that never passed the checkpoint.
+        if isinstance(value, list):
+            value = list(value)
+        elif isinstance(value, dict):
+            value = dict(value)
+        values[name] = value
+
+    guarded = wrapper(**values)
+    guarded._arcjet_tool = tool
+    guarded._arcjet = _Policy(
         guard=guard,
-        tool=tool,
         action=action,
         actor=actor,
         inputs=inputs,
-        rules=rules,
+        rules=tuple(rules),
         on_guard_error=on_guard_error,
     )
+    return guarded
 
 
 __all__ = [

--- a/tests/integration/guard/test_langchain.py
+++ b/tests/integration/guard/test_langchain.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, cast
+import copy
+from typing import Annotated, Any, cast
 
 import pytest
-from langchain_core.tools import StructuredTool
+from langchain_core.tools import (
+    BaseTool,
+    InjectedToolArg,
+    StructuredTool,
+    Tool,
+    tool,
+)
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from pydantic import BaseModel, Field, PrivateAttr
 
 from arcjet.guard import ArcjetGuard, ArcjetGuardSync, server_input
 from arcjet.guard.langchain import ArcjetToolDeniedError, guard_tool
@@ -17,9 +26,11 @@ class _Transport:
     ) -> None:
         self.conclusion = conclusion
         self.request: pb.GuardRequest | None = None
+        self.calls = 0
 
     def guard(self, request: pb.GuardRequest, **_kwargs: Any) -> pb.GuardResponse:
         self.request = request
+        self.calls += 1
         return pb.GuardResponse(
             decision=pb.GuardDecision(
                 id="gdec_test",
@@ -191,3 +202,334 @@ def test_guard_tool_uses_native_async_guard_and_tool_paths() -> None:
     assert asyncio.run(wrapped.ainvoke(cast(Any, {"value": "one"}))) == "found:one"
     assert transport.request is not None
     assert transport.request.actor == "user-async"
+
+
+# --- Guarding must not change what the application already did ---------------
+#
+# guard_tool is an instrumentation layer, so the bar for each of these is that
+# the guarded tool behaves as the unguarded one did. Every case below compares
+# against that baseline rather than against a value written down by hand.
+
+
+class _SubclassTool(BaseTool):
+    """A BaseTool subclass declaring no args_schema, so _run's signature is it."""
+
+    name: str = "search"
+    description: str = "Search the index"
+
+    def _run(self, query: str, limit: int = 5) -> str:
+        return f"search({query},{limit})"
+
+
+@tool
+def _decorated(location: str, units: str = "c") -> str:
+    """Get the weather.
+
+    Args:
+        location: Where to look.
+        units: c or f.
+    """
+    return f"weather({location},{units})"
+
+
+def _authored_tools() -> dict[str, BaseTool]:
+    return {
+        "decorator": _decorated,
+        "structured": StructuredTool.from_function(
+            lambda value: f"st({value})", name="st", description="Structured"
+        ),
+        "subclass": _SubclassTool(),
+        "simple": Tool(name="legacy", description="Legacy", func=lambda v: f"lg({v})"),
+        "json_schema": StructuredTool.from_function(
+            lambda **kwargs: "js",
+            name="js",
+            description="JSON schema",
+            args_schema={
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+                "required": ["q"],
+            },
+        ),
+    }
+
+
+@pytest.mark.parametrize("style", sorted(_authored_tools()))
+def test_guarding_does_not_change_what_the_model_is_told(style: str) -> None:
+    """A guarded tool that advertises a different schema is a broken tool.
+
+    It still gets called, with whatever arguments the changed schema implies,
+    so this fails silently rather than loudly.
+    """
+    original = _authored_tools()[style]
+    wrapped = guard_tool(
+        guard=_guard(_Transport()), tool=original, action="schema.checked"
+    )
+
+    assert convert_to_openai_tool(wrapped) == convert_to_openai_tool(original)
+    assert wrapped.args == original.args
+
+
+def test_guarding_does_not_change_a_single_input_tools_result() -> None:
+    transport = _Transport()
+    original = Tool(name="lookup", description="d", func=lambda v: f"found({v})")
+    wrapped = guard_tool(guard=_guard(transport), tool=original, action="lookup.called")
+
+    assert wrapped.invoke(cast(Any, "widget")) == original.invoke(cast(Any, "widget"))
+    assert transport.calls == 1
+
+
+def test_injected_arguments_are_hidden_from_a_policy_resolver() -> None:
+    """Injected arguments are credentials and graph state, not model input.
+
+    `tool_call_schema` hides them from the model; `_parse_input` puts them back.
+    A resolver that forwards its argument map to Guard would ship them off-box.
+    """
+
+    class Args(BaseModel):
+        query: str
+        api_token: Annotated[str, InjectedToolArg] = "sk-SECRET"
+
+    seen: list[dict[str, Any]] = []
+    wrapped = guard_tool(
+        guard=_guard(_Transport()),
+        tool=StructuredTool.from_function(
+            lambda query, api_token="sk-SECRET": "ok",
+            name="search",
+            description="d",
+            args_schema=Args,
+        ),
+        action="search.called",
+        inputs=lambda arguments, _config: seen.append(dict(arguments)) or {},
+    )
+
+    wrapped.invoke(cast(Any, {"query": "q"}))
+
+    assert seen == [{"query": "q"}]
+
+
+@pytest.mark.parametrize("with_resolver", [False, True])
+def test_bad_model_arguments_reach_the_tools_own_validation_handler(
+    with_resolver: bool,
+) -> None:
+    """Malformed model output is the agent's problem, not an Arcjet outage.
+
+    Reporting it as ArcjetToolUnavailableError would page an operator and kill
+    the agent's retry loop over a routine, permanent error.
+    """
+
+    class Amount(BaseModel):
+        amount: int = Field(ge=0)
+
+    def build() -> BaseTool:
+        t = StructuredTool.from_function(
+            lambda amount: f"charged({amount})",
+            name="charge",
+            description="d",
+            args_schema=Amount,
+        )
+        t.handle_validation_error = "the model sent bad arguments"
+        return t
+
+    original = build()
+    wrapped = guard_tool(
+        guard=_guard(_Transport()),
+        tool=build(),
+        action="charge.made",
+        inputs=(lambda arguments, _config: {}) if with_resolver else None,
+    )
+
+    assert wrapped.invoke(cast(Any, {"amount": -5})) == original.invoke(
+        cast(Any, {"amount": -5})
+    )
+
+
+def test_a_guarded_tool_can_be_deepcopied() -> None:
+    """LangGraph and several tracing paths deepcopy the objects they hold.
+
+    The Arcjet client cannot be copied — it owns a lock — so it is shared.
+    """
+    wrapped = guard_tool(
+        guard=_guard(_Transport()), tool=_SubclassTool(), action="search.called"
+    )
+
+    assert copy.deepcopy(wrapped).invoke(cast(Any, {"query": "q"})) == "search(q,5)"
+
+
+def test_every_execution_is_guarded_including_a_tools_own_recursion() -> None:
+    """A tool that re-enters itself must not amortise one decision over many runs.
+
+    The recursive arguments are the model-derived ones, so they are exactly
+    what a prompt-injection or rate-limit rule needs to see.
+    """
+    transport = _Transport()
+    bodies = 0
+
+    def recurse(depth: int) -> str:
+        nonlocal bodies
+        bodies += 1
+        if depth > 0:
+            return wrapped.invoke(cast(Any, {"depth": depth - 1}))
+        return "done"
+
+    wrapped = guard_tool(
+        guard=_guard(transport),
+        tool=StructuredTool.from_function(recurse, name="recurse", description="d"),
+        action="recurse.called",
+    )
+
+    wrapped.invoke(cast(Any, {"depth": 4}))
+
+    assert bodies == 5
+    assert transport.calls == bodies
+
+
+def test_guarding_an_already_guarded_tool_evaluates_both_policies() -> None:
+    inner_transport, outer_transport = _Transport(), _Transport()
+    tool = StructuredTool.from_function(
+        lambda value: f"ok({value})", name="echo", description="d"
+    )
+
+    inner = guard_tool(guard=_guard(inner_transport), tool=tool, action="echo.inner")
+    outer = guard_tool(guard=_guard(outer_transport), tool=inner, action="echo.outer")
+
+    assert outer.invoke(cast(Any, {"value": "x"})) == "ok(x)"
+    assert (inner_transport.calls, outer_transport.calls) == (1, 1)
+
+
+def test_run_and_arun_are_guarded_entrypoints() -> None:
+    transport = _Transport(pb.GUARD_CONCLUSION_DENY)
+    calls = 0
+
+    def dangerous(value: str) -> str:
+        nonlocal calls
+        calls += 1
+        return value
+
+    wrapped = guard_tool(
+        guard=_guard(transport),
+        tool=StructuredTool.from_function(dangerous, name="dangerous", description="d"),
+        action="dangerous.called",
+    )
+
+    with pytest.raises(ArcjetToolDeniedError):
+        wrapped.run({"value": "no"})
+    assert calls == 0
+
+
+def test_guarding_leaves_the_tool_it_was_given_untouched() -> None:
+    """Applications keep the unguarded tool for trusted internal call sites.
+
+    Shared containers would let a tag or callback attached to one appear on the
+    other, so an audit trail could record executions that never passed a check.
+    """
+    original = _SubclassTool(tags=["billing"], metadata={"team": "payments"})
+    wrapped = guard_tool(
+        guard=_guard(_Transport()), tool=original, action="search.called"
+    )
+
+    assert wrapped.tags is not None and wrapped.metadata is not None
+    wrapped.tags.append("added")
+    wrapped.metadata["added"] = True
+
+    assert original.tags == ["billing"]
+    assert original.metadata == {"team": "payments"}
+
+
+def test_guarding_does_not_edit_the_callers_tool_call() -> None:
+    """A ToolCall's args live in an AIMessage in conversation state.
+
+    Editing them re-serializes to the provider next turn and is replayed by a
+    checkpointer on resume.
+    """
+    call = {
+        "type": "tool_call",
+        "name": "search",
+        "id": "call_1",
+        "args": {"query": "q"},
+    }
+    wrapped = guard_tool(
+        guard=_guard(_Transport()),
+        tool=_SubclassTool(),
+        action="search.called",
+        inputs=lambda arguments, _config: {},
+    )
+
+    wrapped.invoke(cast(Any, call))
+
+    assert call["args"] == {"query": "q"}
+
+
+def test_a_resolver_can_read_a_top_level_config_key() -> None:
+    """`Callable[[RunnableConfig], str]` permits reading the config as passed."""
+    transport = _Transport()
+    wrapped = guard_tool(
+        guard=_guard(transport),
+        tool=StructuredTool.from_function(
+            lambda value: "ok", name="echo", description="d"
+        ),
+        action="echo.called",
+        actor=lambda config: str(cast(Any, config)["user_id"]),
+    )
+
+    wrapped.invoke(cast(Any, {"value": "x"}), cast(Any, {"user_id": "user-1"}))
+
+    assert transport.request is not None
+    assert transport.request.actor == "user-1"
+
+
+def test_guarding_preserves_a_tools_own_private_state() -> None:
+    class Stateful(BaseTool):
+        name: str = "stateful"
+        description: str = "d"
+        _arcjet: str = PrivateAttr(default="the tool's own state")
+
+        def _run(self, query: str) -> str:
+            return f"got:{self._arcjet}"
+
+    original = Stateful()
+    wrapped = guard_tool(
+        guard=_guard(_Transport()), tool=original, action="stateful.called"
+    )
+
+    assert wrapped.invoke(cast(Any, {"query": "q"})) == original.invoke(
+        cast(Any, {"query": "q"})
+    )
+
+
+def test_guarding_fires_no_subclass_registration_hook() -> None:
+    registered: list[str] = []
+
+    class Registering(BaseTool):
+        name: str = "reg"
+        description: str = "d"
+
+        def __init_subclass__(cls, **kwargs: Any) -> None:
+            super().__init_subclass__(**kwargs)
+            registered.append(cls.__name__)
+
+        def _run(self, query: str) -> str:
+            return "r"
+
+    guard_tool(guard=_guard(_Transport()), tool=Registering(), action="reg.called")
+
+    assert registered == []
+
+
+def test_guarding_preserves_an_artifact_result() -> None:
+    original = StructuredTool.from_function(
+        lambda value: ("content", {"rows": 2}),
+        name="report",
+        description="d",
+        response_format="content_and_artifact",
+        return_direct=True,
+    )
+    wrapped = guard_tool(
+        guard=_guard(_Transport()), tool=original, action="report.built"
+    )
+    call = {"type": "tool_call", "name": "report", "id": "c1", "args": {"value": "x"}}
+
+    assert (
+        wrapped.invoke(cast(Any, call)).artifact
+        == original.invoke(cast(Any, call)).artifact
+    )
+    assert wrapped.return_direct == original.return_direct

--- a/tests/integration/guard/test_langchain.py
+++ b/tests/integration/guard/test_langchain.py
@@ -607,9 +607,11 @@ def test_a_zero_argument_tool_is_still_guarded() -> None:
     )
 
     for probe in ("", "N/A"):
-        with pytest.raises(ArcjetToolDeniedError):
+        with pytest.raises((ArcjetToolDeniedError, ArcjetToolUnavailableError)):
             wrapped.invoke(cast(Any, probe))
     assert ran == 0
+    # Guard saw both calls, so a blocked call is on the record rather than
+    # looking like a call that never happened.
     assert transport.calls == 2
 
 
@@ -769,3 +771,62 @@ def test_an_unevaluated_policy_is_governed_by_on_guard_error(
     else:
         assert wrapped.invoke(cast(Any, {"value": "x"})) == "done"
         assert ran == 1
+
+
+def test_arguments_a_resolver_cannot_read_are_an_unevaluated_policy() -> None:
+    """An input rule that sees nothing has not run, whatever Guard replied.
+
+    A tool taking no arguments accepts input no schema validates, so the rule
+    is configured, sees nothing, and the call would otherwise proceed.
+    """
+    transport = _Transport()
+    ran = 0
+
+    @tool
+    def zero() -> str:
+        """Take no arguments."""
+        nonlocal ran
+        ran += 1
+        return "done"
+
+    denied = guard_tool(
+        guard=_guard(transport),
+        tool=zero,
+        action="zero.called",
+        inputs=lambda arguments, _config: {},
+    )
+    with pytest.raises(ArcjetToolUnavailableError):
+        denied.invoke(cast(Any, ""))
+    assert ran == 0
+    assert transport.calls == 1
+
+    allowed = guard_tool(
+        guard=_guard(transport),
+        tool=zero,
+        action="zero.called",
+        inputs=lambda arguments, _config: {},
+        on_guard_error="allow",
+    )
+    assert allowed.invoke(cast(Any, "")) == "done"
+
+
+def test_arguments_the_tool_itself_rejects_are_not_an_arcjet_failure() -> None:
+    """A schema rejection stops the tool, so there is no effect to protect."""
+    transport = _Transport()
+
+    class Amount(BaseModel):
+        amount: int = Field(ge=0)
+
+    original = StructuredTool.from_function(
+        lambda amount: "charged", name="charge", description="d", args_schema=Amount
+    )
+    original.handle_validation_error = "the model sent bad arguments"
+    wrapped = guard_tool(
+        guard=_guard(transport),
+        tool=original,
+        action="charge.made",
+        inputs=lambda arguments, _config: {},
+    )
+
+    assert wrapped.invoke(cast(Any, {"amount": -5})) == "the model sent bad arguments"
+    assert transport.calls == 1

--- a/tests/integration/guard/test_langchain.py
+++ b/tests/integration/guard/test_langchain.py
@@ -16,7 +16,11 @@ from langchain_core.utils.function_calling import convert_to_openai_tool
 from pydantic import BaseModel, Field, PrivateAttr
 
 from arcjet.guard import ArcjetGuard, ArcjetGuardSync, server_input
-from arcjet.guard.langchain import ArcjetToolDeniedError, guard_tool
+from arcjet.guard.langchain import (
+    ArcjetToolDeniedError,
+    ArcjetToolUnavailableError,
+    guard_tool,
+)
 from arcjet.guard.proto.decide.v2 import decide_pb2 as pb
 
 
@@ -158,14 +162,25 @@ def test_guard_tool_uses_wrapped_tool_error_handler_after_denial() -> None:
 
 
 class _AsyncTransport:
-    def __init__(self) -> None:
+    def __init__(
+        self, conclusion: pb.GuardConclusion = pb.GUARD_CONCLUSION_ALLOW
+    ) -> None:
+        self.conclusion = conclusion
         self.request: pb.GuardRequest | None = None
+        self.calls = 0
 
     async def guard(self, request: pb.GuardRequest, **_kwargs: Any) -> pb.GuardResponse:
         self.request = request
+        self.calls += 1
         return pb.GuardResponse(
             decision=pb.GuardDecision(
-                id="gdec_async", conclusion=pb.GUARD_CONCLUSION_ALLOW
+                id="gdec_async",
+                conclusion=self.conclusion,
+                reason=(
+                    pb.GUARD_REASON_INPUT_CONSTRAINT
+                    if self.conclusion == pb.GUARD_CONCLUSION_DENY
+                    else pb.GUARD_REASON_UNSPECIFIED
+                ),
             )
         )
 
@@ -343,16 +358,23 @@ def test_bad_model_arguments_reach_the_tools_own_validation_handler(
     )
 
 
-def test_a_guarded_tool_can_be_deepcopied() -> None:
-    """LangGraph and several tracing paths deepcopy the objects they hold.
+def test_a_guarded_tool_can_be_copied() -> None:
+    """LangGraph and several tracing paths clone the objects they hold.
 
-    The Arcjet client cannot be copied — it owns a lock — so it is shared.
+    The Arcjet client cannot be copied — it owns a lock — so it is shared with
+    the copy. That only holds while the copy reaches the guarded tool before it
+    reaches the client by some other edge, which a caller cannot control; an
+    application holding its client alongside its tools can still fail, and
+    fixing that needs the client itself to be copy-aware.
     """
     wrapped = guard_tool(
         guard=_guard(_Transport()), tool=_SubclassTool(), action="search.called"
     )
 
     assert copy.deepcopy(wrapped).invoke(cast(Any, {"query": "q"})) == "search(q,5)"
+    assert wrapped.model_copy(deep=True).invoke(cast(Any, {"query": "q"})) == (
+        "search(q,5)"
+    )
 
 
 def test_every_execution_is_guarded_including_a_tools_own_recursion() -> None:
@@ -396,7 +418,7 @@ def test_guarding_an_already_guarded_tool_evaluates_both_policies() -> None:
     assert (inner_transport.calls, outer_transport.calls) == (1, 1)
 
 
-def test_run_and_arun_are_guarded_entrypoints() -> None:
+def test_run_is_a_guarded_entrypoint() -> None:
     transport = _Transport(pb.GUARD_CONCLUSION_DENY)
     calls = 0
 
@@ -413,6 +435,28 @@ def test_run_and_arun_are_guarded_entrypoints() -> None:
 
     with pytest.raises(ArcjetToolDeniedError):
         wrapped.run({"value": "no"})
+    assert calls == 0
+
+
+def test_arun_is_a_guarded_entrypoint() -> None:
+    transport = _AsyncTransport(pb.GUARD_CONCLUSION_DENY)
+    calls = 0
+
+    async def dangerous(value: str) -> str:
+        nonlocal calls
+        calls += 1
+        return value
+
+    wrapped = guard_tool(
+        guard=ArcjetGuard("key", transport, 1000, "test-agent"),  # type: ignore[arg-type]
+        tool=StructuredTool.from_function(
+            coroutine=dangerous, name="dangerous", description="d"
+        ),
+        action="dangerous.called",
+    )
+
+    with pytest.raises(ArcjetToolDeniedError):
+        asyncio.run(wrapped.arun({"value": "no"}))
     assert calls == 0
 
 
@@ -533,3 +577,195 @@ def test_guarding_preserves_an_artifact_result() -> None:
         == original.invoke(cast(Any, call)).artifact
     )
     assert wrapped.return_direct == original.return_direct
+
+
+# --- The checkpoint must run, whatever the arguments look like ---------------
+
+
+def test_a_zero_argument_tool_is_still_guarded() -> None:
+    """The checkpoint cannot be conditional on reading the arguments.
+
+    A tool taking no arguments accepts a bare string that no schema validates,
+    so treating an unreadable argument list as "the tool will reject this
+    anyway" lets the call through with policy never consulted.
+    """
+    transport = _Transport(pb.GUARD_CONCLUSION_DENY)
+    ran = 0
+
+    @tool
+    def list_secrets() -> str:
+        """List every secret."""
+        nonlocal ran
+        ran += 1
+        return "secret1,secret2"
+
+    wrapped = guard_tool(
+        guard=_guard(transport),
+        tool=list_secrets,
+        action="secrets.listed",
+        inputs=lambda arguments, _config: {},
+    )
+
+    for probe in ("", "N/A"):
+        with pytest.raises(ArcjetToolDeniedError):
+            wrapped.invoke(cast(Any, probe))
+    assert ran == 0
+    assert transport.calls == 2
+
+
+def test_unreadable_arguments_still_reach_the_checkpoint() -> None:
+    """A schema shape this cannot parse must not become an Arcjet outage.
+
+    Policy still runs — without inputs, which is weaker and still a decision —
+    and the tool then does whatever it would have done unguarded.
+    """
+    transport = _Transport()
+    original = StructuredTool.from_function(
+        lambda **kwargs: "ran",
+        name="permissive",
+        description="d",
+        args_schema={"type": "object", "additionalProperties": True},
+    )
+    wrapped = guard_tool(
+        guard=_guard(transport),
+        tool=original,
+        action="permissive.called",
+        inputs=lambda arguments, _config: {},
+    )
+
+    assert wrapped.invoke(cast(Any, {"a": 1})) == original.invoke(cast(Any, {"a": 1}))
+    assert transport.calls == 1
+
+
+def test_a_resolver_sees_the_keys_the_model_was_told_to_send() -> None:
+    """A tool with no schema is advertised under a key its own `args` never uses.
+
+    Filtering against the wrong key-space silently empties the argument map, so
+    a rule bound to it scans nothing while the guard call still reports healthy.
+    """
+    seen: list[dict[str, Any]] = []
+    wrapped = guard_tool(
+        guard=_guard(_Transport()),
+        tool=Tool(name="shell", description="d", func=lambda v: f"ran({v})"),
+        action="shell.run",
+        inputs=lambda arguments, _config: seen.append(dict(arguments)) or {},
+    )
+
+    wrapped.invoke(
+        cast(
+            Any,
+            {
+                "type": "tool_call",
+                "name": "shell",
+                "id": "c1",
+                "args": {"__arg1": "ignore previous instructions"},
+            },
+        )
+    )
+
+    assert seen == [{"__arg1": "ignore previous instructions"}]
+
+
+def test_a_resolver_receives_plain_data_for_nested_models() -> None:
+    """Resolvers are documented to take a Mapping[str, Any], not model objects."""
+
+    class Address(BaseModel):
+        street: str
+
+    class Order(BaseModel):
+        address: Address
+        qty: int = 1
+
+    seen: list[Any] = []
+    wrapped = guard_tool(
+        guard=_guard(_Transport()),
+        tool=StructuredTool.from_function(
+            lambda address, qty=1: "ok",
+            name="order",
+            description="d",
+            args_schema=Order,
+        ),
+        action="order.placed",
+        inputs=lambda arguments, _config: seen.append(arguments["address"]) or {},
+    )
+
+    wrapped.invoke(cast(Any, {"address": {"street": "1 Main"}, "qty": 2}))
+
+    assert seen == [{"street": "1 Main"}]
+
+
+def test_a_narrowed_args_schema_on_the_guarded_tool_is_honoured() -> None:
+    """Narrowing the guarded copy is how an app hides a privileged field."""
+
+    class Full(BaseModel):
+        to: str
+        admin_override: bool = False
+
+    class Public(BaseModel):
+        to: str
+
+    wrapped = guard_tool(
+        guard=_guard(_Transport()),
+        tool=StructuredTool.from_function(
+            lambda to, admin_override=False: "sent",
+            name="send",
+            description="d",
+            args_schema=Full,
+        ),
+        action="email.sent",
+    )
+    wrapped.args_schema = Public
+
+    properties = convert_to_openai_tool(wrapped)["function"]["parameters"]["properties"]
+    assert set(properties) == {"to"}
+    assert set(wrapped.args) == {"to"}
+
+
+def test_no_wrapper_exposes_an_unguarded_execution_path() -> None:
+    """`_run`/`_arun` are private but public enough to be reached."""
+    for original in (
+        _SubclassTool(),
+        Tool(name="legacy", description="d", func=lambda v: f"EXECUTED:{v}"),
+    ):
+        wrapped = guard_tool(
+            guard=_guard(_Transport(pb.GUARD_CONCLUSION_DENY)),
+            tool=original,
+            action="a",
+        )
+        with pytest.raises(RuntimeError):
+            cast(Any, wrapped)._run("secret", config={})
+
+
+@pytest.mark.parametrize("on_guard_error", ["deny", "allow"])
+def test_an_unevaluated_policy_is_governed_by_on_guard_error(
+    on_guard_error: str,
+) -> None:
+    """The fail-closed default is the property this helper exists for."""
+    ran = 0
+
+    def effect(value: str) -> str:
+        nonlocal ran
+        ran += 1
+        return "done"
+
+    class _Failing:
+        def guard(self, _request: Any, **_kwargs: Any) -> Any:
+            raise RuntimeError("transport down")
+
+        def capture(self, _request: Any, **_kwargs: Any) -> pb.CaptureResponse:
+            return pb.CaptureResponse()
+
+    wrapped = guard_tool(
+        guard=ArcjetGuardSync("key", _Failing(), 1000, "test-agent"),  # type: ignore[arg-type]
+        tool=StructuredTool.from_function(effect, name="effect", description="d"),
+        action="effect.done",
+        on_guard_error=cast(Any, on_guard_error),
+    )
+
+    if on_guard_error == "deny":
+        with pytest.raises(ArcjetToolUnavailableError):
+            wrapped.invoke(cast(Any, {"value": "x"}))
+        assert ran == 0
+    else:
+        assert wrapped.invoke(cast(Any, {"value": "x"})) == "done"
+        assert ran == 1


### PR DESCRIPTION
## Why

`guard_tool()` puts a policy check in front of a LangChain tool. This instrumentation / policy wrapping is supposed to be transparent (it must not cause working code to start failing just because Arcjet has been added in), but the current version of the code breaks the expectations of handlers that are relying on tool signatures and typechecks. Adding the Python SDK to a project can cause working calls to tools to start failing.

Here is a description of what the fix does, as well as a list of the limitations of this fix. I'm experimenting with using [ASD-STE100 Simplified Technical English](https://en.wikipedia.org/wiki/Simplified_Technical_English) as the output style of Claude. I find it easier to follow than Claude's somewhat chaotic default output, and I'm interested to hear other people's thoughts. Here is what Claude came up with:

> ## What the change does
> 
>   The guarded tool now sends each call to the tool that it wraps.
> 
>   - The guarded tool asks the wrapped tool for its schema. The model receives the same schema as before.
>   - The guarded tool copies the field values of the wrapped tool. It does not use a fixed list of field names.
>   - `invoke()`, `ainvoke()`, `run()` and `arun()` each run the policy check one time.
>   - The policy check runs for every call. The wrapper does not skip the check when it cannot read the arguments of the call.
>   - A policy resolver receives the arguments that the tool runs with. The resolver does not receive the credentials or the graph state that the framework adds.
>   - The wrapped tool keeps its own state. `guard_tool()` does not change it.
> 
>   ## Known limitations
> 
>   The current release also has the limitations 4 to 8.
> 
>   1. The guarded tool is not an instance of the class of the wrapped tool. Application code that examines the class of a tool sees the wrapper. A `Tool` object that has no `args_schema` is the exception, because its wrapper is also a `Tool`.
>   2. `copy.deepcopy()` can fail. The guarded tool shares the Arcjet client with the copy, but this is only possible when the copy operation finds the guarded tool before it finds the client. An application that holds the client next to its tools can fail.
>   3. LangChain has a second class check for custom tools. The wrapper does not satisfy it. The model receives a different tool type for a `Tool` object whose `metadata` contains `"type": "custom_tool"`.
>   4. A denied call sends no callback events. A trace shows no record of a call that the policy blocks.
>   5. `pickle` cannot serialize a guarded tool, because the Arcjet client contains an object that `pickle` cannot serialize.
>   6. `ArcjetTestClient` cannot drive a guarded tool. The wrapper tests the class of the client. Use a transport double in a test instead.
>   7. The wrapper copies the field values one time. The wrapped tool ignores a `callbacks`, `tags` or `metadata` value that you set on the guarded tool after `guard_tool()` returns.
>   8. The general wrapper does not carry `func` or `coroutine`. `render_text_description()` shows less detail for a guarded tool.