### PR TITLE
ci: cancel a superseded test run instead of stacking another

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,19 @@ on:
 permissions:
   contents: read
 
+# One in-flight run per pull request. The `labeled` and `unlabeled` triggers
+# above are needed, because the griffe step reads the `breaking` label off the
+# event, but they also mean anything that touches a label re-runs the whole
+# matrix — and a bot that toggles one produces a run per toggle, none of which
+# supersede each other without this.
+#
+# Only pull request runs are cancelled. A merge queue run that loses its
+# checks would fall out of the queue, and every commit on `main` is worth
+# testing on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
The Test workflow triggers on `labeled` and `unlabeled`, and nothing cancelled
the run a new event superseded. Anything that touched a label re-ran the whole
matrix, so a bot toggling one label produced a complete Lint-plus-four-Pythons
run per toggle. Three open pull requests reached roughly 300 runs each on a
single commit, which saturated the runners and left unrelated pull requests
queued behind them.

This adds one in-flight run per pull request, matching the group
`lint-workflows.yml` already declares.

The label triggers stay. The griffe step reads the `breaking` label off the
event, and without `labeled` it would never see that label added.

Only pull request runs are cancelled. A merge queue run that loses its checks
falls out of the queue, and every commit on `main` is worth testing on its own.
