### PR TITLE
fix: use pyqwest's default transport (fixes UnknownIssuer)

### DIFF
--- a/src/arcjet/_transport.py
+++ b/src/arcjet/_transport.py
@@ -1,17 +1,24 @@
 """Shared pyqwest transport construction.
 
 Every Arcjet client builds its HTTP transport here, rather than each factory
-constructing its own.  Four factories previously did it independently, which is
-how they all came to be missing ``tls_include_system_certs``.
+constructing its own.
 
-``tls_include_system_certs=True`` is not optional.  pyqwest 0.7.0 introduced
-that parameter defaulting to ``False``, meaning a transport trusts **no** root
-certificates and every HTTPS request fails with
-``invalid peer certificate: UnknownIssuer``.  Before 0.7.0 the parameter did not
-exist and the system store was always used, so the default flip silently broke
-outbound TLS for anyone who installed a fresh pyqwest.  This is why the
-dependency floor is ``pyqwest>=0.7.0``: on 0.6.2 and earlier, passing the
-keyword is a ``TypeError``.
+Prefer pyqwest's default transport. ``Client()`` / ``SyncClient()`` and
+``get_default_transport()`` / ``get_default_sync_transport()`` load the
+platform CA store and let ALPN pick HTTP/2 on TLS. That is enough for the
+Connect Decide API — it does not require a forced-HTTP/2 transport.
+
+A *custom* ``HTTPTransport()`` is a different object. pyqwest 0.7.0 added
+``tls_include_system_certs`` defaulting to ``False``, so a transport built
+without it trusts **no** root certificates and every HTTPS request fails
+with ``invalid peer certificate: UnknownIssuer``. That is the 0.9.0 bug
+(`#201 <https://github.com/arcjet/arcjet-py/issues/201>`_): the SDK forced
+``http_version=HTTP2``, which required constructing a custom transport, which
+silently dropped the system store.
+
+We only construct a custom transport when a caller passes overrides (tests
+setting ``connect_timeout``, for example). That path always sets
+``tls_include_system_certs=True`` and does **not** force HTTP/2.
 """
 
 from __future__ import annotations
@@ -21,10 +28,8 @@ from typing import Any
 import pyqwest
 
 
-def _transport_kwargs(**overrides: Any) -> dict[str, Any]:
+def _custom_transport_kwargs(**overrides: Any) -> dict[str, Any]:
     return {
-        # Always enable HTTP/2 by default.
-        "http_version": pyqwest.HTTPVersion.HTTP2,
         # Trust the platform's CA store. See the module docstring.
         "tls_include_system_certs": True,
         **overrides,
@@ -34,6 +39,9 @@ def _transport_kwargs(**overrides: Any) -> dict[str, Any]:
 def build_async_transport(**overrides: Any) -> pyqwest.HTTPTransport:
     """Build the async transport every async Arcjet client uses.
 
+    With no overrides this is pyqwest's shared default transport. Overrides
+    build a dedicated transport that still trusts the system CA store.
+
     Args:
         **overrides: Extra pyqwest transport options, or replacements for the
             defaults set here.
@@ -41,11 +49,16 @@ def build_async_transport(**overrides: Any) -> pyqwest.HTTPTransport:
     Returns:
         A configured :class:`pyqwest.HTTPTransport`.
     """
-    return pyqwest.HTTPTransport(**_transport_kwargs(**overrides))
+    if not overrides:
+        return pyqwest.get_default_transport()
+    return pyqwest.HTTPTransport(**_custom_transport_kwargs(**overrides))
 
 
 def build_sync_transport(**overrides: Any) -> pyqwest.SyncHTTPTransport:
     """Build the sync transport every sync Arcjet client uses.
+
+    With no overrides this is pyqwest's shared default transport. Overrides
+    build a dedicated transport that still trusts the system CA store.
 
     Args:
         **overrides: Extra pyqwest transport options, or replacements for the
@@ -54,4 +67,6 @@ def build_sync_transport(**overrides: Any) -> pyqwest.SyncHTTPTransport:
     Returns:
         A configured :class:`pyqwest.SyncHTTPTransport`.
     """
-    return pyqwest.SyncHTTPTransport(**_transport_kwargs(**overrides))
+    if not overrides:
+        return pyqwest.get_default_sync_transport()
+    return pyqwest.SyncHTTPTransport(**_custom_transport_kwargs(**overrides))

--- a/tests/unit/test_proxy_env.py
+++ b/tests/unit/test_proxy_env.py
@@ -95,12 +95,9 @@ class _FakeProxy:
 
 
 def _make_transport() -> pyqwest.SyncHTTPTransport:
-    # Use the same HTTP/2 setting the SDK's transport uses (see arcjet_sync()
-    # and the guard client), so we exercise the same proxy/CONNECT-tunnel code
-    # path the real client uses. connect_timeout is a test-only addition to keep
-    # the bypass cases fast; the SDK does not set it.
-    # Built through the SDK's own helper so this cannot drift from it again;
-    # connect_timeout is a test-only addition to keep the bypass cases fast.
+    # Built through the SDK's own helper so TLS settings cannot drift from the
+    # factories. connect_timeout is a test-only addition to keep the bypass
+    # cases fast; the SDK does not set it (it uses the default transport).
     return build_sync_transport(connect_timeout=3.0)
 
 

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -189,45 +189,97 @@ class _LocalHTTPS:
         self.ca_pem = ca_pem
 
 
-def _make_self_signed_cert(tmp_path: Path) -> tuple[Path, Path]:
-    cert = tmp_path / "cert.pem"
-    key = tmp_path / "key.pem"
+def _run_openssl(*args: str) -> None:
     subprocess.run(
-        [
-            "openssl",
-            "req",
-            "-x509",
-            "-newkey",
-            "rsa:2048",
-            "-keyout",
-            str(key),
-            "-out",
-            str(cert),
-            "-days",
-            "1",
-            "-nodes",
-            "-subj",
-            "/CN=localhost",
-            "-addext",
-            "subjectAltName=DNS:localhost,IP:127.0.0.1",
-        ],
+        ["openssl", *args],
         check=True,
         capture_output=True,
         text=True,
     )
-    return cert, key
+
+
+def _make_ca_and_server_cert(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Return ``(ca_pem, server_pem, server_key)``.
+
+    rustls rejects a CA certificate presented as the server leaf
+    (``CaUsedAsEndEntity``), so the server cert must be a separate
+    end-entity signed by the throwaway CA.
+    """
+    ca_key = tmp_path / "ca.key"
+    ca_pem = tmp_path / "ca.pem"
+    server_key = tmp_path / "server.key"
+    server_csr = tmp_path / "server.csr"
+    server_pem = tmp_path / "server.pem"
+    server_ext = tmp_path / "server.ext"
+
+    _run_openssl(
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        str(ca_key),
+        "-out",
+        str(ca_pem),
+        "-days",
+        "1",
+        "-nodes",
+        "-subj",
+        "/CN=arcjet-test-ca",
+        "-addext",
+        "basicConstraints=critical,CA:TRUE",
+    )
+    _run_openssl(
+        "req",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        str(server_key),
+        "-out",
+        str(server_csr),
+        "-nodes",
+        "-subj",
+        "/CN=localhost",
+    )
+    server_ext.write_text(
+        "basicConstraints=CA:FALSE\n"
+        "subjectAltName=DNS:localhost,IP:127.0.0.1\n"
+        "keyUsage=digitalSignature,keyEncipherment\n"
+        "extendedKeyUsage=serverAuth\n"
+    )
+    _run_openssl(
+        "x509",
+        "-req",
+        "-in",
+        str(server_csr),
+        "-CA",
+        str(ca_pem),
+        "-CAkey",
+        str(ca_key),
+        "-CAcreateserial",
+        "-out",
+        str(server_pem),
+        "-days",
+        "1",
+        "-extfile",
+        str(server_ext),
+    )
+    return ca_pem, server_pem, server_key
 
 
 @pytest.fixture
 def local_https(tmp_path: Path) -> Iterator[_LocalHTTPS]:
     """Local HTTPS server whose CA is *not* in the system store."""
-    cert_path, key_path = _make_self_signed_cert(tmp_path)
+    ca_path, cert_path, key_path = _make_ca_and_server_cert(tmp_path)
 
     class _Handler(http.server.BaseHTTPRequestHandler):
         def do_GET(self) -> None:
+            body = b"ok"
             self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Connection", "close")
             self.end_headers()
-            self.wfile.write(b"ok")
+            self.wfile.write(body)
 
         def log_message(self, format: str, *args: object) -> None:
             return
@@ -242,7 +294,7 @@ def local_https(tmp_path: Path) -> Iterator[_LocalHTTPS]:
         host, port = httpd.server_address
         yield _LocalHTTPS(
             url=f"https://{host}:{port}/",
-            ca_pem=cert_path.read_bytes(),
+            ca_pem=ca_path.read_bytes(),
         )
     finally:
         httpd.shutdown()
@@ -269,7 +321,7 @@ class TestIssue201Reproduction:
     ) -> None:
         client = pyqwest.SyncClient(pyqwest.SyncHTTPTransport())
 
-        with pytest.raises(pyqwest.ConnectionError) as exc_info:
+        with pytest.raises(ConnectionError) as exc_info:
             client.get(local_https.url)
 
         _assert_unknown_issuer(exc_info.value)
@@ -282,7 +334,7 @@ class TestIssue201Reproduction:
             pyqwest.SyncHTTPTransport(http_version=pyqwest.HTTPVersion.HTTP2)
         )
 
-        with pytest.raises(pyqwest.ConnectionError) as exc_info:
+        with pytest.raises(ConnectionError) as exc_info:
             client.get(local_https.url)
 
         _assert_unknown_issuer(exc_info.value)
@@ -302,7 +354,7 @@ class TestIssue201Reproduction:
             )
         )
 
-        with pytest.raises(pyqwest.ConnectionError) as exc_info:
+        with pytest.raises(ConnectionError) as exc_info:
             client.get(local_https.url)
 
         _assert_unknown_issuer(exc_info.value)

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -286,6 +286,9 @@ def local_https(tmp_path: Path) -> Iterator[_LocalHTTPS]:
 
     httpd = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    # PROTOCOL_TLS_SERVER can still offer TLS 1.0/1.1 unless pinned; CodeQL
+    # flags that even for this localhost fixture.
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.load_cert_chain(certfile=str(cert_path), keyfile=str(key_path))
     httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -291,9 +291,8 @@ def local_https(tmp_path: Path) -> Iterator[_LocalHTTPS]:
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)
     thread.start()
     try:
-        host, port = httpd.server_address
         yield _LocalHTTPS(
-            url=f"https://{host}:{port}/",
+            url=f"https://127.0.0.1:{httpd.server_port}/",
             ca_pem=ca_path.read_bytes(),
         )
     finally:

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -1,27 +1,22 @@
 """Tests for shared transport construction.
 
-**What these prove, and what they do not.** None of these establish that TLS
-works — that needs a real request to a real host, which a unit test should not
-make. They are regression guards for the specific mistake that shipped: the flag
-being absent from a transport, and transports being built outside the one helper
-that sets it.
+**What these prove, and what they do not.** Most of these are regression
+guards for the mistake that shipped in 0.9.0: constructing a custom
+HTTP/2-only pyqwest transport, which trusts no root certificates.
 
-The bug: pyqwest 0.7.0 added ``tls_include_system_certs`` defaulting to
-``False``, so a transport trusts no root certificates, and all four Arcjet client
-factories built transports without it. Every HTTPS request failed with
-``invalid peer certificate: UnknownIssuer``. Because the SDK fails open, that
-surfaced as an ALLOW decision with ``reason=ERROR`` rather than an obvious
-network fault.
-
-Why the suite missed it: ``uv.lock`` pinned pyqwest 0.6.2, where the parameter
-did not exist and the system store was always used. Only a fresh install
-resolved 0.7.0 and broke — a dependency-resolution failure, which no in-repo
-test run can see. Catching that class of problem needs a scheduled job that
-installs the published package and makes a real request.
+The TLS handshake itself is covered by a local HTTPS server with a
+throwaway CA — that reproduces ``UnknownIssuer`` without a network call.
+Live requests to ``decide.arcjet.com`` are out of scope here; catching a
+broken *published* package needs a scheduled install-and-request job.
 """
 
 from __future__ import annotations
 
+import http.server
+import ssl
+import subprocess
+import threading
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -56,17 +51,16 @@ class TestInstalledPyqwest:
     def test_the_installed_pyqwest_accepts_the_flag(self, build: Any) -> None:
         """A rename or removal must fail here, loudly and without network.
 
-        This is the one test that touches real pyqwest. The flag is passed
-        unconditionally rather than probed for, so if a future version drops or
-        renames it, construction raises TypeError instead of silently falling
-        back to trusting nothing.
+        The override path passes the flag unconditionally rather than probing
+        for it, so if a future version drops or renames it, construction
+        raises TypeError instead of silently falling back to trusting nothing.
         """
-        transport = build()
+        transport = build(connect_timeout=3.0)
 
         assert transport is not None
 
     def test_the_flag_still_defaults_to_false_upstream(self) -> None:
-        """Documents *why* the flag is passed at all.
+        """Documents *why* a custom transport must set the flag.
 
         If a future pyqwest defaults this back to True, this test fails and the
         explicit flag becomes redundant rather than load-bearing — worth knowing
@@ -84,21 +78,60 @@ class TestInstalledPyqwest:
             f"is still needed (default is now {parameter.default!r})"
         )
 
+    def test_bare_http_transport_is_not_the_default(self) -> None:
+        """``HTTPTransport()`` is not the default Client() transport.
 
-class TestHelperPassesTheFlag:
+        pyqwest's docs are easy to misread here: constructing a transport with
+        no arguments does **not** produce the shared default, and it does not
+        trust any CAs. That distinction is the whole bug.
+        """
+        assert pyqwest.HTTPTransport() is not pyqwest.get_default_transport()
+        assert pyqwest.SyncHTTPTransport() is not pyqwest.get_default_sync_transport()
+
+
+class TestHelperUsesTheDefaultTransport:
+    """Issue #201: we do not need a custom HTTP/2 transport."""
+
+    @pytest.mark.parametrize("build", BUILDERS)
+    def test_no_overrides_returns_the_default_singleton(self, build: Any) -> None:
+        transport = build()
+
+        if build is build_async_transport:
+            assert transport is pyqwest.get_default_transport()
+        else:
+            assert transport is pyqwest.get_default_sync_transport()
+
+    @pytest.mark.parametrize("build", BUILDERS)
+    def test_no_overrides_does_not_construct_a_custom_transport(
+        self, build: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom(**kwargs: Any) -> str:
+            raise AssertionError(
+                f"no-arg helper must use the default transport, not construct one: {kwargs}"
+            )
+
+        monkeypatch.setattr(pyqwest, "SyncHTTPTransport", boom)
+        monkeypatch.setattr(pyqwest, "HTTPTransport", boom)
+
+        assert build() is not None
+
+
+class TestOverridePathKeepsSystemCerts:
     @pytest.mark.parametrize("build", BUILDERS)
     def test_passes_tls_include_system_certs_true(
         self, build: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        seen = _spy_kwargs(monkeypatch, build)
+        seen = _spy_kwargs(monkeypatch, build, connect_timeout=3.0)
 
         assert seen.get("tls_include_system_certs") is True
 
     @pytest.mark.parametrize("build", BUILDERS)
-    def test_passes_http2(self, build: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-        seen = _spy_kwargs(monkeypatch, build)
+    def test_does_not_force_http2(
+        self, build: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_kwargs(monkeypatch, build, connect_timeout=3.0)
 
-        assert seen.get("http_version") == pyqwest.HTTPVersion.HTTP2
+        assert "http_version" not in seen
 
     @pytest.mark.parametrize("build", BUILDERS)
     def test_an_override_cannot_silently_drop_tls_trust(
@@ -116,6 +149,7 @@ class TestHelperPassesTheFlag:
         seen = _spy_kwargs(monkeypatch, build, http_version=pyqwest.HTTPVersion.HTTP1)
 
         assert seen.get("http_version") == pyqwest.HTTPVersion.HTTP1
+        assert seen.get("tls_include_system_certs") is True
 
 
 class TestNothingBypassesTheHelper:
@@ -145,3 +179,150 @@ class TestNothingBypassesTheHelper:
             "build transports via arcjet._transport so TLS settings cannot "
             f"drift: {offenders}"
         )
+
+
+class _LocalHTTPS:
+    """A one-shot HTTPS server serving 200 on GET, with a throwaway CA."""
+
+    def __init__(self, url: str, ca_pem: bytes) -> None:
+        self.url = url
+        self.ca_pem = ca_pem
+
+
+def _make_self_signed_cert(tmp_path: Path) -> tuple[Path, Path]:
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            str(key),
+            "-out",
+            str(cert),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+            "-addext",
+            "subjectAltName=DNS:localhost,IP:127.0.0.1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return cert, key
+
+
+@pytest.fixture
+def local_https(tmp_path: Path) -> Iterator[_LocalHTTPS]:
+    """Local HTTPS server whose CA is *not* in the system store."""
+    cert_path, key_path = _make_self_signed_cert(tmp_path)
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    httpd = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(certfile=str(cert_path), keyfile=str(key_path))
+    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = httpd.server_address
+        yield _LocalHTTPS(
+            url=f"https://{host}:{port}/",
+            ca_pem=cert_path.read_bytes(),
+        )
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=2.0)
+
+
+def _assert_unknown_issuer(exc: BaseException) -> None:
+    message = str(exc)
+    assert "UnknownIssuer" in message, message
+
+
+class TestIssue201Reproduction:
+    """Reproduce the 0.9.0 TLS failure against a local HTTPS server.
+
+    These are the constructions from
+    https://github.com/arcjet/arcjet-py/issues/201. The server's certificate
+    is not in the system store, which is the same situation a custom
+    transport with an empty root store sees for *every* host — including
+    ``decide.arcjet.com``.
+    """
+
+    def test_bare_transport_fails_unknown_issuer(
+        self, local_https: _LocalHTTPS
+    ) -> None:
+        client = pyqwest.SyncClient(pyqwest.SyncHTTPTransport())
+
+        with pytest.raises(pyqwest.ConnectionError) as exc_info:
+            client.get(local_https.url)
+
+        _assert_unknown_issuer(exc_info.value)
+
+    def test_http2_only_transport_fails_unknown_issuer(
+        self, local_https: _LocalHTTPS
+    ) -> None:
+        """The exact 0.9.0 construction: force HTTP/2, forget the CA store."""
+        client = pyqwest.SyncClient(
+            pyqwest.SyncHTTPTransport(http_version=pyqwest.HTTPVersion.HTTP2)
+        )
+
+        with pytest.raises(pyqwest.ConnectionError) as exc_info:
+            client.get(local_https.url)
+
+        _assert_unknown_issuer(exc_info.value)
+
+    def test_http2_plus_system_certs_still_needs_the_server_ca(
+        self, local_https: _LocalHTTPS
+    ) -> None:
+        """System certs alone cannot validate a throwaway local CA.
+
+        This is the #173 construction. It fixes public hosts; it is not a
+        reason to keep forcing HTTP/2.
+        """
+        client = pyqwest.SyncClient(
+            pyqwest.SyncHTTPTransport(
+                http_version=pyqwest.HTTPVersion.HTTP2,
+                tls_include_system_certs=True,
+            )
+        )
+
+        with pytest.raises(pyqwest.ConnectionError) as exc_info:
+            client.get(local_https.url)
+
+        _assert_unknown_issuer(exc_info.value)
+
+    def test_helper_with_server_ca_succeeds(self, local_https: _LocalHTTPS) -> None:
+        client = pyqwest.SyncClient(
+            build_sync_transport(tls_ca_cert=local_https.ca_pem)
+        )
+
+        response = client.get(local_https.url)
+
+        assert response.status == 200
+
+    def test_custom_transport_with_server_ca_succeeds(
+        self, local_https: _LocalHTTPS
+    ) -> None:
+        client = pyqwest.SyncClient(
+            pyqwest.SyncHTTPTransport(tls_ca_cert=local_https.ca_pem)
+        )
+
+        response = client.get(local_https.url)
+
+        assert response.status == 200


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #201.

## Investigation

Every `protect()` in 0.9.0 failed with `invalid peer certificate: UnknownIssuer` because the SDK built a **custom** pyqwest transport:

```python
pyqwest.HTTPTransport(http_version=pyqwest.HTTPVersion.HTTP2)
```

A custom `HTTPTransport()` is not the default `Client()` transport. From pyqwest 0.7.0 the constructor defaults `tls_include_system_certs=False`, so that object trusts **no** CAs. Forcing HTTP/2 is what made us construct a custom transport in the first place.

#173 already papered over this by passing `tls_include_system_certs=True` while still forcing HTTP/2. This PR asks the question that issue left open: do we need that custom transport at all?

**We do not.** Empirically, against both `https://www.google.com` and `https://decide.arcjet.com`:

| Construction | TLS |
|---|---|
| `pyqwest.Client()` / `SyncClient()` (default) | 200 |
| `get_default_transport()` | 200 |
| `HTTPTransport()` / `HTTPTransport(http_version=HTTP2)` | `UnknownIssuer` |
| `HTTPTransport(http_version=HTTP2, tls_include_system_certs=True)` | 200 |
| `HTTPTransport(tls_include_system_certs=True)` | 200 |

The Decide API speaks Connect, which works over HTTP/1.1. pyqwest's default already negotiates HTTP/2 via ALPN on TLS. Timeouts stay on the per-RPC `timeout_ms` path, not the transport. connect-python itself defaults to `Client()` / `SyncClient()`.

The reporter's production workaround — `DecideServiceClient(..., http_client=pyqwest.Client())` — is therefore the correct client, not a compromise.

## Change

- No-arg `build_*_transport()` now returns pyqwest's shared default transport.
- A custom transport is built only when a caller passes overrides (e.g. the proxy tests' `connect_timeout`). That path still sets `tls_include_system_certs=True` and no longer forces HTTP/2.
- Reproduction tests stand up a local HTTPS server with a throwaway CA and an end-entity leaf (rustls rejects a CA used as the server cert) and assert the exact 0.9.0 construction fails with `UnknownIssuer`, while the helper with the server CA succeeds.

No public API change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea74e0b-a8a3-42de-9aa2-66f516e07a1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea74e0b-a8a3-42de-9aa2-66f516e07a1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

