### PR TITLE
fix: use a 2s Decide timeout for every protect() rule

### DIFF
--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -39,7 +39,6 @@ from arcjet.proto.decide.v1alpha1.decide_connect import (
 from ._cache import DecisionCache, make_cache_key
 from ._context import (
     RequestContext,
-    _is_development,
     coerce_request_context,
     request_details_from_context,
 )
@@ -147,25 +146,12 @@ class ProtectOptions(TypedDict, total=False):
     ASCII; invalid values are dropped, not truncated."""
 
 
-# Minimum Decide timeout when ``detect_prompt_injection()`` is configured.
+# Deadline for a protect() call when timeout_ms is not set.
 #
-# Warm inference is typically ~100ms, but a cold model start can exceed the
-# 500ms production default (and the previous 1s floor). A tight deadline
-# fail-opens and skips detection, so we match Guard's 2s default for the
-# same class of remote inference rules.
-_PROMPT_INJECTION_MIN_TIMEOUT_MS = 2000
-
-
-def _default_timeout_ms(
-    rules: Sequence[RuleSpec] = (), environment: str | None = None
-) -> int:
-    # 1000ms in development, 500ms otherwise.
-    default = 1000 if _is_development(environment=environment) else 500
-    # detect_prompt_injection defines its latency guarantees individually
-    # rather than as part of the protect call, so enforce a 2 second minimum.
-    if any(isinstance(r, PromptInjectionDetection) for r in rules):
-        return max(default, _PROMPT_INJECTION_MIN_TIMEOUT_MS)
-    return default
+# Sized for the slowest rules: a cold prompt-injection or content-moderation
+# start can exceed the old 500ms production default, and a tight deadline
+# fail-opens instead of evaluating the rule. Matches Guard's default.
+_DEFAULT_TIMEOUT_MS = 2000
 
 
 DEFAULT_BASE_URL = (
@@ -1475,12 +1461,7 @@ def arcjet(
             (server uses IP address). See https://docs.arcjet.com/fingerprints.
         base_url: Override the Arcjet Decide API endpoint. Only set this if
             directed by Arcjet support.
-        timeout_ms: Request timeout in milliseconds. Defaults to 1000 ms in
-            development and 500 ms in production. When a
-            ``detect_prompt_injection()`` rule is configured, the minimum is
-            2000 ms because that rule defines its latency guarantees
-            individually rather than as part of the protect call, and a cold
-            model start can exceed the shorter defaults.
+        timeout_ms: Request timeout in milliseconds. Defaults to 2000 ms.
         fail_open: When ``True`` (default), transport errors produce an ERROR
             decision instead of raising an exception, so your app stays
             available if Arcjet is temporarily unreachable. Set to ``False``
@@ -1568,11 +1549,7 @@ def arcjet(
         _client=client,
         _sdk_stack=stack,
         _sdk_version=_sdk_version() if sdk_version is None else sdk_version,
-        _timeout_ms=(
-            _default_timeout_ms(rules=rules, environment=environment)
-            if timeout_ms is None
-            else timeout_ms
-        ),
+        _timeout_ms=_DEFAULT_TIMEOUT_MS if timeout_ms is None else timeout_ms,
         _fail_open=fail_open,
         _needs_email=any(isinstance(r, EmailValidation) for r in rules),
         _needs_message=any(isinstance(r, PromptInjectionDetection) for r in rules),
@@ -1614,12 +1591,7 @@ def arcjet_sync(
             (server uses IP address). See https://docs.arcjet.com/fingerprints.
         base_url: Override the Arcjet Decide API endpoint. Only set this if
             directed by Arcjet support.
-        timeout_ms: Request timeout in milliseconds. Defaults to 1000 ms in
-            development and 500 ms in production. When a
-            ``detect_prompt_injection()`` rule is configured, the minimum is
-            2000 ms because that rule defines its latency guarantees
-            individually rather than as part of the protect call, and a cold
-            model start can exceed the shorter defaults.
+        timeout_ms: Request timeout in milliseconds. Defaults to 2000 ms.
         fail_open: When ``True`` (default), transport errors produce an ERROR
             decision instead of raising an exception, so your app stays
             available if Arcjet is temporarily unreachable. Set to ``False``
@@ -1708,11 +1680,7 @@ def arcjet_sync(
         _client=client,
         _sdk_stack=stack,
         _sdk_version=_sdk_version() if sdk_version is None else sdk_version,
-        _timeout_ms=(
-            _default_timeout_ms(rules=rules, environment=environment)
-            if timeout_ms is None
-            else timeout_ms
-        ),
+        _timeout_ms=_DEFAULT_TIMEOUT_MS if timeout_ms is None else timeout_ms,
         _fail_open=fail_open,
         _needs_email=any(isinstance(r, EmailValidation) for r in rules),
         _needs_message=any(isinstance(r, PromptInjectionDetection) for r in rules),

--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -147,15 +147,24 @@ class ProtectOptions(TypedDict, total=False):
     ASCII; invalid values are dropped, not truncated."""
 
 
+# Minimum Decide timeout when ``detect_prompt_injection()`` is configured.
+#
+# Warm inference is typically ~100ms, but a cold model start can exceed the
+# 500ms production default (and the previous 1s floor). A tight deadline
+# fail-opens and skips detection, so we match Guard's 2s default for the
+# same class of remote inference rules.
+_PROMPT_INJECTION_MIN_TIMEOUT_MS = 2000
+
+
 def _default_timeout_ms(
     rules: Sequence[RuleSpec] = (), environment: str | None = None
 ) -> int:
     # 1000ms in development, 500ms otherwise.
     default = 1000 if _is_development(environment=environment) else 500
     # detect_prompt_injection defines its latency guarantees individually
-    # rather than as part of the protect call, so enforce a 1 second minimum.
+    # rather than as part of the protect call, so enforce a 2 second minimum.
     if any(isinstance(r, PromptInjectionDetection) for r in rules):
-        return max(default, 1000)
+        return max(default, _PROMPT_INJECTION_MIN_TIMEOUT_MS)
     return default
 
 
@@ -1469,8 +1478,9 @@ def arcjet(
         timeout_ms: Request timeout in milliseconds. Defaults to 1000 ms in
             development and 500 ms in production. When a
             ``detect_prompt_injection()`` rule is configured, the minimum is
-            1000 ms because that rule defines its latency guarantees
-            individually rather than as part of the protect call.
+            2000 ms because that rule defines its latency guarantees
+            individually rather than as part of the protect call, and a cold
+            model start can exceed the shorter defaults.
         fail_open: When ``True`` (default), transport errors produce an ERROR
             decision instead of raising an exception, so your app stays
             available if Arcjet is temporarily unreachable. Set to ``False``
@@ -1607,8 +1617,9 @@ def arcjet_sync(
         timeout_ms: Request timeout in milliseconds. Defaults to 1000 ms in
             development and 500 ms in production. When a
             ``detect_prompt_injection()`` rule is configured, the minimum is
-            1000 ms because that rule defines its latency guarantees
-            individually rather than as part of the protect call.
+            2000 ms because that rule defines its latency guarantees
+            individually rather than as part of the protect call, and a cold
+            model start can exceed the shorter defaults.
         fail_open: When ``True`` (default), transport errors produce an ERROR
             decision instead of raising an exception, so your app stays
             available if Arcjet is temporarily unreachable. Set to ``False``

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -314,10 +314,11 @@ def test_default_timeout_production_without_prompt_injection(mock_protobuf_modul
 
 
 def test_default_timeout_production_with_prompt_injection(mock_protobuf_modules):
-    """Test that the default timeout in production is at least 1000ms when detect_prompt_injection is configured.
+    """Test that the default timeout in production is at least 2000ms when detect_prompt_injection is configured.
 
     detect_prompt_injection defines its latency guarantees individually rather
-    than as part of the protect call, so a minimum of 1 second is enforced.
+    than as part of the protect call, and a cold model start can exceed the
+    500ms production default, so a minimum of 2 seconds is enforced.
     """
     from arcjet import arcjet
     from arcjet._rules import detect_prompt_injection
@@ -326,7 +327,7 @@ def test_default_timeout_production_with_prompt_injection(mock_protobuf_modules)
         key="ajkey_x",
         rules=[detect_prompt_injection()],
     )
-    assert aj._timeout_ms == 1000
+    assert aj._timeout_ms == 2000
 
 
 def test_default_timeout_development_without_prompt_injection(
@@ -346,7 +347,7 @@ def test_default_timeout_development_without_prompt_injection(
 def test_default_timeout_development_with_prompt_injection(
     mock_protobuf_modules, dev_environment
 ):
-    """Test that the default timeout in development is 1000ms when detect_prompt_injection is configured."""
+    """Test that the default timeout in development is at least 2000ms when detect_prompt_injection is configured."""
     from arcjet import arcjet
     from arcjet._rules import detect_prompt_injection
 
@@ -354,7 +355,7 @@ def test_default_timeout_development_with_prompt_injection(
         key="ajkey_x",
         rules=[detect_prompt_injection()],
     )
-    assert aj._timeout_ms == 1000
+    assert aj._timeout_ms == 2000
 
 
 def test_explicit_timeout_overrides_prompt_injection_floor(mock_protobuf_modules):
@@ -717,24 +718,24 @@ class TestDefaultTimeoutMsEnvironmentKwarg:
         from arcjet._rules import detect_prompt_injection
 
         monkeypatch.delenv("ARCJET_ENV", raising=False)
-        # detect_prompt_injection enforces a 1000ms minimum even in production.
+        # detect_prompt_injection enforces a 2000ms minimum even in production.
         assert (
             _default_timeout_ms([detect_prompt_injection()], environment="production")
-            == 1000
+            == 2000
         )
 
-    def test_prompt_injection_in_development_keeps_1000(
+    def test_prompt_injection_in_development_clamps_to_2000(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         from arcjet._client import _default_timeout_ms
         from arcjet._rules import detect_prompt_injection
 
         monkeypatch.delenv("ARCJET_ENV", raising=False)
-        # Dev default (1000) already meets the prompt-injection min (1000);
-        # the max() should be a no-op rather than incorrectly clamping higher.
+        # Dev default (1000) is below the prompt-injection min (2000);
+        # the max() should raise the timeout rather than keep 1000.
         assert (
             _default_timeout_ms([detect_prompt_injection()], environment="development")
-            == 1000
+            == 2000
         )
 
     def test_env_var_fallback_when_kwarg_none(self, monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -301,8 +301,8 @@ def test_default_base_url_from_env_trailing_slash_is_stripped(
     importlib.reload(client_module)
 
 
-def test_default_timeout_production_without_prompt_injection(mock_protobuf_modules):
-    """Test that the default timeout in production is 500ms without prompt injection."""
+def test_default_timeout_is_2000_ms(mock_protobuf_modules):
+    """Test that the default timeout is 2000ms for every rule set."""
     from arcjet import arcjet
     from arcjet._rules import token_bucket
 
@@ -310,16 +310,11 @@ def test_default_timeout_production_without_prompt_injection(mock_protobuf_modul
         key="ajkey_x",
         rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
     )
-    assert aj._timeout_ms == 500
+    assert aj._timeout_ms == 2000
 
 
-def test_default_timeout_production_with_prompt_injection(mock_protobuf_modules):
-    """Test that the default timeout in production is at least 2000ms when detect_prompt_injection is configured.
-
-    detect_prompt_injection defines its latency guarantees individually rather
-    than as part of the protect call, and a cold model start can exceed the
-    500ms production default, so a minimum of 2 seconds is enforced.
-    """
+def test_default_timeout_is_2000_ms_with_prompt_injection(mock_protobuf_modules):
+    """Test that detect_prompt_injection uses the same 2000ms default."""
     from arcjet import arcjet
     from arcjet._rules import detect_prompt_injection
 
@@ -330,10 +325,10 @@ def test_default_timeout_production_with_prompt_injection(mock_protobuf_modules)
     assert aj._timeout_ms == 2000
 
 
-def test_default_timeout_development_without_prompt_injection(
+def test_default_timeout_is_2000_ms_in_development(
     mock_protobuf_modules, dev_environment
 ):
-    """Test that the default timeout in development is 1000ms without prompt injection."""
+    """Test that the default timeout is 2000ms in development as well."""
     from arcjet import arcjet
     from arcjet._rules import token_bucket
 
@@ -341,25 +336,11 @@ def test_default_timeout_development_without_prompt_injection(
         key="ajkey_x",
         rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
     )
-    assert aj._timeout_ms == 1000
-
-
-def test_default_timeout_development_with_prompt_injection(
-    mock_protobuf_modules, dev_environment
-):
-    """Test that the default timeout in development is at least 2000ms when detect_prompt_injection is configured."""
-    from arcjet import arcjet
-    from arcjet._rules import detect_prompt_injection
-
-    aj = arcjet(
-        key="ajkey_x",
-        rules=[detect_prompt_injection()],
-    )
     assert aj._timeout_ms == 2000
 
 
-def test_explicit_timeout_overrides_prompt_injection_floor(mock_protobuf_modules):
-    """Test that an explicit timeout_ms is not affected by the prompt injection floor."""
+def test_explicit_timeout_overrides_default(mock_protobuf_modules):
+    """Test that an explicit timeout_ms replaces the 2000ms default."""
     from arcjet import arcjet
     from arcjet._rules import detect_prompt_injection
 
@@ -691,63 +672,9 @@ def test_cache_hit_report_redacts_prompt_injection_message(
     assert captured["details"].extra.get("detectPromptInjectionMessage") == "<redacted>"
 
 
-class TestDefaultTimeoutMsEnvironmentKwarg:
-    """`_default_timeout_ms` honors the `environment` kwarg.
-
-    The 1000 vs 500 ms split is keyed off dev/prod, so it has the same
-    pydantic-settings bug as `coerce_request_context` and must accept the
-    same kwarg.
-    """
-
-    def test_kwarg_development_returns_1000(self, monkeypatch: pytest.MonkeyPatch):
-        from arcjet._client import _default_timeout_ms
-
-        monkeypatch.delenv("ARCJET_ENV", raising=False)
-        assert _default_timeout_ms((), environment="development") == 1000
-
-    def test_kwarg_production_returns_500(self, monkeypatch: pytest.MonkeyPatch):
-        from arcjet._client import _default_timeout_ms
-
-        monkeypatch.delenv("ARCJET_ENV", raising=False)
-        assert _default_timeout_ms((), environment="production") == 500
-
-    def test_prompt_injection_min_clamp_still_applies_in_production(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        from arcjet._client import _default_timeout_ms
-        from arcjet._rules import detect_prompt_injection
-
-        monkeypatch.delenv("ARCJET_ENV", raising=False)
-        # detect_prompt_injection enforces a 2000ms minimum even in production.
-        assert (
-            _default_timeout_ms([detect_prompt_injection()], environment="production")
-            == 2000
-        )
-
-    def test_prompt_injection_in_development_clamps_to_2000(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        from arcjet._client import _default_timeout_ms
-        from arcjet._rules import detect_prompt_injection
-
-        monkeypatch.delenv("ARCJET_ENV", raising=False)
-        # Dev default (1000) is below the prompt-injection min (2000);
-        # the max() should raise the timeout rather than keep 1000.
-        assert (
-            _default_timeout_ms([detect_prompt_injection()], environment="development")
-            == 2000
-        )
-
-    def test_env_var_fallback_when_kwarg_none(self, monkeypatch: pytest.MonkeyPatch):
-        from arcjet._client import _default_timeout_ms
-
-        monkeypatch.setenv("ARCJET_ENV", "development")
-        assert _default_timeout_ms((), environment=None) == 1000
-
-
 class TestArcjetFactoryEnvironmentKwarg:
     """End-to-end wiring: `environment=` flows from the factory into the
-    dataclass and through `_default_timeout_ms`.
+    dataclass. Timeout is a flat 2000ms and does not depend on environment.
     """
 
     def test_kwarg_reaches_dataclass(self, monkeypatch: pytest.MonkeyPatch):
@@ -762,10 +689,9 @@ class TestArcjetFactoryEnvironmentKwarg:
             environment="development",
         )
         assert aj._environment == "development"
-        # 1000 ms dev timeout proves _default_timeout_ms saw the kwarg.
-        assert aj._timeout_ms == 1000
+        assert aj._timeout_ms == 2000
 
-    def test_kwarg_production_sets_short_timeout(self, monkeypatch: pytest.MonkeyPatch):
+    def test_kwarg_production_beats_env_var(self, monkeypatch: pytest.MonkeyPatch):
         from arcjet import arcjet
         from arcjet._enums import Mode
         from arcjet._rules import shield
@@ -777,8 +703,7 @@ class TestArcjetFactoryEnvironmentKwarg:
             environment="production",
         )
         assert aj._environment == "production"
-        # Explicit kwarg beats env var: 500 ms prod timeout.
-        assert aj._timeout_ms == 500
+        assert aj._timeout_ms == 2000
 
     def test_no_kwarg_falls_back_to_env_var(self, monkeypatch: pytest.MonkeyPatch):
         """Pre-existing behavior: no kwarg + ARCJET_ENV=development -> dev mode.
@@ -792,7 +717,7 @@ class TestArcjetFactoryEnvironmentKwarg:
         monkeypatch.setenv("ARCJET_ENV", "development")
         aj = arcjet(key="ajkey_x", rules=[shield(mode=Mode.LIVE)])
         assert aj._environment is None
-        assert aj._timeout_ms == 1000
+        assert aj._timeout_ms == 2000
 
     def test_explicit_timeout_overrides_kwarg_inference(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_client_sync.py
+++ b/tests/unit/test_client_sync.py
@@ -302,10 +302,11 @@ def test_default_timeout_production_without_prompt_injection(mock_protobuf_modul
 
 
 def test_default_timeout_production_with_prompt_injection(mock_protobuf_modules):
-    """Test that the default timeout in production is at least 1000ms when detect_prompt_injection is configured.
+    """Test that the default timeout in production is at least 2000ms when detect_prompt_injection is configured.
 
     detect_prompt_injection defines its latency guarantees individually rather
-    than as part of the protect call, so a minimum of 1 second is enforced.
+    than as part of the protect call, and a cold model start can exceed the
+    500ms production default, so a minimum of 2 seconds is enforced.
     """
     from arcjet import arcjet_sync
     from arcjet._rules import detect_prompt_injection
@@ -314,7 +315,7 @@ def test_default_timeout_production_with_prompt_injection(mock_protobuf_modules)
         key="ajkey_x",
         rules=[detect_prompt_injection()],
     )
-    assert aj._timeout_ms == 1000
+    assert aj._timeout_ms == 2000
 
 
 def test_default_timeout_development_without_prompt_injection(
@@ -334,7 +335,7 @@ def test_default_timeout_development_without_prompt_injection(
 def test_default_timeout_development_with_prompt_injection(
     mock_protobuf_modules, dev_environment
 ):
-    """Test that the default timeout in development is 1000ms when detect_prompt_injection is configured."""
+    """Test that the default timeout in development is at least 2000ms when detect_prompt_injection is configured."""
     from arcjet import arcjet_sync
     from arcjet._rules import detect_prompt_injection
 
@@ -342,7 +343,7 @@ def test_default_timeout_development_with_prompt_injection(
         key="ajkey_x",
         rules=[detect_prompt_injection()],
     )
-    assert aj._timeout_ms == 1000
+    assert aj._timeout_ms == 2000
 
 
 def test_explicit_timeout_overrides_prompt_injection_floor(mock_protobuf_modules):

--- a/tests/unit/test_client_sync.py
+++ b/tests/unit/test_client_sync.py
@@ -289,8 +289,8 @@ def test_default_base_url_from_env_trailing_slash_is_stripped(
     importlib.reload(client_module)
 
 
-def test_default_timeout_production_without_prompt_injection(mock_protobuf_modules):
-    """Test that the default timeout in production is 500ms without prompt injection."""
+def test_default_timeout_is_2000_ms(mock_protobuf_modules):
+    """Test that the default timeout is 2000ms for every rule set."""
     from arcjet import arcjet_sync
     from arcjet._rules import token_bucket
 
@@ -298,16 +298,11 @@ def test_default_timeout_production_without_prompt_injection(mock_protobuf_modul
         key="ajkey_x",
         rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
     )
-    assert aj._timeout_ms == 500
+    assert aj._timeout_ms == 2000
 
 
-def test_default_timeout_production_with_prompt_injection(mock_protobuf_modules):
-    """Test that the default timeout in production is at least 2000ms when detect_prompt_injection is configured.
-
-    detect_prompt_injection defines its latency guarantees individually rather
-    than as part of the protect call, and a cold model start can exceed the
-    500ms production default, so a minimum of 2 seconds is enforced.
-    """
+def test_default_timeout_is_2000_ms_with_prompt_injection(mock_protobuf_modules):
+    """Test that detect_prompt_injection uses the same 2000ms default."""
     from arcjet import arcjet_sync
     from arcjet._rules import detect_prompt_injection
 
@@ -318,10 +313,10 @@ def test_default_timeout_production_with_prompt_injection(mock_protobuf_modules)
     assert aj._timeout_ms == 2000
 
 
-def test_default_timeout_development_without_prompt_injection(
+def test_default_timeout_is_2000_ms_in_development(
     mock_protobuf_modules, dev_environment
 ):
-    """Test that the default timeout in development is 1000ms without prompt injection."""
+    """Test that the default timeout is 2000ms in development as well."""
     from arcjet import arcjet_sync
     from arcjet._rules import token_bucket
 
@@ -329,25 +324,11 @@ def test_default_timeout_development_without_prompt_injection(
         key="ajkey_x",
         rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
     )
-    assert aj._timeout_ms == 1000
-
-
-def test_default_timeout_development_with_prompt_injection(
-    mock_protobuf_modules, dev_environment
-):
-    """Test that the default timeout in development is at least 2000ms when detect_prompt_injection is configured."""
-    from arcjet import arcjet_sync
-    from arcjet._rules import detect_prompt_injection
-
-    aj = arcjet_sync(
-        key="ajkey_x",
-        rules=[detect_prompt_injection()],
-    )
     assert aj._timeout_ms == 2000
 
 
-def test_explicit_timeout_overrides_prompt_injection_floor(mock_protobuf_modules):
-    """Test that an explicit timeout_ms is not affected by the prompt injection floor."""
+def test_explicit_timeout_overrides_default(mock_protobuf_modules):
+    """Test that an explicit timeout_ms replaces the 2000ms default."""
     from arcjet import arcjet_sync
     from arcjet._rules import detect_prompt_injection
 
@@ -632,8 +613,7 @@ def test_cache_hit_report_redacts_prompt_injection_message(
 
 class TestArcjetSyncFactoryEnvironmentKwarg:
     """Sync counterpart to `TestArcjetFactoryEnvironmentKwarg` — `environment=`
-    flows from `arcjet_sync()` into the dataclass and through
-    `_default_timeout_ms`.
+    flows from `arcjet_sync()` into the dataclass. Timeout is a flat 2000ms.
     """
 
     def test_kwarg_reaches_dataclass(self, monkeypatch: pytest.MonkeyPatch):
@@ -648,7 +628,7 @@ class TestArcjetSyncFactoryEnvironmentKwarg:
             environment="development",
         )
         assert aj._environment == "development"
-        assert aj._timeout_ms == 1000
+        assert aj._timeout_ms == 2000
 
     def test_kwarg_production_beats_env_var(self, monkeypatch: pytest.MonkeyPatch):
         from arcjet import arcjet_sync
@@ -662,7 +642,7 @@ class TestArcjetSyncFactoryEnvironmentKwarg:
             environment="production",
         )
         assert aj._environment == "production"
-        assert aj._timeout_ms == 500
+        assert aj._timeout_ms == 2000
 
     def test_protect_uses_environment_for_loopback_fallback(
         self,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cold starts can exceed the old 500ms production Decide timeout, so `protect()` fail-opened and skipped evaluation.

`arcjet()` and `arcjet_sync()` now default to **2000ms for every rule**, matching Guard. The previous 500/1000ms environment split and the prompt-injection-only floor are gone. An explicit `timeout_ms` still wins.

Guard (`launch_arcjet` / `launch_arcjet_sync`) was already 2s and is unchanged.

## Test plan

- [x] Default timeout is 2000ms with and without prompt injection
- [x] Development and production both use 2000ms
- [x] Explicit `timeout_ms` still overrides the default
- [x] Sync and async factories behave the same

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c2445e8-3eae-4799-841d-4646141fa79a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c2445e8-3eae-4799-841d-4646141fa79a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

