### PR TITLE
fix: make wasmtime teardown deterministic so pytest 9.1 is safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,7 +245,9 @@ Local WASM evaluation is wired into the main SDK at `src/arcjet/_local.py`:
 `AnalyzeComponentBase` uses a per-instance `threading.Lock` around `_call()`.
 The lock provides defensive safety at negligible cost (WASM calls are 1–5ms).
 `AnalyzeComponent` (in `_overrides.py`) extends this with per-call callback
-swapping under the same lock.
+swapping under the same lock, and wraps construction, calls, and `close()` in
+`wasmtime_section()` so wasmtime-py's process-global function slab cannot be
+re-entered by a `__del__` finalizer (arcjet-py#154).
 
 For detailed wasmtime-py reference (linker setup, type mapping, known bugs),
 see [docs/WASMTIME.md](docs/WASMTIME.md).

--- a/docs/WASMTIME.md
+++ b/docs/WASMTIME.md
@@ -140,6 +140,17 @@ constructor that accepts initial field values. The only way to build a Record
 with data is `Record()` followed by `__dict__` mutation. The `_rec()` helper in
 `_convert.py` encapsulates this.
 
+**4. Process-global `Slab` is not reentrant.** Host functions live in a
+process-global `FUNCTIONS` slab. If a `__del__` finalizer deallocates a handle
+while `Slab.allocate` is running, `self.next` can become a function and the
+next allocation raises `TypeError: list indices must be integers or slices,
+not function`. pytest 9.1 reduced inter-test `gc.collect()` passes from 5 to 1
+on CPython, which left more of those cyclic finalizers pending and surfaced
+the race in CI (arcjet-py#154). `AnalyzeComponent` wraps construction, calls,
+and `close()` in `wasmtime_section()` (a process-global lock + GC suspend),
+and `close()` drops Engine/Linker/Component so finalizers run at a known
+point. Analyze tests also drain five GC passes after each test.
+
 ## Import callback gotchas
 
 **`sensitive_info_detect` must return `[None] * len(tokens)`, not `[]`.** The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,9 +97,9 @@ dev = [
   "langchain-core>=1.2.5,<2",              # For testing integration with LangChain
   "pyright==1.1.411",
   "hypothesis>=6.100.0",
-  # Held <9.1 while bytecodealliance/wasmtime-py#254 remains unresolved; see
-  # tests/analyze/test_detect_bot.py::TestDetectBotThreadSafety and arcjet-py#185.
-  "pytest==9.0.3",
+  # 9.1 cut inter-test gc.collect() passes (pytest#14441); AnalyzeComponent
+  # now serializes wasmtime slab ops so this is safe (arcjet-py#154).
+  "pytest==9.1.1",
   "pytest-cov>=7.0.0",
   "ruff==0.16.2",
   "tomli>=2.0.0; python_version < '3.11'",

--- a/src/arcjet/_analyze/_overrides.py
+++ b/src/arcjet/_analyze/_overrides.py
@@ -79,6 +79,10 @@ class AnalyzeComponent(AnalyzeComponentBase):
         if self._closed:
             raise RuntimeError("AnalyzeComponent is closed")
         with wasmtime_section():
+            # Re-check after acquiring the section: a concurrent close() may
+            # have won the lock, set ``_closed``, and dropped ``_engine``.
+            if self._closed:
+                raise RuntimeError("AnalyzeComponent is closed")
             return super()._call(export_name, *args)
 
     def close(self) -> None:
@@ -91,7 +95,7 @@ class AnalyzeComponent(AnalyzeComponentBase):
         with wasmtime_section():
             if getattr(self, "_closed", False):
                 return
-            self._closed = True
+            super().close()
             for attr in _WASMTIME_ATTRS:
                 if hasattr(self, attr):
                     delattr(self, attr)

--- a/src/arcjet/_analyze/_overrides.py
+++ b/src/arcjet/_analyze/_overrides.py
@@ -6,7 +6,7 @@ for ``detect_sensitive_info`` via inheritance and linker shadowing.
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 from wasmtime import Store
 from wasmtime.component._types import Variant
@@ -19,7 +19,10 @@ from ._convert import (
 )
 from ._import_defaults import _default_sensitive_info_detect
 from ._imports import ImportCallbacks
+from ._safety import wasmtime_section
 from ._types import SensitiveInfoConfig, SensitiveInfoEntity, SensitiveInfoResult
+
+_WASMTIME_ATTRS = ("_linker", "_component", "_engine")
 
 
 class AnalyzeComponent(AnalyzeComponentBase):
@@ -30,42 +33,68 @@ class AnalyzeComponent(AnalyzeComponentBase):
         wasm_path: str,
         callbacks: ImportCallbacks | None = None,
     ) -> None:
-        super().__init__(wasm_path, callbacks)
+        # Construction wires host functions into wasmtime-py's process-global
+        # slab. Suspend GC and serialize so a deferred ``__del__`` cannot
+        # re-enter ``Slab.allocate`` (arcjet-py#154).
+        with wasmtime_section():
+            super().__init__(wasm_path, callbacks)
 
-        # Mutable container for per-call callback swapping
-        cb = callbacks or ImportCallbacks()
-        self._si_detect_ref: list[
-            Callable[[list[str]], list[SensitiveInfoEntity | None]] | None
-        ] = [cb.sensitive_info_detect or _default_sensitive_info_detect]
+            # Mutable container for per-call callback swapping
+            cb = callbacks or ImportCallbacks()
+            self._si_detect_ref: list[
+                Callable[[list[str]], list[SensitiveInfoEntity | None]] | None
+            ] = [cb.sensitive_info_detect or _default_sensitive_info_detect]
 
-        # Re-wire si-detect to read from mutable ref (linker.allow_shadowing = True).
-        # Only mutate index 0; never reassign the list itself — the closure
-        # below captures this reference and would not see a new list object.
-        si_detect_ref = self._si_detect_ref
+            # Re-wire si-detect to read from mutable ref (linker.allow_shadowing = True).
+            # Only mutate index 0; never reassign the list itself — the closure
+            # below captures this reference and would not see a new list object.
+            si_detect_ref = self._si_detect_ref
 
-        with self._linker.root() as root:
-            with root.add_instance(
-                "arcjet:js-req/sensitive-information-identifier"
-            ) as iface:
+            with self._linker.root() as root:
+                with root.add_instance(
+                    "arcjet:js-req/sensitive-information-identifier"
+                ) as iface:
 
-                def _si_detect(
-                    _store: Store, tokens: list[str]
-                ) -> list[Variant | None]:
-                    fn = si_detect_ref[0]
-                    if fn is None:
-                        return [None] * len(tokens)
-                    results = fn(tokens)
-                    if len(results) != len(tokens):
-                        raise ValueError(
-                            f"sensitive_info_detect callback returned "
-                            f"{len(results)} results for {len(tokens)} tokens"
-                        )
-                    return [
-                        None if r is None else to_wasm_sensitive_info_entity(r)
-                        for r in results
-                    ]
+                    def _si_detect(
+                        _store: Store, tokens: list[str]
+                    ) -> list[Variant | None]:
+                        fn = si_detect_ref[0]
+                        if fn is None:
+                            return [None] * len(tokens)
+                        results = fn(tokens)
+                        if len(results) != len(tokens):
+                            raise ValueError(
+                                f"sensitive_info_detect callback returned "
+                                f"{len(results)} results for {len(tokens)} tokens"
+                            )
+                        return [
+                            None if r is None else to_wasm_sensitive_info_entity(r)
+                            for r in results
+                        ]
 
-                iface.add_func("detect", _si_detect)
+                    iface.add_func("detect", _si_detect)
+
+    def _call(self, export_name: str, *args: Any) -> Any:
+        """Call a named export with a fresh Store, under the wasmtime section."""
+        if self._closed:
+            raise RuntimeError("AnalyzeComponent is closed")
+        with wasmtime_section():
+            return super()._call(export_name, *args)
+
+    def close(self) -> None:
+        """Release WASM engine resources and drop wasmtime object references.
+
+        Dropping the linker/component/engine here lets their ``__del__``
+        finalizers run at a known point instead of later, mid-allocation
+        in another component (arcjet-py#154).
+        """
+        with wasmtime_section():
+            if getattr(self, "_closed", False):
+                return
+            self._closed = True
+            for attr in _WASMTIME_ATTRS:
+                if hasattr(self, attr):
+                    delattr(self, attr)
 
     def detect_sensitive_info(
         self,
@@ -83,20 +112,26 @@ class AnalyzeComponent(AnalyzeComponentBase):
         if self._closed:
             raise RuntimeError("AnalyzeComponent is closed")
         if detect is not None:
-            with self._call_lock:
-                prev = self._si_detect_ref[0]
-                self._si_detect_ref[0] = detect
-                try:
-                    store = Store(self._engine)
-                    instance = self._linker.instantiate(store, self._component)
-                    func = instance.get_func(store, "detect-sensitive-info")
-                    if func is None:
-                        raise RuntimeError(
-                            "detect-sensitive-info export not found in component"
-                        )
-                    raw = func(store, content, wasm_opts)
-                finally:
-                    self._si_detect_ref[0] = prev
+            # Global section first, then the instance lock — same order as
+            # ``_call`` → ``super()._call`` — so concurrent override and
+            # non-override paths cannot deadlock.
+            with wasmtime_section():
+                if self._closed:
+                    raise RuntimeError("AnalyzeComponent is closed")
+                with self._call_lock:
+                    prev = self._si_detect_ref[0]
+                    self._si_detect_ref[0] = detect
+                    try:
+                        store = Store(self._engine)
+                        instance = self._linker.instantiate(store, self._component)
+                        func = instance.get_func(store, "detect-sensitive-info")
+                        if func is None:
+                            raise RuntimeError(
+                                "detect-sensitive-info export not found in component"
+                            )
+                        raw = func(store, content, wasm_opts)
+                    finally:
+                        self._si_detect_ref[0] = prev
         else:
             raw = self._call("detect-sensitive-info", content, wasm_opts)
         return from_wasm_detect_sensitive_info(raw)

--- a/src/arcjet/_analyze/_safety.py
+++ b/src/arcjet/_analyze/_safety.py
@@ -25,7 +25,6 @@ from contextlib import contextmanager
 
 _lock = threading.RLock()
 _depth = 0
-_restore_gc = False
 
 
 @contextmanager
@@ -43,21 +42,21 @@ def wasmtime_section() -> Iterator[None]:
     an interrupt between ``gc.disable()`` and the depth increment cannot
     leave collection permanently off.
     """
-    global _depth, _restore_gc
+    global _depth
     with _lock:
-        if _depth == 0:
-            _restore_gc = gc.isenabled()
-            gc.disable()
+        restore_gc = False
         try:
+            if _depth == 0:
+                restore_gc = gc.isenabled()
+                gc.disable()
             _depth += 1
             try:
                 yield
             finally:
                 _depth -= 1
         finally:
-            if _depth == 0 and _restore_gc:
+            if _depth == 0 and restore_gc:
                 gc.enable()
-                _restore_gc = False
 
 
 def collect_wasmtime_finalizers() -> None:

--- a/src/arcjet/_analyze/_safety.py
+++ b/src/arcjet/_analyze/_safety.py
@@ -33,21 +33,31 @@ def wasmtime_section() -> Iterator[None]:
     """Hold the process-global wasmtime lock and suspend GC.
 
     Re-entrant on the same thread so ``__init__``, ``_call``, and ``close``
-    can nest. Distinct threads serialize, which also covers wasmtime-py's
-    unsynchronized slabs.
+    can nest. Distinct threads — and distinct ``AnalyzeComponent`` instances
+    — fully serialize for the duration of the section, including the WASM
+    call itself. That is required: wasmtime-py's function slab is
+    process-global and unsynchronized, so a per-instance lock is not enough
+    and must not be restored in place of this section.
+
+    GC is disabled only at depth 0 and re-enabled in an outer ``finally`` so
+    an interrupt between ``gc.disable()`` and the depth increment cannot
+    leave collection permanently off.
     """
     global _depth, _restore_gc
     with _lock:
         if _depth == 0:
             _restore_gc = gc.isenabled()
             gc.disable()
-        _depth += 1
         try:
-            yield
+            _depth += 1
+            try:
+                yield
+            finally:
+                _depth -= 1
         finally:
-            _depth -= 1
             if _depth == 0 and _restore_gc:
                 gc.enable()
+                _restore_gc = False
 
 
 def collect_wasmtime_finalizers() -> None:

--- a/src/arcjet/_analyze/_safety.py
+++ b/src/arcjet/_analyze/_safety.py
@@ -1,0 +1,60 @@
+"""Workarounds for wasmtime-py process-global slabs and cyclic finalizers.
+
+wasmtime-py keeps host functions in a process-global ``Slab`` (see
+bytecodealliance/wasmtime-py#254). ``Slab.allocate`` is not reentrant: if a
+``__del__`` finalizer deallocates a handle while another allocation is in
+progress, ``self.next`` can become a function and the next ``allocate``
+raises ``TypeError: list indices must be integers or slices, not function``.
+
+pytest 9.1 reduced inter-test ``gc.collect()`` passes from 5 to 1 on CPython
+(pytest#14441), which left more of those cyclic finalizers pending and
+surfaced the race in CI (arcjet-py#154).
+
+``wasmtime_section`` serializes slab-touching operations and suspends GC so a
+finalizer cannot run mid-allocate. ``collect_wasmtime_finalizers`` drains the
+cycles at a known point (test teardown) rather than during the next
+component's construction.
+"""
+
+from __future__ import annotations
+
+import gc
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+_lock = threading.RLock()
+_depth = 0
+_restore_gc = False
+
+
+@contextmanager
+def wasmtime_section() -> Iterator[None]:
+    """Hold the process-global wasmtime lock and suspend GC.
+
+    Re-entrant on the same thread so ``__init__``, ``_call``, and ``close``
+    can nest. Distinct threads serialize, which also covers wasmtime-py's
+    unsynchronized slabs.
+    """
+    global _depth, _restore_gc
+    with _lock:
+        if _depth == 0:
+            _restore_gc = gc.isenabled()
+            gc.disable()
+        _depth += 1
+        try:
+            yield
+        finally:
+            _depth -= 1
+            if _depth == 0 and _restore_gc:
+                gc.enable()
+
+
+def collect_wasmtime_finalizers() -> None:
+    """Run enough cyclic GC passes to drain wasmtime ``__del__`` finalizers.
+
+    CPython needs multiple passes when finalizers themselves produce
+    garbage — the situation pytest 9.1 no longer handles between tests.
+    """
+    for _ in range(5):
+        gc.collect()

--- a/tests/analyze/conftest.py
+++ b/tests/analyze/conftest.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import importlib.resources as _res
 import json
 import os
+from collections.abc import Iterator
 
 import pytest
 
 from arcjet._analyze import AnalyzeComponent
+from arcjet._analyze._safety import collect_wasmtime_finalizers
 
 WASM_PATH = str(
     _res.files("arcjet._analyze") / "wasm" / "arcjet_analyze_js_req.component.wasm"
@@ -33,7 +35,23 @@ def wasm_path() -> str:
     return WASM_PATH
 
 
+@pytest.fixture(autouse=True)
+def _drain_wasmtime_finalizers() -> Iterator[None]:
+    """Drain wasmtime cyclic finalizers between tests.
+
+    pytest 9.1 runs one ``gc.collect()`` pass on CPython between tests
+    (pytest#14441). wasmtime-py handle slabs need several cyclic passes
+    or a deferred ``__del__`` can corrupt ``Slab.allocate`` in the next
+    test (arcjet-py#154).
+    """
+    yield
+    collect_wasmtime_finalizers()
+
+
 @pytest.fixture(scope="session")
-def component(wasm_path: str) -> AnalyzeComponent:
+def component(wasm_path: str) -> Iterator[AnalyzeComponent]:
     """Default AnalyzeComponent with no custom callbacks."""
-    return AnalyzeComponent(wasm_path)
+    ac = AnalyzeComponent(wasm_path)
+    yield ac
+    ac.close()
+    collect_wasmtime_finalizers()

--- a/tests/analyze/test_imports.py
+++ b/tests/analyze/test_imports.py
@@ -586,3 +586,25 @@ class TestCloseAndContextManager:
         ac = AnalyzeComponent(wasm_path)
         ac.close()
         ac.close()  # Should not raise
+
+    def test_close_releases_wasmtime_objects(self, wasm_path: str) -> None:
+        """close() drops Engine/Linker/Component so finalizers can run now."""
+        ac = AnalyzeComponent(wasm_path)
+        ac.close()
+        assert not hasattr(ac, "_engine")
+        assert not hasattr(ac, "_linker")
+        assert not hasattr(ac, "_component")
+
+    def test_construct_after_closed_instances(self, wasm_path: str) -> None:
+        """Creating a component after others were closed must not corrupt slabs.
+
+        This is the pytest>=9.1 failure mode in arcjet-py#154: a deferred
+        wasmtime ``__del__`` re-entering ``Slab.allocate``.
+        """
+        for _ in range(3):
+            ac = AnalyzeComponent(wasm_path)
+            ac.match_filters("{}", "{}", [], True)
+            ac.close()
+        later = AnalyzeComponent(wasm_path)
+        later.match_filters("{}", "{}", [], True)
+        later.close()

--- a/tests/unit/test_analyze_safety.py
+++ b/tests/unit/test_analyze_safety.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import gc
 
-import pytest
-
 from arcjet._analyze._safety import collect_wasmtime_finalizers, wasmtime_section
 
 
@@ -39,9 +37,14 @@ def test_wasmtime_section_preserves_already_disabled_gc() -> None:
 
 def test_wasmtime_section_restores_gc_when_body_raises() -> None:
     assert gc.isenabled()
-    with pytest.raises(RuntimeError, match="boom"):
+    raised = False
+    try:
         with wasmtime_section():
             raise RuntimeError("boom")
+    except RuntimeError as exc:
+        raised = True
+        assert str(exc) == "boom"
+    assert raised
     assert gc.isenabled()
 
 

--- a/tests/unit/test_analyze_safety.py
+++ b/tests/unit/test_analyze_safety.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import gc
 
+import pytest
+
 from arcjet._analyze._safety import collect_wasmtime_finalizers, wasmtime_section
 
 
@@ -32,6 +34,14 @@ def test_wasmtime_section_preserves_already_disabled_gc() -> None:
         assert not gc.isenabled()
     finally:
         gc.enable()
+    assert gc.isenabled()
+
+
+def test_wasmtime_section_restores_gc_when_body_raises() -> None:
+    assert gc.isenabled()
+    with pytest.raises(RuntimeError, match="boom"):
+        with wasmtime_section():
+            raise RuntimeError("boom")
     assert gc.isenabled()
 
 

--- a/tests/unit/test_analyze_safety.py
+++ b/tests/unit/test_analyze_safety.py
@@ -1,0 +1,40 @@
+"""Tests for wasmtime slab-safety helpers (no WASM required)."""
+
+from __future__ import annotations
+
+import gc
+
+from arcjet._analyze._safety import collect_wasmtime_finalizers, wasmtime_section
+
+
+def test_wasmtime_section_disables_gc_and_restores() -> None:
+    assert gc.isenabled()
+    with wasmtime_section():
+        assert not gc.isenabled()
+    assert gc.isenabled()
+
+
+def test_wasmtime_section_is_reentrant() -> None:
+    assert gc.isenabled()
+    with wasmtime_section():
+        assert not gc.isenabled()
+        with wasmtime_section():
+            assert not gc.isenabled()
+        assert not gc.isenabled()
+    assert gc.isenabled()
+
+
+def test_wasmtime_section_preserves_already_disabled_gc() -> None:
+    gc.disable()
+    try:
+        with wasmtime_section():
+            assert not gc.isenabled()
+        assert not gc.isenabled()
+    finally:
+        gc.enable()
+    assert gc.isenabled()
+
+
+def test_collect_wasmtime_finalizers_runs() -> None:
+    # Just prove the helper is callable and does not raise.
+    collect_wasmtime_finalizers()

--- a/uv.lock
+++ b/uv.lock
@@ -116,7 +116,7 @@ dev = [
     { name = "langchain", specifier = ">=1,<2" },
     { name = "langchain-core", specifier = ">=1.2.5,<2" },
     { name = "pyright", specifier = "==1.1.411" },
-    { name = "pytest", specifier = "==9.0.3" },
+    { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = "==0.16.2" },
@@ -1603,7 +1603,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1614,9 +1614,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #154.

## Problem

pytest 9.1 cut the `unraisableexception` plugin's `gc.collect()` passes from 5 → 1 on CPython ([pytest#14441](https://github.com/pytest-dev/pytest/issues/14441)). wasmtime-py finalizes `Store`/host-function handles via `__del__` sitting in reference cycles, and those need multiple cyclic GC passes to drain in order.

With only one pass, a deferred finalizer can fire during a later test's `Linker.add_func` → `FUNCTIONS.allocate`. wasmtime-py's process-global slab is not reentrant ([wasmtime-py#254](https://github.com/bytecodealliance/wasmtime-py/issues/254)), so `self.next` becomes a function and the next allocation raises:

```
TypeError: list indices must be integers or slices, not function
```

This showed up in CI on `TestCloseAndContextManager.test_close_prevents_further_calls` and forced the pytest 9.0.3 hold (#185, #190).

`close()` previously only set a flag — it did not drop `Engine`/`Linker`/`Component`, so calling it did nothing to make finalization deterministic.

## Fix

- Wrap `AnalyzeComponent` construction, calls, and `close()` in `wasmtime_section()`: a process-global re-entrant lock that also suspends GC, so a `__del__` cannot re-enter `Slab.allocate`.
- Make `close()` drop the wasmtime objects so their finalizers run at a known point instead of mid-allocation in the next component.
- Drain five GC passes after each analyze test (restores the pre-9.1 inter-test behavior for this suite).
- Unpin pytest to 9.1.1.

No public API change. Production still uses a long-lived singleton; this hardens the create/destroy path the test suite exercises.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-949b67a8-70ed-4bda-8e38-e4ae0f54d0de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-949b67a8-70ed-4bda-8e38-e4ae0f54d0de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

