### PR TITLE
docs: document Alpine/musl as unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ Or with pip:
 pip install arcjet
 ```
 
+Prefer a glibc Linux image (Debian/Ubuntu slim) in containers. Alpine/musl is
+not a supported install target — see [Compatibility](#compatibility).
+
 ## Prompt injection detection
 
 Detect and block prompt injection attacks — attempts by users to hijack your
@@ -2032,8 +2035,22 @@ Policy](https://docs.arcjet.com/security).
 
 ## Compatibility
 
-Packages maintained in this repository are compatible with Python 3.10 and
-above.
+Packages maintained in this repository support CPython 3.10+ on macOS, Windows,
+and glibc Linux (Debian, Ubuntu, RHEL, and `*-slim` / manylinux container
+images).
+
+Two runtime dependencies ship native code:
+
+- [`wasmtime`](https://pypi.org/project/wasmtime/) — local WASM rule evaluation
+- [`pyqwest`](https://pypi.org/project/pyqwest/) — HTTP client used by
+  `connect-python`
+
+Those packages publish `musllinux` wheels today, so `pip install arcjet` often
+succeeds on Alpine without a compiler. Alpine/musl is still **not a supported
+target**. A future wheel gap forces a source build (Rust plus a C toolchain),
+which is what broke `python3.10-alpine` images after local analysis landed.
+Prefer a glibc image such as `python:3.10-slim` or
+`astral/uv:python3.10-trixie-slim`.
 
 ## License
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #159.

## Investigation

[#159](https://github.com/arcjet/arcjet-py/issues/159) was opened when the Python examples moved to 0.9.0 and `astral/uv:python3.10-alpine` stopped working. The images were switched to `python3.10-trixie-slim` in [arcjet/examples#187](https://github.com/arcjet/examples/pull/187).

The break was not an Alpine-only packaging change. `arcjet` 0.2.1 (the version those examples originally used) was pure Python (`connect-python`, `httpx`, `typeid-python`). Local analysis later added two native dependencies:

- `wasmtime` — local WASM rule evaluation
- `pyqwest` — HTTP client used by `connect-python`

Those are the packages that fail on musl when they do not publish a matching wheel (the installer then tries a source build, which needs Rust and a C toolchain that Alpine images do not ship).

## Can we fix Alpine?

Not as a first-class target, and we should not promise it.

Current `wasmtime` 47.0.1 and `pyqwest` 0.9.0 **do** publish `musllinux_1_2` wheels. I reproduced this in an Alpine 3.22 chroot:

- `arcjet==0.9.0` and current `0.10.0b1` install on Alpine CPython 3.12 and musl CPython 3.10
- `wasmtime.Engine` / `Store` construct
- `evaluate_bot_locally()` returns a real DENY for `curl` via the analyze component
- `examples/fastapi` `uv sync` succeeds

So there is no SDK code change that “fixes” Alpine. Support would mean committing to musl wheels on every native dep bump, plus CI. A missing wheel in a future `wasmtime`/`pyqwest` release would break Alpine again.

That matches the existing preference to stay off Alpine.

## Change

Document the platforms we actually support and name the native dependencies. Recommend glibc slim images (`python:3.10-slim`, `astral/uv:python3.10-trixie-slim`). Note that musl wheels often work today, but Alpine is not supported.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a316ce7e-b820-4b5d-8718-6f3616b48843?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a316ce7e-b820-4b5d-8718-6f3616b48843&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

