### PR TITLE
ci: add Windows and macOS test runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,9 @@ jobs:
   # above therefore needs no change to the ruleset, which cannot be edited from
   # a pull request and so would otherwise drift behind the matrix.
   #
-  # The name is the context `main` already requires. It predates the matrix,
-  # when the only axis was `os`.
+  # The name is the context `main` already requires. It predates the Python
+  # matrix, when the only axis was `os`. Windows and macOS report through
+  # their own aggregators below so this check stays Linux-only.
   test-matrix:
     name: Run tests (ubuntu-latest)
     # Runs whether the matrix passed or failed, so the context always reports.
@@ -110,4 +111,92 @@ jobs:
         if: needs.test.result != 'success'
         run: |
           echo "::error::Test matrix result: ${{ needs.test.result }}"
+          exit 1
+
+  # Floor + current latest on each non-Linux OS. Ubuntu already covers every
+  # released interpreter; repeating that on windows-latest (2× minutes) and
+  # macos-latest (10×) would dominate the bill without catching much more than
+  # "does the locked wheel set install, and does WASM/TLS still work".
+  #
+  # Separate jobs — not extra cells on `test` — so a Windows or macOS failure
+  # cannot fail the required `Run tests (ubuntu-latest)` context. Each OS has
+  # its own aggregator with a stable name for a later ruleset addition.
+  test-windows:
+    name: Run tests (windows-latest, py${{ matrix.python-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.14"]
+    runs-on: windows-latest
+    # First-run uv/Python/wheel fetch on Windows is slower than Ubuntu; a hung
+    # wasmtime or onnxruntime import must not sit on the 6h GitHub default.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # The local-HTTPS transport tests shell out to `openssl`. The image ships
+      # it, but it is not always on PATH for PowerShell.
+      - name: Put OpenSSL on PATH
+        shell: pwsh
+        run: |
+          if (Get-Command openssl -ErrorAction SilentlyContinue) { exit 0 }
+          foreach ($dir in @(
+            "${env:ProgramFiles}\OpenSSL\bin",
+            "${env:ProgramFiles}\OpenSSL-Win64\bin",
+            "${env:ProgramFiles}\Git\usr\bin",
+            "${env:ProgramFiles}\Git\mingw64\bin"
+          )) {
+            if (Test-Path (Join-Path $dir "openssl.exe")) {
+              Add-Content -Path $env:GITHUB_PATH -Value $dir
+              exit 0
+            }
+          }
+          Write-Error "openssl.exe not found (required by tests/unit/test_transport.py)"
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Tests
+        run: uv run --python ${{ matrix.python-version }} pytest
+
+  test-windows-matrix:
+    name: Run tests (windows-latest)
+    if: ${{ !cancelled() }}
+    needs: test-windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the matrix result
+        if: needs.test-windows.result != 'success'
+        run: |
+          echo "::error::Windows test matrix result: ${{ needs.test-windows.result }}"
+          exit 1
+
+  test-macos:
+    name: Run tests (macos-latest, py${{ matrix.python-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.14"]
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Tests
+        run: uv run --python ${{ matrix.python-version }} pytest
+
+  test-macos-matrix:
+    name: Run tests (macos-latest)
+    if: ${{ !cancelled() }}
+    needs: test-macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the matrix result
+        if: needs.test-macos.result != 'success'
+        run: |
+          echo "::error::macOS test matrix result: ${{ needs.test-macos.result }}"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,9 @@ jobs:
         python-version: ["3.10", "3.14"]
     runs-on: macos-latest
     timeout-minutes: 30
+    # macos-latest ships openssl on PATH (`/usr/bin/openssl`), so unlike
+    # Windows there is no extra PATH step. The TLS transport tests skip at
+    # collection if `shutil.which("openssl")` misses.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -196,7 +196,7 @@ def _openssl_bin() -> str | None:
     """Return an ``openssl`` executable, or ``None`` if none is installed.
 
     GitHub's Windows image ships OpenSSL, but it is not always on PATH for
-    PowerShell. Search the well-known install locations before skipping.
+    PowerShell. Search the well-known install locations.
     """
     found = shutil.which("openssl")
     if found is not None:
@@ -215,12 +215,15 @@ def _openssl_bin() -> str | None:
     return None
 
 
+_OPENSSL = _openssl_bin()
+_OPENSSL_SKIP_REASON = "openssl is required for the local HTTPS transport tests"
+
+
 def _run_openssl(*args: str) -> None:
-    binary = _openssl_bin()
-    if binary is None:
-        pytest.skip("openssl is required for the local HTTPS transport tests")
+    if _OPENSSL is None:
+        raise FileNotFoundError(_OPENSSL_SKIP_REASON)
     subprocess.run(
-        [binary, *args],
+        [_OPENSSL, *args],
         check=True,
         capture_output=True,
         text=True,
@@ -337,6 +340,7 @@ def _assert_unknown_issuer(exc: BaseException) -> None:
     assert "UnknownIssuer" in message, message
 
 
+@pytest.mark.skipif(_OPENSSL is None, reason=_OPENSSL_SKIP_REASON)
 class TestIssue201Reproduction:
     """Reproduce the 0.9.0 TLS failure against a local HTTPS server.
 

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -13,8 +13,11 @@ broken *published* package needs a scheduled install-and-request job.
 from __future__ import annotations
 
 import http.server
+import os
+import shutil
 import ssl
 import subprocess
+import sys
 import threading
 from collections.abc import Iterator
 from pathlib import Path
@@ -189,9 +192,35 @@ class _LocalHTTPS:
         self.ca_pem = ca_pem
 
 
+def _openssl_bin() -> str | None:
+    """Return an ``openssl`` executable, or ``None`` if none is installed.
+
+    GitHub's Windows image ships OpenSSL, but it is not always on PATH for
+    PowerShell. Search the well-known install locations before skipping.
+    """
+    found = shutil.which("openssl")
+    if found is not None:
+        return found
+    if sys.platform != "win32":
+        return None
+    program_files = Path(os.environ.get("ProgramFiles", r"C:\Program Files"))
+    for candidate in (
+        program_files / "OpenSSL" / "bin" / "openssl.exe",
+        program_files / "OpenSSL-Win64" / "bin" / "openssl.exe",
+        program_files / "Git" / "usr" / "bin" / "openssl.exe",
+        program_files / "Git" / "mingw64" / "bin" / "openssl.exe",
+    ):
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
 def _run_openssl(*args: str) -> None:
+    binary = _openssl_bin()
+    if binary is None:
+        pytest.skip("openssl is required for the local HTTPS transport tests")
     subprocess.run(
-        ["openssl", *args],
+        [binary, *args],
         check=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The suite has only ever run on `ubuntu-latest`. The package claims OS Independent, ships native deps (`wasmtime`, `pyqwest`, `onnxruntime`), and evaluates WASM locally — none of which Linux CI can prove works on Windows or macOS.

## What this adds

Two new jobs, each with floor + current latest (`3.10`, `3.14`):

- `Run tests (windows-latest, py…)` → aggregator `Run tests (windows-latest)`
- `Run tests (macos-latest, py…)` → aggregator `Run tests (macos-latest)`

Ubuntu’s 3.10–3.14 matrix and the required `Run tests (ubuntu-latest)` check are unchanged. Windows/macOS are **not** folded into that job: a non-Linux failure must not fail the ruleset context, which cannot be edited from a PR.

## Why not a full OS × Python matrix

A 3 × 5 matrix is 15 cells. `macos-latest` bills at 10× minutes, `windows-latest` at 2×. Ubuntu already covers every released interpreter; the interesting cross-OS failures are “does the locked wheel set install” and “does WASM/TLS still work”, which floor + latest catch. Expand the Python list on those jobs if a version-specific native-dep issue shows up.

`macos-latest` is Apple Silicon. Intel Macs are not covered; GitHub is winding `macos-13` down and the locked wheels are universal2 / arm64.

## Native wheels (from `uv.lock`)

| Package | Windows x64 | macOS arm64 | 3.10 | 3.14 |
|---|---|---|---|---|
| `wasmtime` 47.0.1 | yes | yes | py3-none | py3-none |
| `pyqwest` 0.9.0 | yes | yes | abi3 / cp310 | cp314 |
| `onnxruntime` 1.22.1 (≤3.13) | yes | universal2 | yes | n/a |
| `onnxruntime` 1.28.0 (3.14) | yes | macosx_14 arm64 | n/a | yes |

`uv.lock` already carries `sys_platform == 'win32'` markers (`colorama`, `pyreadline3`).

## Test-side change

`tests/unit/test_transport.py` builds a throwaway CA with `openssl`. Windows images ship OpenSSL 3 but it is not always on PATH for PowerShell. The helper now searches the usual install locations; the TLS cases skip at collection if `openssl` is missing. CI also prepends the found `bin` directory to `PATH` on Windows. macOS relies on the image `openssl` already being on PATH.

Known Windows-only test nuance: `HTTPS_PROXY` / `https_proxy` are the same env slot (case-insensitive). The parametrized proxy tests still pass; they just exercise one name twice.

## Making them required later

Add `Run tests (windows-latest)` and `Run tests (macos-latest)` to the branch-protection ruleset once the new legs are green and stable. Do not rename the Ubuntu aggregator.

## Test plan

- [x] `Run tests (windows-latest, py3.10)` and `py3.14` green — 1405 passed, 5 skipped
- [x] `Run tests (macos-latest, py3.10)` and `py3.14` green — 1405 passed, 5 skipped
- [x] `Run tests (windows-latest)` / `Run tests (macos-latest)` aggregators green
- [x] Existing Ubuntu 3.10–3.14 matrix and `Run tests (ubuntu-latest)` unchanged
- [x] Local `uv run pytest tests/unit/test_transport.py --no-cov` — 23 passed
- [x] Review nits: macOS OpenSSL PATH comment; collection-time `skipif` for TLS tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24cafadd-0f36-4f28-8499-f1129678ac05?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24cafadd-0f36-4f28-8499-f1129678ac05&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

