### PR TITLE
docs: add cross-SDK parity review for Python, Go, and JS

### DIFF
--- a/PARITY_GO.md
+++ b/PARITY_GO.md
@@ -1,0 +1,324 @@
+# Arcjet SDK parity review — changes required in `arcjet-go`
+
+**Reviewed:** 2026-08-20
+**Scope:** Core SDK only — `Protect`, rules, decisions, local WASM evaluation, cache,
+Guard, redact, metadata. HTTP middleware/router adapters are out of scope.
+
+**Sources compared:**
+
+| SDK | Repo | Commit |
+| --- | --- | --- |
+| Go | `arcjet/arcjet-go` (v0.1.0) | `872675701dadb4988ffcf4576f7e8571c9ac8dd8` |
+| JavaScript | `arcjet/arcjet-js` (v1.10.0) | `0099fb76e9229fa0b5922f938f4f1ce2e1033ce1` |
+| Python | `arcjet/arcjet-py` | `eef50a1ddee709efab855f5de738892cf5a68964` |
+
+Every item below was verified against source in all three repos, not inferred from
+documentation. Items are ordered by risk × blast radius.
+
+---
+
+## Summary
+
+| # | Priority | Change | Type |
+| --- | --- | --- | --- |
+| 1 | P0 | `Protect` returns an unusable zero `Decision` on transport error | Footgun / internal inconsistency |
+| 2 | P0 | Guard rate-limit rules default to bucket `"default"` | Wrong counter grouping |
+| 3 | P0 | Guard rules default to `DRY_RUN` when `Mode` is empty | Cross-SDK divergence |
+| 4 | P1 | Local rules evaluate in declaration order, not priority order | Privacy / divergence |
+| 5 | P1 | No default deadline when the caller passes a context without one | Divergence |
+| 6 | P2 | HTTP `SensitiveInfo` has no `ContextWindowSize` | Missing API |
+| 7 | P3 | Correct the `redact` package doc's claim about Python | Doc fix |
+| 8 | P3 | Document the Guard `ARCJET_KEY` policy | Cleanup |
+
+---
+
+## P0 — correctness
+
+### 1. `Protect` returns an unusable zero `Decision` on transport error
+
+**Where:** `client.go:498-501`.
+
+```go
+resp, err := c.decideClient.Decide(ctx, req)
+if err != nil {
+    return Decision{}, err
+}
+```
+
+The zero `Decision` has `Conclusion == ""`, so **both** predicates are false:
+
+- `IsAllowed()` → `"" == ConclusionAllow` → `false`
+- `IsDenied()`  → `"" == ConclusionDeny`  → `false`
+
+A handler written the natural way —
+
+```go
+decision, err := client.Protect(ctx, r)
+if err != nil { /* log */ }
+if !decision.IsAllowed() {
+    http.Error(w, "Forbidden", http.StatusForbidden)
+    return
+}
+```
+
+— **blocks all traffic during an Arcjet outage**, the exact opposite of the fail-open
+behavior promised in `doc.go`:
+
+> Arcjet is designed to fail open: if the service is unavailable, Protect and Guard
+> return an error and the caller should continue serving.
+
+Returning an `error` is correct Go and should stay. The problem is returning an
+*unusable value* alongside it.
+
+**This is an internal inconsistency, not a language-idiom difference.** Go's own Guard
+already does the right thing (`guard.go:153-155`, `:254`): on transport failure it
+returns an `ALLOW` decision carrying a synthetic errored result **and** a non-nil error,
+so `HasFailedOpen()` and `ErrorResults()` work for callers who ignore `err`.
+
+For reference, the other SDKs both synthesize a decision:
+
+- JS returns `ArcjetErrorDecision` where `isAllowed()` is `true` and `isErrored()` is
+  `true` (`arcjet/src/index.ts:3988-3998`, `protocol/src/index.ts`).
+- Python returns a `CONCLUSION_ERROR` decision when `fail_open=True`
+  (`_client.py:807-814`).
+
+**Fix:** return an `ERROR`-conclusion `Decision` alongside the error, mirroring
+`GuardClient.Guard`. Callers who check `err` are unaffected; callers who check the
+decision get sane values, and `IsErrored()` becomes meaningful on the Protect path.
+Returning a populated value with a non-nil error is idiomatic when the value is
+meaningful.
+
+---
+
+### 2. Guard rate-limit rules default to bucket `"default"`
+
+**Where:** `guard.go:454-457` (token bucket), `:560-563` (fixed window),
+`:657-660` (sliding window):
+
+```go
+bucket := opts.Bucket
+if bucket == "" {
+    bucket = "default"
+}
+```
+
+Both other SDKs use distinct, typed defaults:
+
+| Rule | JS / Python | Go |
+| --- | --- | --- |
+| Token bucket | `default-token-bucket` | `default` |
+| Fixed window | `default-fixed-window` | `default` |
+| Sliding window | `default-sliding-window` | `default` |
+
+Evidence: JS `arcjet-guard/src/convert.ts:601, 614, 627`; Python
+`guard/_rules/_rate_limit.py:52, 72, 92`.
+
+Two consequences:
+
+1. The same logical rate limit lands in a **different server-side counter** in Go than
+   in JS/Python, so a polyglot deployment silently splits its limit.
+2. Within Go, all three algorithms **collide in one bucket** when `Bucket` is left
+   empty, so a token bucket and a fixed window on the same key share a counter.
+
+**Fix:** use the same three default names. One line per rule; no idiom argument.
+
+---
+
+### 3. Guard rules default to `DRY_RUN` when `Mode` is empty
+
+**Where:** `normalizeMode` (`types.go:23-28`) maps `""` → `ModeDryRun`, and both
+`requestMode` and `guardMode` route through it, so the default applies to Guard as
+well as HTTP.
+
+Verified defaults across all three SDKs:
+
+| Surface | JS | Python | Go |
+| --- | --- | --- | --- |
+| HTTP `protect` rules | `DRY_RUN` | `LIVE` | `DRY_RUN` |
+| Guard rules | `LIVE` | `LIVE` | **`DRY_RUN`** |
+
+JS documents `@default "LIVE"` on every Guard rule config
+(`arcjet-guard/src/types.ts:582-584, 720-722, 846-848, 972-974, 1015-1017, 1153-1155,
+1227-1229, 1389-1391`); Python uses `mode: Mode = "LIVE"` throughout
+`guard/_rules/`.
+
+A Go Guard rule constructed without `Mode` therefore **observes but never enforces**,
+while the same rule in JS or Python blocks. On the HTTP side Go matches JS and is fine.
+
+**Do not simply flip the Go Guard default to `LIVE`.** That would start blocking
+traffic that existing deployments only observe — a silent behavior change delivered by
+a version bump.
+
+**Fix:** make an empty `Mode` an error for Guard rule constructors. They already return
+`(*Rule, error)`, so `GuardTokenBucket`, `GuardFixedWindow`, `GuardSlidingWindow`,
+`GuardPromptInjection`, `GuardModerateContent`, `GuardSensitiveInfo`, and `GuardCustom`
+can reject it in `newGuardRuleBase` via `validateMode` without normalizing first. Go
+cannot require a struct field, so a constructor error is the idiomatic loud signal.
+
+Leave the HTTP `DRY_RUN` default alone, or apply the same treatment there via
+`NewClient` returning an error — see `PARITY_PY.md` item 2 for the matching Python-side
+change.
+
+---
+
+## P1 — divergence
+
+### 4. Local rules evaluate in declaration order, not priority order
+
+**Where:** `evaluateLocal` (`client.go:556-586`) iterates `for i, rule := range c.rules`
+in the order the caller configured them.
+
+JS sorts by an explicit priority table before evaluating
+(`arcjet/src/index.ts:1730-1738`, applied via `sortRule` at `:4036`):
+
+```
+SensitiveInfo(1) → Filter(2) → Shield(3) → RateLimit(4) → Bot(5) → Email(6) → PromptInjection(7)
+```
+
+The first live DENY short-circuits (`liveDeny()`), so ordering decides which rule's
+reason, TTL, and Report payload the caller sees. Sensitive-info-first is a privacy
+property: it should deny before another rule's path forwards the payload.
+
+Python has the same gap.
+
+**Fix:** sort by the JS priority order in `evaluateLocal`. Because Go precomputes
+`ruleIDs`, `fpChars`, and `builtRuleIndices` positionally at construction, sort once in
+`NewClient`/`WithRule` and keep those slices aligned rather than sorting per request.
+
+---
+
+### 5. No default deadline when the caller's context has none
+
+**Where:** `Protect` / `ProtectDetails` (`client.go:406, 415`) rely entirely on the
+caller's `context.Context`. There is no SDK-level timeout.
+
+| SDK | Base | Adjustments |
+| --- | --- | --- |
+| JS | 500 ms prod / 1000 ms dev (`arcjet-node/src/index.ts:139`) | ×2 with an email rule; floor 1000 ms with prompt injection (`protocol/src/client.ts:118-142`) |
+| Python | 2000 ms (`_client.py:155`) | none |
+| Go | none | none |
+
+Deferring to `context` is idiomatic Go and should remain the primary mechanism. The gap
+is the fallback: `Protect(context.Background(), r)` has no deadline at all, so a hung
+Decide call stalls the handler indefinitely — whereas the same code in JS or Python
+fails open on a timer.
+
+Go already applies bounded deadlines elsewhere: `reportTimeout = 5 * time.Second`
+(`client.go:26`) and `guardPolicyFetchTimeout = 2s` (`remote_policy.go`).
+
+**Fix:** apply a default deadline when the incoming context has none
+(`ctx.Deadline()` returns `ok == false`), sized to whatever base the SDKs agree on.
+Never shorten a caller-supplied deadline.
+
+---
+
+## P2 — missing API surface
+
+### 6. HTTP `SensitiveInfo` has no `ContextWindowSize`
+
+**Where:** `SensitiveInfoOptions` (`rules.go:314-326`) exposes `Mode`, `Allow`, `Deny`,
+and `Backend` — no context window. `Config.SensitiveInfoDetect` (`client.go:58-64`) is
+client-wide.
+
+Both other SDKs expose it per rule, defaulting to 1:
+
+- JS — `contextWindowSize?: number`, applied as `options.contextWindowSize || 1`
+  (`arcjet/src/index.ts:1528, 1636, 2688`).
+- Python — `context_window_size: int | None` on `detect_sensitive_info()`
+  (`_rules.py:585, 1198`).
+
+Go already threads the value through its WASM bindings —
+`SensitiveInfoConfig.ContextWindowSize *uint32`
+(`internal/local/jsreq/bindings.go:173-177`) — and `redact.Options.ContextWindowSize`
+uses the same mechanism (`redact/redact.go:46-48, 132-135`). Only the public HTTP rule
+option is missing, so a Go `SensitiveInfoDetect` callback always receives single-token
+windows and cannot implement multi-token detectors.
+
+**Fix:** add `ContextWindowSize int` to `SensitiveInfoOptions`, defaulting to 1 when
+zero or negative, matching `redact.Options`.
+
+---
+
+## P3 — cleanup
+
+### 7. Correct the `redact` package doc's claim about Python
+
+**Where:** `redact/redact.go:1-9`:
+
+> It runs the same WebAssembly component as the @arcjet/redact (JavaScript) and
+> **arcjet.redact (Python)** packages, so all three SDKs redact identically.
+
+`arcjet.redact` does not exist. Python has no redaction API — only inline
+`"<redacted>"` substitution on outbound Report payloads.
+
+**Fix:** either drop the Python reference until `arcjet-py` ships the package
+(tracked as `PARITY_PY.md` item 9), or reword to describe the shared component
+without asserting a Python package.
+
+### 8. Document the Guard `ARCJET_KEY` policy
+
+- Go Guard reads `ARCJET_KEY` when `Key` is empty (`guard.go:71-74`).
+- JS Guard is documented as **never** reading environment variables
+  (`arcjet-guard/src/index.ts:66-69`).
+- Python Guard requires an explicit key with no env fallback.
+
+Go's behavior is internally consistent (`NewClient` does the same at `client.go:109-112`)
+and idiomatic. The three-way split should nonetheless be a deliberate, documented
+decision rather than an accident.
+
+Related: Go implements no `ARCJET_ENV` / development mode, which both other SDKs have
+(missing-IP fallback to `127.0.0.1`, `X-Arcjet-Ip` override). Given Go's explicit
+`Platform` enum and `WithIPSrc`, this is a reasonable omission — worth confirming it
+is intentional.
+
+---
+
+## Verified aligned — no action
+
+Checked and confirmed identical; previously suspected as gaps.
+
+- **Local deny TTL is 60s everywhere.** Go `localDeny(..., 60, ...)`
+  (`local_decision.go:200, 243`), JS `ttl: 60` (`index.ts:3040, 3536`), Python
+  `_LOCAL_DENY_TTL_SECONDS = 60`.
+- **Per-rule cache semantics match JS.** `(ruleID, fingerprint)` key, DENY + `RUN` +
+  `TTL > 0` only, TTL rewritten to remaining lifetime on read, fresh `lreq` id
+  (`cache.go:46-104`). This is the reference implementation — Python is the outlier
+  here, not Go.
+- **Guard `requested` defaults to 1** in all three.
+- **No SDK reports on a first remote DENY** — the Decide call creates the dashboard
+  entry. Go's Report-on-cached-DENY matches JS.
+- **Allow/deny exclusivity** is enforced for bot, email, sensitive info, and filter
+  (`rules.go:467-495`) — Go and JS both enforce; Python is the gap.
+- **Global characteristics apply to rate-limit fingerprints only**
+  (`collectFingerprintChars`, `client.go:186-203`).
+- **Prompt injection is server-side only; content moderation is Guard-only.**
+- **Metadata**: same 768 KiB ceiling, excluded from fingerprint and cache key.
+- **`IsSpoofedBot` / `IsVerifiedBot` / `IsMissingUserAgent`** correctly skip
+  `RuleStateDryRun` (`types.go:302-326`), matching JS `@arcjet/inspect`. Python is the
+  gap here.
+- **Prompt-injection `threshold` already removed** — Go is ahead; JS and Python should
+  follow.
+
+---
+
+## Deliberate differences — leave as-is
+
+Language idiom, not parity bugs:
+
+- **`time.Duration` for rate-limit windows.** The natural Go type. JS uses duration
+  strings only because it lacks one; Python uses integer seconds. `seconds()`
+  (`rules.go:497-502`) already clamps sub-second values to 1.
+- **No global Guard registry / free `guard()`.** JS `registerArcjet` and Python's
+  module-level registry have no clean Go equivalent; an explicit client handle is the
+  better Go design.
+- **No ambient correlation context.** Explicit `CorrelationId` on `GuardRequest`,
+  `ProtectOptions`, and `CaptureEvent` is correct Go; Python's `ContextVar` is not
+  portable here.
+- **`.Key(...)` / `.Text(...)` rule binding** instead of calling the rule as a function.
+- **Metadata warnings surfaced on the `Decision`** rather than logged. Go takes no
+  logger; this is the right call and arguably better than JS/Python logging them.
+- **`SetRateLimitHeaders`** (`headers.go`) — Go and JS have this; Python does not.
+- **`ProtectDetails` / `DetailsFromRequest`** for non-`*http.Request` sources.
+- **`sensitiveInfoValue` never placed on the wire** (`client.go:446-449`). Stricter
+  than JS/Python, which send it and redact. Keep the stricter behavior.
+- **wazero + wizer pre-initialization** for the WASM runtime.

--- a/PARITY_JS.md
+++ b/PARITY_JS.md
@@ -1,0 +1,294 @@
+# Arcjet SDK parity review — changes required in `arcjet-js`
+
+**Reviewed:** 2026-08-20
+**Scope:** Core and shared packages only — `arcjet`, `@arcjet/protocol`,
+`@arcjet/analyze`, `@arcjet/cache`, `@arcjet/guard`, `@arcjet/inspect`,
+`@arcjet/decorate`, `@arcjet/redact`. Framework adapters (`arcjet-next`,
+`arcjet-node`, `arcjet-bun`, `nosecone*`, …) are out of scope except where they own a
+default the core cannot express.
+
+**Sources compared:**
+
+| SDK | Repo | Commit |
+| --- | --- | --- |
+| JavaScript | `arcjet/arcjet-js` (v1.10.0) | `0099fb76e9229fa0b5922f938f4f1ce2e1033ce1` |
+| Python | `arcjet/arcjet-py` | `eef50a1ddee709efab855f5de738892cf5a68964` |
+| Go | `arcjet/arcjet-go` (v0.1.0) | `872675701dadb4988ffcf4576f7e8571c9ac8dd8` |
+
+Every item below was verified against source in all three repos, not inferred from
+documentation. Items are ordered by risk × blast radius.
+
+**JS is the reference implementation for most core behavior** — priority ordering,
+per-rule caching, and allow/deny validation are all correct here and missing elsewhere.
+The list below is correspondingly short.
+
+---
+
+## Summary
+
+| # | Priority | Change | Type |
+| --- | --- | --- | --- |
+| 1 | P1 | Decide timeout base is 500 ms, below the documented cold-start cost | Fail-open risk |
+| 2 | P2 | Joint decision: require an explicit `mode` rather than defaulting | Cross-SDK divergence (no JS defect) |
+| 3 | P2 | Token bucket throws when `requested` is absent instead of defaulting to 1 | Divergence |
+| 4 | P2 | Shield ignores rule-level `characteristics` | Missing option |
+| 5 | P3 | `ArcjetDecision.ttl` is documented as milliseconds but is seconds | Doc bug |
+| 6 | P3 | Remove deprecated prompt-injection `threshold` | Cleanup |
+| 7 | P3 | Core `arcjet()` cannot be used standalone | Architecture note |
+
+---
+
+## P1
+
+### 1. Decide timeout base is 500 ms, below the documented cold-start cost
+
+**Where:** `arcjet-node/src/index.ts:139` —
+`const timeout = options?.timeout ?? (isDevelopment(env) ? 1000 : 500);`
+Adjusted by `decideTimeout` (`protocol/src/client.ts:118-142`): ×2 with an email rule,
+floored at 1000 ms with a prompt-injection rule.
+
+| SDK | Base | Adjustments |
+| --- | --- | --- |
+| JS | 500 ms prod / 1000 ms dev | ×2 email; floor 1000 ms prompt injection |
+| Python | 2000 ms flat (`_client.py:155`) | none |
+| Go | none — caller `context` only | none |
+
+Python raised its default specifically because of this, and its comment reads as a
+direct finding against the JS value:
+
+> Sized for the slowest rules: a cold prompt-injection or content-moderation start can
+> exceed the old 500ms production default, and a tight deadline fail-opens instead of
+> evaluating the rule. Matches Guard's default.
+
+If that measurement is right, a JS app with prompt injection or content moderation
+fails open on cold starts where the same configuration in Python evaluates the rule.
+Note the JS prompt-injection floor is 1000 ms — still half of Python's base — and there
+is **no** adjustment for content moderation.
+
+**Fix:** agree a single base across SDKs (Python's 2000 ms is the only value with a
+stated rationale) and keep the per-rule adjustments. Because the timeout lives in the
+adapters rather than core, this is a change across `arcjet-node`, `arcjet-bun`, and the
+other adapters, or a shared default hoisted into `createRemoteClient`.
+
+---
+
+## P2
+
+### 2. Joint decision: require an explicit `mode` rather than defaulting
+
+**Where:** every HTTP rule builder coerces with
+`options.mode === "LIVE" ? "LIVE" : "DRY_RUN"`
+(`arcjet/src/index.ts:1967, 2116, 2248, 2573, 2774, 2956, 3146, 3238, 3467`).
+Guard configs document `@default "LIVE"` (`arcjet-guard/src/types.ts`).
+
+Verified defaults across all three SDKs:
+
+| Surface | JS | Python | Go |
+| --- | --- | --- | --- |
+| HTTP `protect` rules | `DRY_RUN` | **`LIVE`** | `DRY_RUN` |
+| Guard rules | `LIVE` | `LIVE` | **`DRY_RUN`** |
+
+JS is on the majority side of both. The divergences are Python's HTTP default and Go's
+Guard default, and both are addressed in their own files.
+
+**JS input validation is sound** — worth recording, because the coercion pattern looks
+lossy at a glance and is not. Every builder calls its `validate*Options` function
+before coercing (`validateTokenBucketOptions:803`, `validateShieldOptions:970`,
+`validateBotOptions:953`, `validateDetectPromptInjectionOptions:987`, and the
+equivalents for fixed window, sliding window, email, sensitive info, and filter). Each
+declares `{ key: "mode", required: false, validate: validateMode }`, and `validateMode`
+(`:764-766`) throws on anything outside `{"LIVE","DRY_RUN"}`. So `mode: "live"` raises
+rather than silently downgrading to dry-run. **No change needed here.**
+
+**Cross-SDK consideration only:** if the SDKs converge on requiring an explicit `mode`
+— the recommendation in `PARITY_PY.md` item 2, since flipping any default silently
+changes enforcement in one direction or the other — JS would make `mode` a required
+field on the rule option types. TypeScript makes this the least disruptive of the
+three: a compile-time error rather than a runtime surprise, and `validateMode` already
+gives the runtime backstop. Worth deciding jointly rather than per SDK; there is no
+JS-only defect driving it.
+
+---
+
+### 3. Token bucket throws when `requested` is absent instead of defaulting to 1
+
+**Where:** `arcjet/src/index.ts:1987-1995`:
+
+```ts
+assert(
+  typeof details.extra.requested === "string",
+  "TokenBucket requires `requested` to be set.",
+);
+```
+
+Backed at the type level by `{ requested: number }` in the rule's props.
+
+| SDK | HTTP token bucket | Guard token bucket |
+| --- | --- | --- |
+| JS | **required** — throws if absent | defaults to 1 (`convert.ts:603`) |
+| Python | defaults to 1 (`_client.py:587-588`) | defaults to 1 |
+| Go | omitted from `Extra` unless `> 0` (`client.go:439-441`) | defaults to 1 (`guard.go`) |
+
+So JS is the only SDK that hard-requires it, and it is inconsistent with **its own
+Guard implementation**, which defaults to 1 in the same repo.
+
+Defaulting to 1 is the better contract: it is what all three Guard implementations
+already do, it matches the common case of one unit per call, and it removes a runtime
+throw from a hot path.
+
+**Fix:** default `requested` to 1 in the HTTP token bucket rule and relax the prop type
+to optional, matching Guard. Keep the type-level hint so explicit costs are still
+discoverable.
+
+### 4. Shield ignores rule-level `characteristics`
+
+**Where:** `shield()` (`arcjet/src/index.ts:3141-3203`). `ShieldOptions` exposes only
+`mode`, and the implementation carries a standing TODO:
+
+```ts
+// TODO(#1989): Prefer characteristics defined on rule once available
+const localCharacteristics = context.characteristics;
+```
+
+Both other SDKs accept per-rule characteristics on Shield:
+
+- Python — `Shield.characteristics` and `shield(characteristics=...)`
+  (`_rules.py:96-118, 818`), serialized into `ShieldRule.characteristics`.
+- Go — `ShieldOptions.Characteristics` (`rules.go:193-199`), serialized as
+  `"characteristics"` on the `shield` wire object.
+
+A Shield rule keyed on a custom characteristic is expressible in Python and Go but not
+in JS.
+
+**Fix:** add `characteristics` to `ShieldOptions` and use it for fingerprinting when
+present, falling back to `context.characteristics` — the same precedence rate-limit
+rules already use. Closes `#1989`.
+
+---
+
+## P3
+
+### 5. `ArcjetDecision.ttl` is documented as milliseconds but is seconds
+
+**Where:** `protocol/src/index.ts:1240-1243` and `:1282-1285`:
+
+> Duration in **milliseconds** this decision should be considered valid, also known as
+> time-to-live.
+
+It is seconds. Evidence:
+
+- `ArcjetRuleResult.ttl` is documented as *"Duration in **seconds**"*
+  (`protocol/src/index.ts:716-719, 754-757`).
+- The deny decision is built directly from it: `new ArcjetDenyDecision({ ttl: result.ttl, … })`
+  (`arcjet/src/index.ts:3911-3915`).
+- `MemoryCache` is entirely seconds-based — `nowInSeconds()`, and
+  `set()` computes `expiresAt = nowInSeconds() + ttl` (`cache/src/index.ts:35-37, 64-68`).
+- Local denies use `ttl: 60`, meaning 60 seconds (`arcjet/src/index.ts:3040, 3536`),
+  matching Python's `_LOCAL_DENY_TTL_SECONDS = 60` and Go's `localDeny(..., 60, ...)`.
+
+Both other SDKs document and treat decision TTL as seconds.
+
+**Fix:** correct both doc comments to seconds. Documentation-only, but it will mislead
+anyone porting between SDKs or writing a custom cache against the `Cache` interface.
+
+### 6. Remove deprecated prompt-injection `threshold`
+
+**Where:** `DetectPromptInjectionOptions.threshold`
+(`arcjet/src/index.ts:3087-3108`), already marked `@deprecated` — *"no longer respected
+by the server"* — and validated at `:3241-3246`.
+
+Status across SDKs:
+
+- JS — deprecated, still sent; rejects `threshold <= 0.0 || threshold >= 1.0` (**exclusive**).
+- Python — deprecated, still sent; accepts `0.0 <= threshold <= 1.0` (**inclusive**).
+- Go — **removed**; `PromptInjectionOptions` has only `Mode` (`rules.go:375-382`).
+
+`threshold: 0` therefore throws in JS and is accepted in Python. Since the server
+ignores the value, reconciling the ranges is wasted work.
+
+**Fix:** remove the option in JS and Python, following Go. Also remove the paired
+`ArcjetPromptInjectionReason.score`, already deprecated.
+
+### 7. Core `arcjet()` cannot be used standalone
+
+**Where:** `arcjet/src/index.ts:3669-3682` throws `"Log is required"` and
+`"Client is required"` when `options.log` / `options.client` are absent, with a
+standing TODO:
+
+```ts
+// TODO(#207): Remove this when we can default the transport so client is not required
+```
+
+Both other SDKs construct a working client from a key and rules alone
+(`arcjet(key=..., rules=[...])`, `NewClient(Config{Key: ..., Rules: ...})`), supplying
+their own transport, logger, and defaults.
+
+This is a deliberate monorepo architecture choice — adapters inject transport, logging,
+IP detection, and body reading — and is not a bug. It does mean the package named
+`arcjet` on npm is not usable on its own, which surprises people arriving from the
+Python or Go SDKs, and it prevents a plain Node script from using the core without
+`@arcjet/node`.
+
+**Fix (optional):** resolve `#207` by defaulting the transport and logger, keeping the
+injection points as overrides. Lower priority than the items above; recorded so the
+cross-SDK difference is deliberate rather than incidental.
+
+---
+
+## Verified aligned — no action
+
+Checked and confirmed identical; previously suspected as gaps.
+
+- **Local deny TTL is 60s everywhere.** JS `ttl: 60` (`index.ts:3040, 3536`), Python
+  `_LOCAL_DENY_TTL_SECONDS = 60`, Go `localDeny(..., 60, ...)`.
+- **No SDK reports on a first remote DENY** — the Decide call creates the dashboard
+  entry. JS reports only on local DENY (`index.ts:3917-3920`) and error paths; Go and
+  Python match, including Report on a cached DENY.
+- **Global characteristics apply to rate-limit rules only** (`index.ts:3830-3837`), the
+  same rule Python's `_apply_global_characteristics` and Go's `collectFingerprintChars`
+  implement.
+- **Redaction of `filterLocal` / `sensitiveInfoValue` for remote calls, and
+  `detectPromptInjectionMessage` for Reports** (`index.ts:3719-3744`) — Python mirrors
+  this exactly and cites JS as the source; Go goes further and never puts
+  `sensitiveInfoValue` on the wire at all.
+- **Guard `requested` defaults to 1** in all three.
+- **Prompt injection is server-side only; content moderation is Guard-only.**
+- **Metadata**: same 768 KiB SDK ceiling, same `AJ1017` warning code, excluded from
+  fingerprint and cache key everywhere.
+- **DRY_RUN local denies log and continue** rather than short-circuiting, in all three.
+- **Bot categories, email types, native sensitive-info entity types, and the
+  `requireTopLevelDomain: true` / `allowDomainLiteral: false` email defaults** match.
+
+---
+
+## JS behavior other SDKs should adopt
+
+Recorded here so it is not lost — these are tracked as changes in `PARITY_PY.md` and
+`PARITY_GO.md`.
+
+- **Local rule priority ordering** (`index.ts:1730-1738`, `sortRule` at `:4036`).
+  Sensitive info → filter → shield → rate limit → bot → email → prompt injection.
+  Python and Go both evaluate in caller-declaration order, so the rule that
+  short-circuits — and therefore the reason, TTL, and Report payload — differs. The
+  sensitive-info-first ordering is a privacy property, not a micro-optimization.
+- **Allow/deny validation.** JS enforces "exactly one of `allow`/`deny`" at both
+  compile time (discriminated unions) and runtime for bot, email, sensitive info, and
+  filter (`:2947-2951`, `:2763-2769`, `:2562-2568`, `:3471-3480`). Go enforces it for
+  all four; **Python does not enforce it for bot or email**.
+- **Per-rule caching keyed on `(ruleId, fingerprint)`**, where `ruleId` is a stable hash
+  of the rule's full config via `@arcjet/stable-hash`. Go mirrors this; Python caches
+  whole decisions keyed on rule class names plus characteristic values, which is both
+  coarser and stale on read.
+- **Rebuilding rate-limit `reset` from the live cache TTL on a cache hit**
+  (`:2030-2039`). Go rewrites TTL similarly; Python returns the cached decision
+  untouched, so `Retry-After` values derived from it are wrong.
+- **`@arcjet/inspect` state-awareness.** `isSpoofedBot` / `isVerifiedBot` /
+  `isMissingUserAgent` return `undefined` for `DRY_RUN` or non-bot results rather than
+  a misleading boolean (`inspect/src/index.ts:34-44`). Go matches; Python's
+  `is_spoofed_bot` does not check state and returns `True` for dry-run results.
+- **`withRule`** (`:4011-4014`) and **`protectSignup`** (`:3417-3429`) — Go has both,
+  Python has neither.
+- **`@arcjet/decorate`** (`setRateLimitHeaders`) — Go has `SetRateLimitHeaders`,
+  Python has no equivalent.
+- **`@arcjet/redact`** — Go has a `redact` package, Python has none (and Go's package
+  doc incorrectly claims Python ships one).

--- a/PARITY_PY.md
+++ b/PARITY_PY.md
@@ -1,0 +1,363 @@
+# Arcjet SDK parity review — changes required in `arcjet-py`
+
+**Reviewed:** 2026-08-20
+**Scope:** Core SDK only — HTTP `protect()`, Guard, local WASM evaluation, decision
+cache, metadata. Framework integrations (FastAPI/Flask/Django coercion, LangChain)
+are explicitly out of scope.
+
+**Sources compared:**
+
+| SDK | Repo | Commit |
+| --- | --- | --- |
+| Python | `arcjet/arcjet-py` | `eef50a1ddee709efab855f5de738892cf5a68964` |
+| JavaScript | `arcjet/arcjet-js` (v1.10.0) | `0099fb76e9229fa0b5922f938f4f1ce2e1033ce1` |
+| Go | `arcjet/arcjet-go` (v0.1.0) | `8726757 01dadb4988ffcf4576f7e8571c9ac8dd8` |
+
+Every item below was verified against source in all three repos, not inferred from
+documentation. Items are ordered by risk × blast radius.
+
+---
+
+## Summary
+
+| # | Priority | Change | Type |
+| --- | --- | --- | --- |
+| 1 | P0 | Cache hits return a stale, shared, mutable decision | Correctness bug |
+| 2 | P0 | Require an explicit `mode` instead of defaulting to `LIVE` | Cross-SDK divergence |
+| 3 | P1 | `detect_bot` accepts both `allow` and `deny`, and accepts neither | Silent misconfiguration |
+| 4 | P1 | Local rules evaluate in declaration order, not priority order | Privacy / divergence |
+| 5 | P1 | `is_spoofed_bot` ignores `DRY_RUN` rule state | Silent misconfiguration |
+| 6 | P1 | Timeout policy differs from JS | Divergence |
+| 7 | P2 | No `with_rule` | Missing API |
+| 8 | P2 | No `protect_signup` | Missing API |
+| 9 | P2 | No `arcjet.redact` package | Missing API |
+| 10 | P2 | No `is_verified_bot` / `is_missing_user_agent` / rate-limit header helper | Missing API |
+| 11 | P3 | Remove deprecated prompt-injection `threshold` | Cleanup |
+| 12 | P3 | Document Guard `ARCJET_KEY` policy | Cleanup |
+
+---
+
+## P0 — correctness
+
+### 1. Cache hits return a stale, shared, mutable decision
+
+**Where:** `src/arcjet/_client.py` — cache-hit block in `Arcjet.protect()` (~L632-706)
+and the mirrored block in `ArcjetSync.protect()` (~L1140+). `Decision.to_proto()` in
+`src/arcjet/_decision.py` (~L377).
+
+Three distinct defects in one code path.
+
+**1a. TTL is never decremented.** The cached `Decision` is returned unmodified, so
+`decision.ttl` reports the *original* TTL for the entire cache window. A decision
+cached with `ttl=60` still reports `60` when served 59 seconds later.
+
+Both other SDKs rewrite it:
+
+- Go — `cache.go:66-72` computes `remaining := time.Until(entry.expiresAt)` and sets
+  `cloned.Ttl = ttl`, flooring at `1`.
+- JS — `arcjet/src/index.ts:2022-2040` rebuilds `ArcjetRateLimitReason` with
+  `reset: ttl` taken from the live cache lookup, explicitly commented:
+  *"We rebuild the `ArcjetRateLimitReason` because we need to adjust the `reset`
+  based on the current time-to-live."*
+
+**1b. Rate-limit reason fields go stale with it.** Because the whole decision is
+returned as-is, `reason_v2.remaining`, `reason_v2.reset`, and `reason_v2.reset_time`
+are frozen at cache-write time. `RateLimitReason`'s own docstring tells users to build
+`RateLimit-Remaining` and `Retry-After` headers from exactly these fields, so a cache
+hit produces a `Retry-After` that is too large by up to the full TTL.
+
+**1c. The cached proto is mutated in place, and it is shared.**
+
+```python
+dec = cached.to_proto()          # returns self._d by reference, not a copy
+dec.id = _new_local_request_id() # mutates the object still held in the cache
+...
+return cached                    # same object the cache holds
+```
+
+`Decision.to_proto()` returns `self._d` directly, and `DecisionCache` stores the
+`Decision` wrapper, so the proto is aliased by the cache, by the returned value, and
+by every previously returned value. Consequences:
+
+- A `Decision` a caller already holds silently changes its `.id` when a later request
+  hits the same cache entry.
+- Concurrent requests hitting the same key race on one mutable protobuf. `DecisionCache`
+  guards the dict with an `RLock`, but nothing guards the object it hands out.
+
+**Fix:** on a cache hit, deep-copy the proto, rewrite `ttl` to the remaining lifetime,
+recompute rate-limit `remaining` / `reset` / `reset_time` against that remaining
+lifetime, and assign the fresh `lreq_…` id to the copy only. Mirror `ruleCache.get`
+in `arcjet-go/cache.go`.
+
+**Why it matters:** this is a bug in any language. It produces wrong `Retry-After`
+values, wrong client-visible TTLs, and a data race — none of which are visible to the
+caller.
+
+---
+
+### 2. Require an explicit `mode` instead of defaulting to `LIVE`
+
+**Where:** every rule factory in `src/arcjet/_rules.py` uses
+`mode: Union[str, Mode] = Mode.LIVE`. Guard rules in `src/arcjet/guard/_rules/`
+use `mode: Mode = "LIVE"`.
+
+Verified defaults across all three SDKs:
+
+| Surface | JS | Python | Go |
+| --- | --- | --- | --- |
+| HTTP `protect` rules | `DRY_RUN` | **`LIVE`** | `DRY_RUN` |
+| Guard rules | `LIVE` | `LIVE` | **`DRY_RUN`** |
+
+Evidence: JS coerces with `options.mode === "LIVE" ? "LIVE" : "DRY_RUN"` in every HTTP
+rule builder (`arcjet/src/index.ts:1967, 2116, 2248, 2573, 2774, 2956, 3146, 3238, 3467`)
+and documents `@default "LIVE"` on every Guard config in `arcjet-guard/src/types.ts`.
+Go's `normalizeMode` (`types.go:23-28`) maps `""` → `ModeDryRun` for **both** surfaces.
+
+Porting `detectBot({ allow: ["CATEGORY:SEARCH_ENGINE"] })` from JS to Python without
+setting `mode` silently changes it from log-only to live blocking.
+
+**Do not simply flip the Python default to `DRY_RUN`.** That would silently disable
+enforcement for every existing Python user on upgrade — a security regression delivered
+by a version bump.
+
+**Fix:** make `mode` a required keyword argument so omitting it raises `TypeError`.
+A loud break is strictly safer than a silent enforcement change in either direction.
+Per `AGENTS.md`, ship it with the `breaking` label and a migration note; a
+`DeprecationWarning` release before the hard requirement is a reasonable intermediate
+step.
+
+**Note on the HTTP/Guard split:** the split itself is defensible — HTTP rules land in
+broad middleware where accidental blocking is costly, Guard rules are opted into at a
+specific call site. The problem is Python sitting on the wrong side of the HTTP default
+(and Go on the wrong side of the Guard default). Requiring the field resolves both
+without choosing.
+
+---
+
+## P1 — silent misconfiguration
+
+### 3. `detect_bot` accepts both `allow` and `deny`, and accepts neither
+
+**Where:** `BotDetection.__post_init__` (`src/arcjet/_rules.py:288-309`) and the
+`detect_bot()` factory (`:907`). Both validate types and reject empty strings, but
+neither enforces exclusivity or presence.
+
+Both other SDKs reject it:
+
+- JS — `` `detectBot` options error: `allow` and `deny` cannot be provided together ``
+  and `` either `allow` or `deny` must be specified `` (`arcjet/src/index.ts:2947-2951`),
+  plus a compile-time discriminated union (`BotOptionsAllow | BotOptionsDeny`).
+- Go — `validateBotOptions` returns `ErrAllowDenyConflict` (`rules.go:467-475`).
+
+Python is also inconsistent with itself: `Filter.__post_init__` and
+`SensitiveInfoDetection.__post_init__` both already raise on the same condition.
+
+Silent failure modes today:
+
+- `detect_bot()` with neither list builds a rule that allows all bots.
+- `detect_bot(allow=[...], deny=[...])` is accepted, and local WASM silently prefers
+  `allow` — `_local.py:181-189` documents this as defensive behavior:
+  *"allow takes precedence over deny (matches JS SDK); the builder API prevents both
+  being set, but we handle it defensively here."* The builder does **not** prevent it.
+
+**Fix:** raise `ValueError` from `detect_bot()` and `BotDetection.__post_init__` when
+both lists are set, and when neither is. Apply the same to `validate_email()`, which
+has the same gap.
+
+---
+
+### 4. Local rules evaluate in declaration order, not priority order
+
+**Where:** `_run_local_rules()` (`src/arcjet/_client.py:208-255`) iterates
+`for rule in rules` in the order the caller listed them.
+
+JS sorts by an explicit priority table before evaluating
+(`arcjet/src/index.ts:1730-1738`, applied via `sortRule` at `:4036`):
+
+```
+SensitiveInfo(1) → Filter(2) → Shield(3) → RateLimit(4) → Bot(5) → Email(6) → PromptInjection(7)
+```
+
+The first LIVE DENY wins and short-circuits, so ordering decides which rule's reason,
+TTL, and Report payload the caller sees. Sensitive-info-first is a privacy property,
+not a micro-optimization: it should deny before another rule's path forwards the
+payload.
+
+Go has the same gap (`evaluateLocal`, `client.go:556-586`).
+
+**Fix:** adopt the JS priority ordering in `_run_local_rules()`.
+
+---
+
+### 5. `is_spoofed_bot` ignores `DRY_RUN` rule state
+
+**Where:** `src/arcjet/_decision.py:396-421`.
+
+```python
+r = result.raw.reason
+if not r:
+    return False
+if r.WhichOneof("reason") == "bot_v2":
+    return bool(r.bot_v2.spoofed)
+return False
+```
+
+No check of `result.state`, so a rule running in `DRY_RUN` still reports `True`.
+
+Both other SDKs gate on state:
+
+- JS — `isActive(result)` requires `result.state !== "DRY_RUN"`, and the helper returns
+  `undefined` (not `False`) for non-bot or dry-run results
+  (`inspect/src/index.ts:34-44, 145-154`).
+- Go — `anyActiveReason` skips `RuleStateDryRun`; covered by `rules_test.go:107, 125-129`.
+
+A user staging bot detection in dry-run and gating on `is_spoofed_bot()` blocks traffic
+the rule was only meant to observe — the precise failure dry-run exists to prevent.
+
+**Fix:** skip results whose state is `RULE_STATE_DRY_RUN`. Consider matching JS's
+tri-state return (`None` for "check did not apply"), though that is a breaking signature
+change and could ship separately.
+
+---
+
+### 6. Timeout policy differs from JS
+
+**Where:** `_DEFAULT_TIMEOUT_MS = 2000` (`src/arcjet/_client.py:155`), applied flat.
+
+| SDK | Base | Adjustments |
+| --- | --- | --- |
+| JS | 500 ms prod / 1000 ms dev (`arcjet-node/src/index.ts:139`) | ×2 with an email rule; floor 1000 ms with prompt injection (`protocol/src/client.ts:118-142`) |
+| Python | 2000 ms | none |
+| Go | none — caller `context` only | none |
+
+Python's own comment argues its value is the correct one:
+
+> Sized for the slowest rules: a cold prompt-injection or content-moderation start can
+> exceed the old 500ms production default, and a tight deadline fail-opens instead of
+> evaluating the rule.
+
+If that reasoning holds, JS's 500 ms base is the outlier and should move, not Python's.
+
+**Fix:** agree one base across SDKs plus the same per-rule adjustments. Python should
+additionally adopt the email ×2 and prompt-injection floor so a slow rule does not
+fail open at a deadline sized for fast ones.
+
+---
+
+## P2 — missing API surface
+
+### 7. No `with_rule`
+
+JS has `withRule(rule[])` (`arcjet/src/index.ts:4011-4014`); Go has
+`(*Client).WithRule` (`client.go:209-235`), which copies the client and **shares the
+cache pointer** so route-specific clones do not lose cached entries.
+
+Without it, per-route rules require constructing a whole new client — which in Python
+also allocates a fresh `DecisionCache`, discarding all cached denials.
+
+**Fix:** add `Arcjet.with_rule()` / `ArcjetSync.with_rule()` returning a copy that
+shares `_cache` and recomputes `_needs_email` / `_needs_message` / `_has_token_bucket`.
+
+### 8. No `protect_signup`
+
+Sugar over sliding window + bot + email. JS: `protectSignup`
+(`arcjet/src/index.ts:3417-3429`). Go: `ProtectSignup` (`rules.go:459-465`).
+Python has no equivalent.
+
+### 9. No `arcjet.redact`
+
+JS ships `@arcjet/redact`; Go ships the `redact` package. Both drive the same WASM
+component. Python has no redaction API — only inline `"<redacted>"` substitution for
+outbound Report payloads (`_context.py:337-341`, `_client.py:258-275`).
+
+Go's package doc already asserts the Python one exists:
+
+> It runs the same WebAssembly component as the @arcjet/redact (JavaScript) and
+> **arcjet.redact (Python)** packages, so all three SDKs redact identically.
+
+**Fix:** build `arcjet.redact` (with `entities`, `context_window_size`, `detect`,
+`replace`, and an unredact callback) or correct the Go comment.
+
+### 10. No `is_verified_bot` / `is_missing_user_agent` / rate-limit header helper
+
+- JS `@arcjet/inspect` exports `isSpoofedBot`, `isVerifiedBot`, `isMissingUserAgent`.
+- Go exposes `Decision.IsSpoofedBot`, `IsVerifiedBot`, `IsMissingUserAgent`
+  (`types.go:302-326`).
+- Python exports only `is_spoofed_bot`.
+
+Similarly, JS has `@arcjet/decorate` (`setRateLimitHeaders`) and Go has
+`SetRateLimitHeaders` (`headers.go`). Python is the only SDK where emitting
+`RateLimit-*` / `Retry-After` is entirely the application's job — and, per item 1,
+the values it would use are currently stale on cache hits.
+
+---
+
+## P3 — cleanup
+
+### 11. Remove deprecated prompt-injection `threshold`
+
+Already deprecated in Python and JS; **removed** in Go
+(`PromptInjectionOptions` has only `Mode`). The server ignores it.
+
+The two remaining implementations also disagree on validation:
+
+- JS rejects `threshold <= 0.0 || threshold >= 1.0` — exclusive
+  (`arcjet/src/index.ts:3241-3246`).
+- Python accepts `0.0 <= threshold <= 1.0` — inclusive (`_rules.py:141-145`).
+
+So `threshold=0.0` throws in JS and passes in Python. Since the value is inert,
+remove it from both rather than reconciling the ranges.
+
+### 12. Document the Guard `ARCJET_KEY` policy
+
+- JS Guard: documented as never reading environment variables
+  (`arcjet-guard/src/index.ts:66-69`).
+- Go Guard: reads `ARCJET_KEY` when `Key` is empty (`guard.go:71-74`).
+- Python Guard: requires an explicit key, no env fallback
+  (`guard/_client.py:974, 1029`).
+
+Python HTTP `arcjet()` also requires an explicit key while reading `ARCJET_BASE_URL`
+and `FLY_APP_NAME` — defensible, but the three-way Guard split should be a deliberate,
+documented decision.
+
+---
+
+## Verified aligned — no action
+
+Checked and confirmed identical; previously suspected as gaps.
+
+- **Local deny TTL is 60s everywhere.** Python `_LOCAL_DENY_TTL_SECONDS = 60`
+  (`_local.py:127`), JS `ttl: 60` (`index.ts:3040, 3536`), Go `localDeny(..., 60, ...)`
+  (`local_decision.go:200, 243`).
+- **Guard `requested` defaults to 1** in all three (Python
+  `guard/_rules/_rate_limit.py:108, 167, 226`; JS `convert.ts:603, 616, 629`;
+  Go `guard.go` `if requested <= 0 { requested = 1 }`).
+- **No SDK reports on a first remote DENY** — the Decide call creates the dashboard
+  entry. Only local and cached denials trigger `Report`.
+- **Global characteristics apply to rate-limit rules only** in all three
+  (`_apply_global_characteristics`, JS `index.ts:3830-3837`,
+  Go `collectFingerprintChars`).
+- **Bot categories, email types, and native sensitive-info entity types** match.
+- **Prompt injection is server-side only; content moderation is Guard-only** in all three.
+- **Metadata**: same 768 KiB SDK ceiling, same `AJ1017` warning code, excluded from
+  fingerprint and cache key everywhere.
+- **DRY_RUN local denies do not short-circuit** in any SDK.
+
+---
+
+## Deliberate differences — leave as-is
+
+Language idiom, not parity bugs:
+
+- **Integer seconds for rate-limit windows.** JS accepts duration strings (`"1h45m"`)
+  because it has no duration type; Go uses `time.Duration`. Integer seconds is the
+  natural Python choice. Worth documenting seconds as the canonical wire contract; not
+  worth adding a string parser.
+- **Dual async/sync clients** (`arcjet()` / `arcjet_sync()`). No analogue needed elsewhere.
+- **`arcjet_sequence` ContextVar.** A `ContextVar` is the idiomatic Python correlation
+  mechanism; Go correctly prefers explicit `CorrelationId`.
+- **`fail_open` flag.** Python's flag plus `ArcjetTransportError` is reasonable; see
+  `PARITY_GO.md` item 1 for the Go-side problem this contrasts with.
+- **`reason` vs `reason_v2`.** Already deprecated with a migration path.
+- **`disable_automatic_ip_detection` + required `ip_src`.** A stricter, defensible
+  contract that neither other SDK models the same way.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds three review documents recording a verified core-SDK parity comparison across `arcjet-py`, `arcjet-go`, and `arcjet-js`.

These are review artifacts intended for download and triage, not library code. If they should live somewhere other than the repo root — or in an internal doc store rather than `arcjet-py` — say so and I will move or drop them.

## Scope

Core SDK only: HTTP `protect`, Guard, local WASM evaluation, decision cache, and metadata. Framework integrations (FastAPI/Flask/Django coercion, LangChain, Next/Node/Bun adapters, `nosecone`) are explicitly excluded.

Commits compared:

| SDK | Commit |
| --- | --- |
| `arcjet-py` | `eef50a1` |
| `arcjet-js` (v1.10.0) | `0099fb7` |
| `arcjet-go` (v0.1.0) | `8726757` |

Every finding was verified against source in all three repos rather than inferred from documentation.

## Files

- **`PARITY_PY.md`** — 12 items. Two P0: cache hits return a stale, shared, mutable decision (stale `ttl` and rate-limit `reset`/`remaining`, plus in-place mutation of the cached proto); and the `mode` default divergence.
- **`PARITY_GO.md`** — 8 items. Three P0: `Protect` returns a zero `Decision` on transport error so both `IsAllowed()` and `IsDenied()` are false; Guard rate-limit rules default to bucket `"default"` instead of the typed per-algorithm names; Guard rules default to `DRY_RUN`.
- **`PARITY_JS.md`** — 7 items, mostly low priority. JS is the reference implementation for priority ordering, per-rule caching, and allow/deny validation. Includes a section listing JS behavior the other two SDKs should adopt.

Each file also records the surfaces verified as **already aligned** (local deny TTL of 60s, Guard `requested` defaulting to 1, report-on-remote-deny semantics, metadata limits, entity/category enums) and the differences that are **language idiom rather than parity bugs** (duration types, Go's explicit correlation IDs, Python's dual async/sync clients).

## Note on the `mode` finding

The headline divergence is that HTTP rules default to `DRY_RUN` in JS/Go but `LIVE` in Python, while Guard defaults to `LIVE` in JS/Python but `DRY_RUN` in Go.

The documents deliberately **do not** recommend flipping any default. Each flip is a silent behavior change shipped in a version bump — either disabling enforcement or starting to block previously observed traffic. The recommendation is to require an explicit `mode` so omission is a loud error instead.

## Verification

Documentation only; no source or test changes. `PARITY_JS.md` item 2 was corrected during review after confirming that every JS rule builder does validate `mode` through `validateMode`, so the initially suspected silent-downgrade path does not exist.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3545a681-4d2c-4be9-9498-f7abb93e24aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3545a681-4d2c-4be9-9498-f7abb93e24aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

