### PR TITLE
Align HTTP SDK with JS cache, rules, and inspect APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,14 +315,6 @@ def chat():
     # safe to pass body["message"] to your LLM
 ```
 
-You can tune the detection sensitivity with the `threshold` parameter (0.0–1.0,
-default 0.5). Higher values require stronger signals to trigger a denial,
-reducing false positives but potentially missing subtle attacks:
-
-```py
-detect_prompt_injection(mode=Mode.LIVE, threshold=0.8)
-```
-
 See the [Prompt Injection docs](https://docs.arcjet.com/prompt-injection) for
 more details.
 
@@ -940,6 +932,7 @@ if not arcjet_key:
     raise RuntimeError("ARCJET_KEY is required")
 
 # Create a single guard client and reuse it.
+# Guard never reads ARCJET_KEY itself — pass key= explicitly (same as JS Guard).
 aj = launch_arcjet(key=arcjet_key)
 
 # Configure rules once at startup

--- a/src/arcjet/__init__.py
+++ b/src/arcjet/__init__.py
@@ -7,9 +7,12 @@ from ._decision import (
     IpInfo,
     Reason,  # type: ignore -- intentionally deprecated
     RuleResult,
+    is_missing_user_agent,
     is_spoofed_bot,
+    is_verified_bot,
 )
 from ._enums import Mode
+from ._headers import set_rate_limit_headers
 from ._metadata import Metadata, MetadataValue
 from ._rules import (
     BotCategory,
@@ -22,6 +25,7 @@ from ._rules import (
     detect_sensitive_info,
     filter_request,
     fixed_window,
+    protect_signup,
     shield,
     sliding_window,
     token_bucket,
@@ -53,14 +57,18 @@ __all__ = [
     "IpInfo",
     "IpDetails",
     "ThreatIntelligence",
+    "is_missing_user_agent",
     "is_spoofed_bot",
+    "is_verified_bot",
     "Metadata",
     "MetadataValue",
     "Mode",
     "PromptInjectionDetection",
+    "protect_signup",
     "Reason",
     "RuleResult",
     "RuleSpec",
+    "set_rate_limit_headers",
     "shield",
     "sliding_window",
     "token_bucket",

--- a/src/arcjet/_cache.py
+++ b/src/arcjet/_cache.py
@@ -33,7 +33,13 @@ class DecisionCache:
         self._lock = threading.RLock()
         self._store: dict[str, _CacheEntry] = {}
 
-    def get(self, key: str) -> Decision | None:
+    def get(self, key: str) -> tuple[Decision, int] | None:
+        """Return ``(decision, remaining_ttl)`` or ``None`` on miss/expiry.
+
+        ``remaining_ttl`` is the live lifetime of the entry in whole seconds,
+        floored at ``1`` so a just-about-to-expire hit still reports a
+        positive cache window (matching Go ``ruleCache.get``).
+        """
         now = time.monotonic()
         with self._lock:
             entry = self._store.get(key)
@@ -46,7 +52,10 @@ class DecisionCache:
                 except Exception:
                     pass
                 return None
-            return entry.decision
+            remaining = int(entry.expires_at - now)
+            if remaining < 1:
+                remaining = 1
+            return entry.decision, remaining
 
     def set(self, key: str, decision: Decision, ttl_seconds: int | float) -> None:
         if ttl_seconds <= 0:

--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -42,7 +42,7 @@ from ._context import (
     coerce_request_context,
     request_details_from_context,
 )
-from ._decision import Decision
+from ._decision import Decision, materialize_cached_decision
 from ._errors import ArcjetMisconfiguration, ArcjetTransportError
 from ._ids import crockford32, uuidv7_bytes
 from ._local import (
@@ -66,6 +66,7 @@ from ._rules import (
     PromptInjectionDetection,
     RuleSpec,
     SensitiveInfoDetection,
+    Shield,
     SlidingWindow,
     TokenBucket,
 )
@@ -205,6 +206,36 @@ def _sdk_version(default: str = "0.0.0") -> str:
         return default
 
 
+# Local evaluation order matches the JS SDK priority table. The first LIVE
+# DENY wins, so Sensitive Info must run before any rule that might forward
+# the payload.
+_LOCAL_RULE_PRIORITY: dict[type[RuleSpec], int] = {
+    SensitiveInfoDetection: 1,
+    Filter: 2,
+    Shield: 3,
+    TokenBucket: 4,
+    FixedWindow: 4,
+    SlidingWindow: 4,
+    BotDetection: 5,
+    EmailValidation: 6,
+    PromptInjectionDetection: 7,
+}
+
+
+def _sort_rules_for_local(rules: Sequence[RuleSpec]) -> list[RuleSpec]:
+    """Sort rules by JS local-evaluation priority (stable for equal ranks)."""
+    return sorted(rules, key=lambda rule: _LOCAL_RULE_PRIORITY.get(type(rule), 100))
+
+
+def _rule_flags(rules: Sequence[RuleSpec]) -> tuple[bool, bool, bool]:
+    """Return ``(needs_email, needs_message, has_token_bucket)`` for *rules*."""
+    return (
+        any(isinstance(r, EmailValidation) for r in rules),
+        any(isinstance(r, PromptInjectionDetection) for r in rules),
+        any(isinstance(r, TokenBucket) for r in rules),
+    )
+
+
 def _run_local_rules(
     ctx: RequestContext,
     rules: tuple[RuleSpec, ...],
@@ -213,10 +244,13 @@ def _run_local_rules(
 
     Returns a DENY Decision if any rule denies in LIVE mode (short-circuit),
     or None if all locally-evaluated rules allow (proceed to remote API).
+
+    Rules are evaluated in JS priority order, not declaration order, so a
+    Sensitive Info LIVE DENY is reported before a later Bot/Email DENY.
     """
     local_results: list[decide_pb2.RuleResult] = []
 
-    for rule in rules:
+    for rule in _sort_rules_for_local(rules):
         result: decide_pb2.RuleResult | None = None
         if isinstance(rule, BotDetection):
             result = evaluate_bot_locally(ctx, rule)
@@ -631,13 +665,17 @@ class Arcjet:
 
         # Cache lookup before hitting Decide API
         cache_key = make_cache_key(ctx, self._rules)
-        cached = self._cache.get(cache_key) if cache_key is not None else None
-        if cached is not None:
+        cached_hit = self._cache.get(cache_key) if cache_key is not None else None
+        if cached_hit is not None:
+            cached, remaining_ttl = cached_hit
+            # Isolate the caller from the cached proto: new id, live TTL, and
+            # a rewritten rate-limit reset. The object in the cache is unchanged.
+            served = materialize_cached_decision(
+                cached, remaining_ttl, _new_local_request_id()
+            )
             # Fire-and-forget async report; do not await
             try:
-                # Use cached decision but override ID with locally generated request ID
-                dec = cached.to_proto()
-                dec.id = _new_local_request_id()
+                dec = served.to_proto()
                 rep = decide_pb2.ReportRequest(
                     sdk_stack=_sdk_stack(self._sdk_stack),
                     sdk_version=self._sdk_version,
@@ -675,9 +713,9 @@ class Arcjet:
                     logger.debug(
                         "report: id=%s conclusion=%s reason=%s ttl=%s api_ms=%.3f prepare_ms=%.3f total_ms=%.3f rules=%d",
                         dec.id,
-                        decide_pb2.Conclusion.Name(cached.conclusion),
-                        cached.reason.which(),
-                        str(cached.ttl),
+                        decide_pb2.Conclusion.Name(served.conclusion),
+                        served.reason.which(),
+                        str(served.ttl),
                         round(api_ms, 3),
                         round(prepare_ms, 3),
                         round(total_ms, 3),
@@ -685,9 +723,9 @@ class Arcjet:
                         extra={
                             "event": "arcjet_report_cache_hit",
                             "decision_id": dec.id,
-                            "conclusion": decide_pb2.Conclusion.Name(cached.conclusion),
-                            "reason": cached.reason.which(),
-                            "ttl": cached.ttl,
+                            "conclusion": decide_pb2.Conclusion.Name(served.conclusion),
+                            "reason": served.reason.which(),
+                            "ttl": served.ttl,
                             "rule_count": len(self._rules),
                             "api_ms": round(api_ms, 3),
                             "prepare_ms": round(prepare_ms, 3),
@@ -703,7 +741,7 @@ class Arcjet:
                         "error": str(e),
                     },
                 )
-            return cached
+            return served
 
         # Local WASM evaluation: run bot/email rules locally before remote API
         local_decision = _run_local_rules(ctx, self._rules)
@@ -917,6 +955,44 @@ class Arcjet:
                 },
             )
         return decision
+
+    def with_rule(self, rule: RuleSpec | Sequence[RuleSpec]) -> Arcjet:
+        """Return a copy of this client with extra rule(s) appended.
+
+        The returned client shares this instance's decision cache, so
+        route-specific clones still benefit from cached denials. Flags
+        such as ``_needs_email`` are recomputed from the combined rule set.
+
+        Args:
+            rule: A single rule or a sequence of rules (for example the
+                tuple returned by ``protect_signup()``).
+
+        Returns:
+            A new ``Arcjet`` instance. This client is unchanged.
+
+        Example::
+
+            signup = aj.with_rule(
+                protect_signup(
+                    rate_limit={"mode": Mode.LIVE, "max": 5, "interval": 600},
+                    bots={"mode": Mode.LIVE, "allow": []},
+                    email={
+                        "mode": Mode.LIVE,
+                        "deny": [EmailType.DISPOSABLE, EmailType.INVALID],
+                    },
+                )
+            )
+        """
+        extra = (rule,) if isinstance(rule, RuleSpec) else tuple(rule)
+        new_rules = self._rules + extra
+        needs_email, needs_message, has_token_bucket = _rule_flags(new_rules)
+        return replace(
+            self,
+            _rules=new_rules,
+            _needs_email=needs_email,
+            _needs_message=needs_message,
+            _has_token_bucket=has_token_bucket,
+        )
 
     async def aclose(self) -> None:
         """Close the underlying transport when supported (async)."""
@@ -1137,12 +1213,15 @@ class ArcjetSync:
 
         # Cache lookup before hitting Decide API
         cache_key = make_cache_key(ctx, self._rules)
-        cached = self._cache.get(cache_key) if cache_key is not None else None
-        if cached is not None:
+        cached_hit = self._cache.get(cache_key) if cache_key is not None else None
+        if cached_hit is not None:
+            cached, remaining_ttl = cached_hit
+            served = materialize_cached_decision(
+                cached, remaining_ttl, _new_local_request_id()
+            )
             # Fire-and-forget background report using sync client
             try:
-                dec = cached.to_proto()
-                dec.id = _new_local_request_id()
+                dec = served.to_proto()
                 rep = decide_pb2.ReportRequest(
                     sdk_stack=_sdk_stack(self._sdk_stack),
                     sdk_version=self._sdk_version,
@@ -1179,9 +1258,9 @@ class ArcjetSync:
                     logger.debug(
                         "report (cache-hit sync): id=%s conclusion=%s reason=%s ttl=%s api_ms=%.3f prepare_ms=%.3f total_ms=%.3f rules=%d",
                         dec.id,
-                        decide_pb2.Conclusion.Name(cached.conclusion),
-                        cached.reason.which(),
-                        str(cached.ttl),
+                        decide_pb2.Conclusion.Name(served.conclusion),
+                        served.reason.which(),
+                        str(served.ttl),
                         round(api_ms, 3),
                         round(prepare_ms, 3),
                         round(total_ms, 3),
@@ -1189,9 +1268,9 @@ class ArcjetSync:
                         extra={
                             "event": "arcjet_report_cache_hit",
                             "decision_id": dec.id,
-                            "conclusion": decide_pb2.Conclusion.Name(cached.conclusion),
-                            "reason": cached.reason.which(),
-                            "ttl": cached.ttl,
+                            "conclusion": decide_pb2.Conclusion.Name(served.conclusion),
+                            "reason": served.reason.which(),
+                            "ttl": served.ttl,
                             "rule_count": len(self._rules),
                             "api_ms": round(api_ms, 3),
                             "prepare_ms": round(prepare_ms, 3),
@@ -1207,7 +1286,7 @@ class ArcjetSync:
                         "error": str(e),
                     },
                 )
-            return cached
+            return served
 
         # Local WASM evaluation: run bot/email rules locally before remote API
         local_decision = _run_local_rules(ctx, self._rules)
@@ -1418,6 +1497,31 @@ class ArcjetSync:
             )
         return decision
 
+    def with_rule(self, rule: RuleSpec | Sequence[RuleSpec]) -> ArcjetSync:
+        """Return a copy of this client with extra rule(s) appended.
+
+        The returned client shares this instance's decision cache, so
+        route-specific clones still benefit from cached denials. Flags
+        such as ``_needs_email`` are recomputed from the combined rule set.
+
+        Args:
+            rule: A single rule or a sequence of rules (for example the
+                tuple returned by ``protect_signup()``).
+
+        Returns:
+            A new ``ArcjetSync`` instance. This client is unchanged.
+        """
+        extra = (rule,) if isinstance(rule, RuleSpec) else tuple(rule)
+        new_rules = self._rules + extra
+        needs_email, needs_message, has_token_bucket = _rule_flags(new_rules)
+        return replace(
+            self,
+            _rules=new_rules,
+            _needs_email=needs_email,
+            _needs_message=needs_message,
+            _has_token_bucket=has_token_bucket,
+        )
+
     def close(self) -> None:
         """Close the underlying transport when supported (sync)."""
         close = getattr(self._client, "close", None)
@@ -1539,6 +1643,7 @@ def arcjet(
     if not key:
         raise ArcjetMisconfiguration("Arcjet key is required.")
     resolved_rules = _apply_global_characteristics(tuple(rules), tuple(characteristics))
+    needs_email, needs_message, has_token_bucket = _rule_flags(resolved_rules)
     transport = build_async_transport()
     client = DecideServiceClient(
         base_url.rstrip("/"), http_client=pyqwest.Client(transport)
@@ -1551,9 +1656,9 @@ def arcjet(
         _sdk_version=_sdk_version() if sdk_version is None else sdk_version,
         _timeout_ms=_DEFAULT_TIMEOUT_MS if timeout_ms is None else timeout_ms,
         _fail_open=fail_open,
-        _needs_email=any(isinstance(r, EmailValidation) for r in rules),
-        _needs_message=any(isinstance(r, PromptInjectionDetection) for r in rules),
-        _has_token_bucket=any(isinstance(r, TokenBucket) for r in rules),
+        _needs_email=needs_email,
+        _needs_message=needs_message,
+        _has_token_bucket=has_token_bucket,
         _proxies=tuple(proxies),
         _disable_automatic_ip_detection=disable_automatic_ip_detection,
         _environment=environment,
@@ -1669,6 +1774,7 @@ def arcjet_sync(
     if not key:
         raise ArcjetMisconfiguration("Arcjet key is required.")
     resolved_rules = _apply_global_characteristics(tuple(rules), tuple(characteristics))
+    needs_email, needs_message, has_token_bucket = _rule_flags(resolved_rules)
     transport = build_sync_transport()
     client = DecideServiceClientSync(
         base_url.rstrip("/"), http_client=pyqwest.SyncClient(transport)
@@ -1682,9 +1788,9 @@ def arcjet_sync(
         _sdk_version=_sdk_version() if sdk_version is None else sdk_version,
         _timeout_ms=_DEFAULT_TIMEOUT_MS if timeout_ms is None else timeout_ms,
         _fail_open=fail_open,
-        _needs_email=any(isinstance(r, EmailValidation) for r in rules),
-        _needs_message=any(isinstance(r, PromptInjectionDetection) for r in rules),
-        _has_token_bucket=any(isinstance(r, TokenBucket) for r in rules),
+        _needs_email=needs_email,
+        _needs_message=needs_message,
+        _has_token_bucket=has_token_bucket,
         _proxies=tuple(proxies),
         _disable_automatic_ip_detection=disable_automatic_ip_detection,
         _environment=environment,

--- a/src/arcjet/_decision.py
+++ b/src/arcjet/_decision.py
@@ -14,6 +14,7 @@ Core types:
 
 from __future__ import annotations
 
+import copy
 import json
 from dataclasses import dataclass
 
@@ -393,18 +394,24 @@ class Decision:
         return json.dumps(self.to_dict())
 
 
+def _is_active_result(result: RuleResult) -> bool:
+    """Return ``True`` when a rule result is not a dry-run observation."""
+    return result.state != decide_pb2.RULE_STATE_DRY_RUN
+
+
 def is_spoofed_bot(result: RuleResult) -> bool:
-    """Return ``True`` if a bot detection rule found a spoofed user agent.
+    """Return ``True`` if a live bot rule found a spoofed user agent.
 
     A spoofed bot claims to be a well-known crawler (e.g. Googlebot) but
     originates from an IP address that does not match the verified ranges for
-    that crawler.
+    that crawler. Results from ``DRY_RUN`` rules are ignored so staging a bot
+    rule cannot accidentally block traffic.
 
     Args:
         result: A single ``RuleResult`` from ``decision.results``.
 
     Returns:
-        ``True`` when the bot rule detected a spoofed user agent.
+        ``True`` when a live bot rule detected a spoofed user agent.
 
     Example::
 
@@ -413,9 +420,125 @@ def is_spoofed_bot(result: RuleResult) -> bool:
         if any(is_spoofed_bot(r) for r in decision.results):
             return jsonify(error="Spoofed bot detected"), 403
     """
+    if not _is_active_result(result):
+        return False
     r = result.raw.reason
     if not r:
         return False
     if r.WhichOneof("reason") == "bot_v2":
         return bool(r.bot_v2.spoofed)
     return False
+
+
+def is_verified_bot(result: RuleResult) -> bool:
+    """Return ``True`` if a live bot rule verified a known legitimate bot.
+
+    Verified bots are identified by matching the client IP against official
+    ranges for that crawler (e.g. Googlebot). Results from ``DRY_RUN`` rules
+    are ignored.
+
+    Args:
+        result: A single ``RuleResult`` from ``decision.results``.
+
+    Returns:
+        ``True`` when a live bot rule verified the client as a known bot.
+
+    Example::
+
+        from arcjet import is_verified_bot
+
+        if any(is_verified_bot(r) for r in decision.results):
+            return jsonify(message="Hello bot")
+    """
+    if not _is_active_result(result):
+        return False
+    r = result.raw.reason
+    if not r:
+        return False
+    if r.WhichOneof("reason") == "bot_v2":
+        return bool(r.bot_v2.verified)
+    return False
+
+
+def is_missing_user_agent(result: RuleResult) -> bool:
+    """Return ``True`` if a live bot rule failed because ``User-Agent`` was missing.
+
+    A missing ``User-Agent`` is a strong signal of a non-browser client.
+    Results from ``DRY_RUN`` rules are ignored.
+
+    Args:
+        result: A single ``RuleResult`` from ``decision.results``.
+
+    Returns:
+        ``True`` when a live bot rule reported a missing ``User-Agent`` header.
+
+    Example::
+
+        from arcjet import is_missing_user_agent
+
+        if any(is_missing_user_agent(r) for r in decision.results):
+            return jsonify(error="User-Agent required"), 403
+    """
+    if not _is_active_result(result):
+        return False
+    r = result.raw.reason
+    if not r:
+        return False
+    if r.WhichOneof("reason") != "error":
+        return False
+    message = getattr(r.error, "message", "") or ""
+    return (
+        "missing User-Agent header" in message
+        or "requires user-agent header" in message
+    )
+
+
+def _clone_decision_proto(src: decide_pb2.Decision) -> decide_pb2.Decision:
+    """Deep-copy a decision proto without aliasing the cached object.
+
+    Real protobuf messages use ``CopyFrom``. Test stubs fall back to
+    ``deepcopy``.
+    """
+    clone = decide_pb2.Decision()
+    copy_from = getattr(clone, "CopyFrom", None)
+    if callable(copy_from):
+        copy_from(src)
+        return clone
+    return copy.deepcopy(src)
+
+
+def _rewrite_rate_limit_reset(
+    reason: decide_pb2.Reason | None, remaining_ttl: int
+) -> None:
+    """Point rate-limit ``reset`` at the live remaining cache lifetime."""
+    if reason is None:
+        return
+    which = reason.WhichOneof("reason") if hasattr(reason, "WhichOneof") else None
+    if which != "rate_limit":
+        return
+    rate_limit = reason.rate_limit
+    if rate_limit is None:
+        return
+    if hasattr(rate_limit, "reset_in_seconds"):
+        rate_limit.reset_in_seconds = remaining_ttl
+
+
+def materialize_cached_decision(
+    cached: Decision, remaining_ttl: int, request_id: str
+) -> Decision:
+    """Return an isolated cache-hit decision with a live TTL and request id.
+
+    The cached proto is never mutated. Rate-limit ``reset`` / ``reset_in_seconds``
+    are rewritten to ``remaining_ttl`` so ``Retry-After`` stays accurate.
+    """
+    proto = _clone_decision_proto(cached.to_proto())
+    proto.id = request_id
+    proto.ttl = remaining_ttl
+    reason = proto.reason if getattr(proto, "reason", None) is not None else None
+    _rewrite_rate_limit_reset(reason, remaining_ttl)
+    for rule_result in getattr(proto, "rule_results", ()) or ():
+        rr_reason = getattr(rule_result, "reason", None)
+        _rewrite_rate_limit_reset(rr_reason, remaining_ttl)
+        if hasattr(rule_result, "ttl"):
+            rule_result.ttl = remaining_ttl
+    return Decision(proto)

--- a/src/arcjet/_decision.py
+++ b/src/arcjet/_decision.py
@@ -496,14 +496,18 @@ def is_missing_user_agent(result: RuleResult) -> bool:
 def _clone_decision_proto(src: decide_pb2.Decision) -> decide_pb2.Decision:
     """Deep-copy a decision proto without aliasing the cached object.
 
-    Real protobuf messages use ``CopyFrom``. Test stubs fall back to
-    ``deepcopy``.
+    Construct the clone from ``type(src)`` so test stubs do not get mixed
+    with the real protobuf class (``CopyFrom`` requires the same type).
+    Real messages use ``CopyFrom``; anything else falls back to ``deepcopy``.
     """
-    clone = decide_pb2.Decision()
+    clone = type(src)()
     copy_from = getattr(clone, "CopyFrom", None)
     if callable(copy_from):
-        copy_from(src)
-        return clone
+        try:
+            copy_from(src)
+            return clone
+        except TypeError:
+            pass
     return copy.deepcopy(src)
 
 

--- a/src/arcjet/_headers.py
+++ b/src/arcjet/_headers.py
@@ -1,0 +1,194 @@
+"""Helpers for applying Arcjet decisions to HTTP response headers.
+
+Mirrors ``@arcjet/decorate`` ``setRateLimitHeaders`` in the JS SDK: emit
+``RateLimit`` and ``RateLimit-Policy`` from the IETF Rate Limit Fields draft.
+"""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any
+
+from arcjet._dataclasses import RateLimitReason
+from arcjet._decision import Decision
+from arcjet._logging import logger
+
+
+def _to_limit_string(reason: RateLimitReason) -> str:
+    return (
+        f"limit={reason.max}, remaining={reason.remaining}, "
+        f"reset={int(reason.reset.total_seconds())}"
+    )
+
+
+def _to_policy_string(max_requests: int, window_seconds: int) -> str:
+    return f"{max_requests};w={window_seconds}"
+
+
+def _nearest_limit(current: RateLimitReason, nxt: RateLimitReason) -> RateLimitReason:
+    if current.remaining < nxt.remaining:
+        return current
+    if current.remaining > nxt.remaining:
+        return nxt
+    if current.reset < nxt.reset:
+        return current
+    if current.reset > nxt.reset:
+        return nxt
+    if current.max < nxt.max:
+        return current
+    return nxt
+
+
+def _rate_limit_reasons(decision: Decision) -> list[RateLimitReason]:
+    reasons = [
+        result.reason_v2
+        for result in decision.results
+        if isinstance(result.reason_v2, RateLimitReason)
+    ]
+    if reasons:
+        return reasons
+    if isinstance(decision.reason_v2, RateLimitReason):
+        return [decision.reason_v2]
+    return []
+
+
+def _is_header_like(value: Any) -> bool:
+    return (
+        hasattr(value, "has")
+        and callable(value.has)
+        and hasattr(value, "get")
+        and callable(value.get)
+        and hasattr(value, "set")
+        and callable(value.set)
+    )
+
+
+def _is_outgoing_message_like(value: Any) -> bool:
+    return (
+        isinstance(getattr(value, "headersSent", None), bool)
+        and hasattr(value, "hasHeader")
+        and callable(value.hasHeader)
+        and hasattr(value, "getHeader")
+        and callable(value.getHeader)
+        and hasattr(value, "setHeader")
+        and callable(value.setHeader)
+    )
+
+
+def _warn_existing(name: str, original: Any, new: str) -> None:
+    logger.warning(
+        "Response already contains `%s` header (original=%s new=%s)",
+        name,
+        original,
+        new,
+    )
+
+
+def _apply_headers(target: Any, limit: str, policy: str) -> bool:
+    """Write the two IETF headers onto *target*. Return ``False`` if unsupported."""
+    if _is_header_like(target):
+        if target.has("RateLimit"):
+            _warn_existing("RateLimit", target.get("RateLimit"), limit)
+        if target.has("RateLimit-Policy"):
+            _warn_existing(
+                "RateLimit-Policy", target.get("RateLimit-Policy"), policy
+            )
+        target.set("RateLimit", limit)
+        target.set("RateLimit-Policy", policy)
+        return True
+
+    headers = getattr(target, "headers", None)
+    if headers is not None and _is_header_like(headers):
+        return _apply_headers(headers, limit, policy)
+
+    if _is_outgoing_message_like(target):
+        if target.headersSent:
+            logger.error("Headers have already been sent—cannot set RateLimit header")
+            return True
+        if target.hasHeader("RateLimit"):
+            _warn_existing("RateLimit", target.getHeader("RateLimit"), limit)
+        if target.hasHeader("RateLimit-Policy"):
+            _warn_existing(
+                "RateLimit-Policy", target.getHeader("RateLimit-Policy"), policy
+            )
+        target.setHeader("RateLimit", limit)
+        target.setHeader("RateLimit-Policy", policy)
+        return True
+
+    mapping: MutableMapping[str, str] | None
+    if isinstance(target, MutableMapping):
+        mapping = target
+    elif isinstance(headers, MutableMapping):
+        mapping = headers
+    elif headers is not None and hasattr(headers, "__setitem__"):
+        mapping = headers
+    elif hasattr(target, "__setitem__") and hasattr(target, "__contains__"):
+        mapping = target
+    else:
+        mapping = None
+
+    if mapping is None:
+        return False
+
+    if "RateLimit" in mapping:
+        _warn_existing("RateLimit", mapping["RateLimit"], limit)
+    if "RateLimit-Policy" in mapping:
+        _warn_existing("RateLimit-Policy", mapping["RateLimit-Policy"], policy)
+    mapping["RateLimit"] = limit
+    mapping["RateLimit-Policy"] = policy
+    return True
+
+
+def set_rate_limit_headers(target: Any, decision: Decision) -> None:
+    """Set ``RateLimit`` and ``RateLimit-Policy`` on a response or header map.
+
+    Accepts Fetch-style ``Headers`` (``.has`` / ``.get`` / ``.set``), an
+    object with those methods on ``.headers`` (Starlette / FastAPI /
+    Flask), a Node-style ``setHeader`` response, or a mutable mapping.
+
+    When several rate-limit results are present, the tightest remaining
+    budget is advertised, matching ``@arcjet/decorate``.
+
+    Args:
+        target: Response or header map to decorate.
+        decision: Decision returned from ``protect()``.
+
+    Example::
+
+        from arcjet import set_rate_limit_headers
+
+        decision = await aj.protect(request, requested=1)
+        set_rate_limit_headers(response, decision)
+        if decision.is_denied():
+            return JSONResponse({"error": "Too many requests"}, status_code=429)
+    """
+    reasons = _rate_limit_reasons(decision)
+    if not reasons:
+        return
+
+    policies: dict[int, int] = {}
+    for reason in reasons:
+        window_seconds = int(reason.window.total_seconds())
+        # JS rejects two policies that share the same limit, even when the
+        # windows match — the IETF field cannot disambiguate them.
+        if reason.max in policies:
+            logger.error(
+                "Invalid rate limit policy—two policies should not share the same limit"
+            )
+            return
+        policies[reason.max] = window_seconds
+
+    nearest = reasons[0]
+    for reason in reasons[1:]:
+        nearest = _nearest_limit(nearest, reason)
+
+    limit = _to_limit_string(nearest)
+    policy = ", ".join(
+        _to_policy_string(max_requests, window)
+        for max_requests, window in sorted(policies.items())
+    )
+
+    if not _apply_headers(target, limit, policy):
+        logger.debug(
+            "Cannot determine how to set RateLimit headers on %r", type(target)
+        )

--- a/src/arcjet/_headers.py
+++ b/src/arcjet/_headers.py
@@ -39,17 +39,37 @@ def _nearest_limit(current: RateLimitReason, nxt: RateLimitReason) -> RateLimitR
     return nxt
 
 
+def _as_rate_limit_reason(holder: Any) -> RateLimitReason | None:
+    """Return a ``RateLimitReason`` if *holder* has one, else ``None``.
+
+    ``Decision.reason_v2`` assumes a proto reason is present; ALLOW
+    decisions often have none, so we check before converting.
+    """
+    raw = getattr(holder, "raw", None)
+    if raw is None:
+        to_proto = getattr(holder, "to_proto", None)
+        raw = to_proto() if callable(to_proto) else None
+    if raw is None or getattr(raw, "reason", None) is None:
+        return None
+    typed = holder.reason_v2
+    # Discriminate on the public ``type`` field rather than ``isinstance``.
+    # Tests reload ``arcjet.*`` after stubbing protobuf, which can create a
+    # second ``RateLimitReason`` class object with the same name.
+    if getattr(typed, "type", None) == "RATE_LIMIT":
+        return typed
+    return None
+
+
 def _rate_limit_reasons(decision: Decision) -> list[RateLimitReason]:
     reasons = [
-        result.reason_v2
+        reason
         for result in decision.results
-        if isinstance(result.reason_v2, RateLimitReason)
+        if (reason := _as_rate_limit_reason(result)) is not None
     ]
     if reasons:
         return reasons
-    if isinstance(decision.reason_v2, RateLimitReason):
-        return [decision.reason_v2]
-    return []
+    top = _as_rate_limit_reason(decision)
+    return [top] if top is not None else []
 
 
 def _is_header_like(value: Any) -> bool:
@@ -90,9 +110,7 @@ def _apply_headers(target: Any, limit: str, policy: str) -> bool:
         if target.has("RateLimit"):
             _warn_existing("RateLimit", target.get("RateLimit"), limit)
         if target.has("RateLimit-Policy"):
-            _warn_existing(
-                "RateLimit-Policy", target.get("RateLimit-Policy"), policy
-            )
+            _warn_existing("RateLimit-Policy", target.get("RateLimit-Policy"), policy)
         target.set("RateLimit", limit)
         target.set("RateLimit-Policy", policy)
         return True

--- a/src/arcjet/_local.py
+++ b/src/arcjet/_local.py
@@ -179,13 +179,13 @@ def evaluate_bot_locally(
     request_json = _context_to_analyze_request(ctx)
 
     # Build the WASM config from the rule's allow/deny lists.
-    # allow takes precedence over deny (matches JS SDK); the builder API
-    # prevents both being set, but we handle it defensively here.
-    if rule.allow:
+    # `is not None` so an empty allow list (block every bot) stays an allow
+    # config, matching JS `detectBot({ allow: [] })`.
+    if rule.allow is not None:
         entities = [str(e) for e in rule.allow]
         config = AllowedBotConfig(entities=entities, skip_custom_detect=True)
     else:
-        entities = [str(e) for e in rule.deny]
+        entities = [str(e) for e in (rule.deny or ())]
         config = DeniedBotConfig(entities=entities, skip_custom_detect=True)
 
     try:
@@ -247,7 +247,7 @@ def evaluate_email_locally(
         return None
 
     # Build the WASM config from the rule
-    if rule.allow:
+    if rule.allow is not None:
         email_config = AllowEmailValidationConfig(
             require_top_level_domain=rule.require_top_level_domain,
             allow_domain_literal=rule.allow_domain_literal,
@@ -257,7 +257,7 @@ def evaluate_email_locally(
         email_config = DenyEmailValidationConfig(
             require_top_level_domain=rule.require_top_level_domain,
             allow_domain_literal=rule.allow_domain_literal,
-            deny=[str(t.value) for t in rule.deny],
+            deny=[str(t.value) for t in (rule.deny or ())],
         )
 
     try:

--- a/src/arcjet/_rules.py
+++ b/src/arcjet/_rules.py
@@ -17,27 +17,31 @@ Shield common sensitive endpoints:
 
 Detect bots with allow/deny lists:
 
-    from arcjet import detect_bot, BotCategory
+    from arcjet import detect_bot, BotCategory, Mode
     rules = [
         detect_bot(
+            mode=Mode.LIVE,
             allow=(BotCategory.GOOGLE, "OPENAI_CRAWLER_SEARCH"),
         )
     ]
 
 Rate limiting (token bucket):
 
-    from arcjet import token_bucket
+    from arcjet import token_bucket, Mode
     rules = [
-        token_bucket(refill_rate=10, interval=60, capacity=20),
+        token_bucket(mode=Mode.LIVE, refill_rate=10, interval=60, capacity=20),
     ]
     # When using token buckets, pass `requested` to charge tokens per request:
     #   decision = await aj.protect(req, requested=1)
 
 Email validation:
 
-    from arcjet import validate_email, EmailType
+    from arcjet import validate_email, EmailType, Mode
     rules = [
-        validate_email(deny=(EmailType.DISPOSABLE, EmailType.INVALID))
+        validate_email(
+            mode=Mode.LIVE,
+            deny=(EmailType.DISPOSABLE, EmailType.INVALID),
+        )
     ]
     # When configured, pass `email=...` to `protect()`:
     #   decision = await aj.protect(req, email="alice@example.com")
@@ -47,7 +51,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, Iterable, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, Mapping, Sequence, Tuple, Union
 
 from arcjet.proto.decide.v1alpha1 import decide_pb2
 
@@ -126,28 +130,14 @@ class PromptInjectionDetection(RuleSpec):
     """
 
     mode: Mode
-    threshold: float = 0.5
-    """.. deprecated::
-
-        The ``threshold`` parameter is deprecated and will be removed in a
-        future release.
-    """
 
     def __post_init__(self):
         if not isinstance(self.mode, Mode):
             raise TypeError("PromptInjectionDetection.mode must be a Mode enum")
-        if not isinstance(self.threshold, (int, float)):
-            raise TypeError("PromptInjectionDetection.threshold must be a number")
-        threshold = float(self.threshold)
-        if not (0.0 <= threshold <= 1.0):
-            raise ValueError(
-                f"PromptInjectionDetection.threshold must be between 0.0 and 1.0, got {threshold}"
-            )
 
     def to_proto(self) -> decide_pb2.Rule:
         pidr = decide_pb2.PromptInjectionDetectionRule(
             mode=_mode_to_proto(self.mode),
-            threshold=float(self.threshold),
         )
         return decide_pb2.Rule(prompt_injection_detection=pidr)
 
@@ -281,14 +271,24 @@ class BotDetection(RuleSpec):
     """
 
     mode: Mode
-    allow: tuple[BotSpecifier, ...] = ()
-    deny: tuple[BotSpecifier, ...] = ()
+    allow: tuple[BotSpecifier, ...] | None = None
+    deny: tuple[BotSpecifier, ...] | None = None
     characteristics: tuple[str, ...] = ()
 
     def __post_init__(self):
         if not isinstance(self.mode, Mode):
             raise TypeError("BotDetection.mode must be a Mode enum")
+        if self.allow is not None and self.deny is not None:
+            raise ValueError(
+                "BotDetection options error: `allow` and `deny` cannot be provided together"
+            )
+        if self.allow is None and self.deny is None:
+            raise ValueError(
+                "BotDetection options error: either `allow` or `deny` must be specified"
+            )
         for seq, name in ((self.allow, "allow"), (self.deny, "deny")):
+            if seq is None:
+                continue
             if not isinstance(seq, tuple):
                 raise TypeError(
                     f"BotDetection.{name} must be a tuple of BotCategory or str"
@@ -310,8 +310,8 @@ class BotDetection(RuleSpec):
 
     def to_proto(self) -> decide_pb2.Rule:
         br = decide_pb2.BotV2Rule(mode=_mode_to_proto(self.mode))
-        br.allow.extend([_bot_category_to_proto(a) for a in self.allow])
-        br.deny.extend([_bot_category_to_proto(d) for d in self.deny])
+        br.allow.extend([_bot_category_to_proto(a) for a in (self.allow or ())])
+        br.deny.extend([_bot_category_to_proto(d) for d in (self.deny or ())])
         return decide_pb2.Rule(bot_v2=br)
 
 
@@ -744,8 +744,8 @@ class EmailValidation(RuleSpec):
     """
 
     mode: Mode
-    deny: tuple[EmailType, ...] = ()
-    allow: tuple[EmailType, ...] = ()
+    deny: tuple[EmailType, ...] | None = None
+    allow: tuple[EmailType, ...] | None = None
     require_top_level_domain: bool = True
     allow_domain_literal: bool = False
     characteristics: tuple[str, ...] = ()
@@ -753,7 +753,17 @@ class EmailValidation(RuleSpec):
     def __post_init__(self):
         if not isinstance(self.mode, Mode):
             raise TypeError("EmailValidation.mode must be a Mode enum")
+        if self.allow is not None and self.deny is not None:
+            raise ValueError(
+                "EmailValidation options error: `allow` and `deny` cannot be provided together"
+            )
+        if self.allow is None and self.deny is None:
+            raise ValueError(
+                "EmailValidation options error: either `allow` or `deny` must be specified"
+            )
         for seq, name in ((self.allow, "allow"), (self.deny, "deny")):
+            if seq is None:
+                continue
             if not isinstance(seq, tuple):
                 raise TypeError(f"EmailValidation.{name} must be a tuple of EmailType")
             for item in seq:
@@ -777,8 +787,8 @@ class EmailValidation(RuleSpec):
             require_top_level_domain=bool(self.require_top_level_domain),
             allow_domain_literal=bool(self.allow_domain_literal),
         )
-        er.allow.extend([_email_type_to_proto(t.value) for t in self.allow])
-        er.deny.extend([_email_type_to_proto(t.value) for t in self.deny])
+        er.allow.extend([_email_type_to_proto(t.value) for t in (self.allow or ())])
+        er.deny.extend([_email_type_to_proto(t.value) for t in (self.deny or ())])
         # Do not set version explicitly; server will use the latest
         return decide_pb2.Rule(email=er)
 
@@ -814,9 +824,24 @@ def _coerce_mode(mode: Union[str, Mode]) -> Mode:
     raise ValueError(f"Unknown mode: {mode!r}")
 
 
-def shield(
-    *, mode: Union[str, Mode] = Mode.LIVE, characteristics: Sequence[str] = ()
-) -> Shield:
+def _require_allow_xor_deny(
+    allow: object | None,
+    deny: object | None,
+    *,
+    name: str,
+) -> None:
+    """Reject allow+deny together or neither, matching the JS SDK builders."""
+    if allow is not None and deny is not None:
+        raise ValueError(
+            f"`{name}` options error: `allow` and `deny` cannot be provided together"
+        )
+    if allow is None and deny is None:
+        raise ValueError(
+            f"`{name}` options error: either `allow` or `deny` must be specified"
+        )
+
+
+def shield(*, mode: Union[str, Mode], characteristics: Sequence[str] = ()) -> Shield:
     """Protect your app against common attacks such as SQL injection, XSS, and CSRF.
 
     Shield analyzes each request server-side and blocks those that match known
@@ -825,8 +850,9 @@ def shield(
 
     Args:
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
-            ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
-            ``Mode.LIVE``.
+            ``Mode.DRY_RUN`` logs matches without blocking. Required — there
+            is no default, so a port from another SDK cannot silently change
+            from observe-only to live blocking.
         characteristics: Request attributes used to fingerprint the client
             (e.g. ``["ip.src"]``). Defaults to IP address.
 
@@ -845,9 +871,7 @@ def shield(
     return Shield(mode=_coerce_mode(mode), characteristics=tuple(characteristics))
 
 
-def detect_prompt_injection(
-    *, mode: Union[str, Mode] = Mode.LIVE, threshold: float = 0.5
-) -> PromptInjectionDetection:
+def detect_prompt_injection(*, mode: Union[str, Mode]) -> PromptInjectionDetection:
     """Detect prompt injection attacks in user messages.
 
     Analyzes messages for prompt injection attempts where users try to override
@@ -857,11 +881,7 @@ def detect_prompt_injection(
 
     Args:
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
-            ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
-            ``Mode.LIVE``.
-        threshold: **Deprecated.** Detection confidence threshold (0.0 to 1.0).
-            This parameter is deprecated and will be removed in a future
-            release. Defaults to ``0.5``.
+            ``Mode.DRY_RUN`` logs matches without blocking. Required.
 
     Returns:
         A ``PromptInjectionDetection`` rule to include in the ``rules`` list of
@@ -882,7 +902,7 @@ def detect_prompt_injection(
             # Handle detected prompt injection
             return {"error": "Invalid message"}, 400
     """
-    return PromptInjectionDetection(mode=_coerce_mode(mode), threshold=float(threshold))
+    return PromptInjectionDetection(mode=_coerce_mode(mode))
 
 
 def _coerce_bot_categories(
@@ -906,9 +926,9 @@ def _coerce_bot_categories(
 
 def detect_bot(
     *,
-    mode: Union[str, Mode] = Mode.LIVE,
-    allow: Sequence[Union[str, BotCategory]] = (),
-    deny: Sequence[Union[str, BotCategory]] = (),
+    mode: Union[str, Mode],
+    allow: Sequence[Union[str, BotCategory]] | None = None,
+    deny: Sequence[Union[str, BotCategory]] | None = None,
 ) -> BotDetection:
     """Detect and filter automated bot traffic.
 
@@ -925,12 +945,12 @@ def detect_bot(
 
     Args:
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
-            ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
-            ``Mode.LIVE``.
-        allow: Bots to permit. All other bots are denied. Do not combine
-            with ``deny``.
+            ``Mode.DRY_RUN`` logs matches without blocking. Required.
+        allow: Bots to permit. All other bots are denied. An empty list
+            denies every bot. Do not combine with ``deny``.
         deny: Bots to block. All other bots are allowed. Do not combine
-            with ``allow``.
+            with ``allow``. Exactly one of ``allow`` or ``deny`` must be
+            provided.
 
     Returns:
         A ``BotDetection`` rule to include in the ``rules`` list of
@@ -948,16 +968,17 @@ def detect_bot(
             )
         ]
     """
+    _require_allow_xor_deny(allow, deny, name="detect_bot")
     return BotDetection(
         mode=_coerce_mode(mode),
-        allow=_coerce_bot_categories(allow),
-        deny=_coerce_bot_categories(deny),
+        allow=_coerce_bot_categories(allow) if allow is not None else None,
+        deny=_coerce_bot_categories(deny) if deny is not None else None,
     )
 
 
 def token_bucket(
     *,
-    mode: Union[str, Mode] = Mode.LIVE,
+    mode: Union[str, Mode],
     refill_rate: int,
     interval: int,
     capacity: int,
@@ -975,8 +996,7 @@ def token_bucket(
 
     Args:
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
-            ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
-            ``Mode.LIVE``.
+            ``Mode.DRY_RUN`` logs matches without blocking. Required.
         refill_rate: Number of tokens added to the bucket each interval.
         interval: How often (in seconds) tokens are refilled.
         capacity: Maximum number of tokens the bucket can hold.
@@ -1023,7 +1043,7 @@ def token_bucket(
 
 def fixed_window(
     *,
-    mode: Union[str, Mode] = Mode.LIVE,
+    mode: Union[str, Mode],
     max: int,
     window: int,
     characteristics: Sequence[str] = (),
@@ -1037,8 +1057,7 @@ def fixed_window(
 
     Args:
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
-            ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
-            ``Mode.LIVE``.
+            ``Mode.DRY_RUN`` logs matches without blocking. Required.
         max: Maximum number of requests allowed per window.
         window: Window duration in seconds.
         characteristics: Request attributes used to identify the client for
@@ -1070,7 +1089,7 @@ def fixed_window(
 
 def sliding_window(
     *,
-    mode: Union[str, Mode] = Mode.LIVE,
+    mode: Union[str, Mode],
     max: int,
     interval: int,
     characteristics: Sequence[str] = (),
@@ -1083,8 +1102,7 @@ def sliding_window(
 
     Args:
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
-            ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
-            ``Mode.LIVE``.
+            ``Mode.DRY_RUN`` logs matches without blocking. Required.
         max: Maximum number of requests allowed per window.
         interval: Window duration in seconds.
         characteristics: Request attributes used to identify the client for
@@ -1137,9 +1155,9 @@ def _coerce_email_types(
 
 def validate_email(
     *,
-    mode: Union[str, Mode] = Mode.LIVE,
-    deny: Sequence[Union[str, EmailType]] = (),
-    allow: Sequence[Union[str, EmailType]] = (),
+    mode: Union[str, Mode],
+    deny: Sequence[Union[str, EmailType]] | None = None,
+    allow: Sequence[Union[str, EmailType]] | None = None,
     require_top_level_domain: bool = True,
     allow_domain_literal: bool = False,
 ) -> EmailValidation:
@@ -1154,10 +1172,10 @@ def validate_email(
 
     Args:
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
-            ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
-            ``Mode.LIVE``.
+            ``Mode.DRY_RUN`` logs matches without blocking. Required.
         deny: Email types to reject. Common choices: ``EmailType.DISPOSABLE``,
-            ``EmailType.INVALID``, ``EmailType.NO_MX_RECORDS``.
+            ``EmailType.INVALID``, ``EmailType.NO_MX_RECORDS``. Exactly one of
+            ``allow`` or ``deny`` must be provided.
         allow: Email types to permit. All other types are rejected.
         require_top_level_domain: Reject addresses without a valid TLD.
             Defaults to ``True``.
@@ -1181,10 +1199,11 @@ def validate_email(
         # Then pass the email address on each protect() call:
         # decision = await aj.protect(request, email="alice@example.com")
     """
+    _require_allow_xor_deny(allow, deny, name="validate_email")
     return EmailValidation(
         mode=_coerce_mode(mode),
-        deny=_coerce_email_types(deny),
-        allow=_coerce_email_types(allow),
+        deny=_coerce_email_types(deny) if deny is not None else None,
+        allow=_coerce_email_types(allow) if allow is not None else None,
         require_top_level_domain=require_top_level_domain,
         allow_domain_literal=allow_domain_literal,
     )
@@ -1192,7 +1211,7 @@ def validate_email(
 
 def detect_sensitive_info(
     *,
-    mode: Union[str, Mode] = Mode.LIVE,
+    mode: Union[str, Mode],
     allow: Sequence[Union[str, SensitiveInfoEntityType]] = (),
     deny: Sequence[Union[str, SensitiveInfoEntityType]] = (),
     context_window_size: int | None = None,
@@ -1213,8 +1232,7 @@ def detect_sensitive_info(
 
     Args:
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
-            ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
-            ``Mode.LIVE``.
+            ``Mode.DRY_RUN`` logs matches without blocking. Required.
         allow: Entity types to permit. All other detected types are denied.
         deny: Entity types to deny.
         context_window_size: Optional context window size for detection.
@@ -1309,7 +1327,7 @@ def detect_sensitive_info(
 
 def filter_request(
     *,
-    mode: Union[str, Mode] = Mode.LIVE,
+    mode: Union[str, Mode],
     allow: Sequence[str] = (),
     deny: Sequence[str] = (),
 ) -> Filter:
@@ -1335,8 +1353,7 @@ def filter_request(
 
     Args:
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
-            ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
-            ``Mode.LIVE``.
+            ``Mode.DRY_RUN`` logs matches without blocking. Required.
         allow: Expressions that allow a request when matched. All other
             requests are denied. Do not combine with ``deny``.
         deny: Expressions that deny a request when matched. All other
@@ -1360,4 +1377,62 @@ def filter_request(
         mode=_coerce_mode(mode),
         allow=tuple(str(e) for e in allow),
         deny=tuple(str(e) for e in deny),
+    )
+
+
+def protect_signup(
+    *,
+    rate_limit: Mapping[str, Any],
+    bots: Mapping[str, Any],
+    email: Mapping[str, Any],
+) -> tuple[SlidingWindow, BotDetection, EmailValidation]:
+    """Signup protection: sliding window + bot detection + email validation.
+
+    Sugar over the three rules the JS ``protectSignup`` helper composes.
+    Returns a tuple you can unpack into ``arcjet(..., rules=...)`` or pass
+    to ``with_rule()``.
+
+    Args:
+        rate_limit: Options forwarded to ``sliding_window()``. Requires
+            ``mode``, ``max``, and ``interval``.
+        bots: Options forwarded to ``detect_bot()``. Requires ``mode`` and
+            either ``allow`` or ``deny``. Use ``allow=[]`` to block every
+            detected bot.
+        email: Options forwarded to ``validate_email()``. Requires ``mode``
+            and either ``allow`` or ``deny``.
+
+    Returns:
+        ``(sliding_window, detect_bot, validate_email)`` rule specs.
+
+    Example::
+
+        from arcjet import (
+            EmailType,
+            Mode,
+            arcjet,
+            protect_signup,
+        )
+
+        aj = arcjet(
+            key="ajkey_...",
+            rules=[
+                *protect_signup(
+                    rate_limit={"mode": Mode.LIVE, "max": 5, "interval": 600},
+                    bots={"mode": Mode.LIVE, "allow": []},
+                    email={
+                        "mode": Mode.LIVE,
+                        "deny": [
+                            EmailType.DISPOSABLE,
+                            EmailType.INVALID,
+                            EmailType.NO_MX_RECORDS,
+                        ],
+                    },
+                )
+            ],
+        )
+    """
+    return (
+        sliding_window(**dict(rate_limit)),
+        detect_bot(**dict(bots)),
+        validate_email(**dict(email)),
     )

--- a/src/arcjet/guard/_client.py
+++ b/src/arcjet/guard/_client.py
@@ -952,7 +952,11 @@ def launch_arcjet(
     """Create an async Arcjet Guard client.
 
     Args:
-        key: Your Arcjet site key.
+        key: Your Arcjet site key. Required and must be passed explicitly —
+            Guard never reads ``ARCJET_KEY`` (or any other environment
+            variable) for credentials. This matches the JavaScript Guard
+            SDK. The Go Guard SDK falls back to ``ARCJET_KEY`` when ``Key``
+            is empty; Python does not.
         base_url: Override the Arcjet API endpoint.
         timeout_ms: Request timeout in milliseconds (default 2000).
         logger: Where to report capture diagnostics — dropped events, failed
@@ -1007,7 +1011,11 @@ def launch_arcjet_sync(
     """Create a sync Arcjet Guard client.
 
     Args:
-        key: Your Arcjet site key.
+        key: Your Arcjet site key. Required and must be passed explicitly —
+            Guard never reads ``ARCJET_KEY`` (or any other environment
+            variable) for credentials. This matches the JavaScript Guard
+            SDK. The Go Guard SDK falls back to ``ARCJET_KEY`` when ``Key``
+            is empty; Python does not.
         base_url: Override the Arcjet API endpoint.
         timeout_ms: Request timeout in milliseconds (default 2000).
         logger: Where to report capture diagnostics — dropped events, failed

--- a/tests/benchmarks/bench_protect.py
+++ b/tests/benchmarks/bench_protect.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 from arcjet._client import ArcjetSync
 from arcjet._context import RequestContext
 from arcjet._enums import Mode
-from arcjet._rules import (
+from arcjet._rules import Mode, (
     BotDetection,
     EmailType,
     EmailValidation,
@@ -41,7 +41,7 @@ def _make_aj(mock_client: MagicMock, *rules) -> ArcjetSync:
 def test_bench_protect_no_local_rules(
     benchmark, mock_decide_client: MagicMock, bot_ctx: RequestContext
 ):
-    """Baseline: shield() only, no WASM, mocked remote."""
+    """Baseline: shield(mode=Mode.LIVE) only, no WASM, mocked remote."""
     aj = _make_aj(mock_decide_client, Shield(mode=Mode.LIVE))
     benchmark(aj.protect, bot_ctx)
 

--- a/tests/benchmarks/bench_protect.py
+++ b/tests/benchmarks/bench_protect.py
@@ -15,12 +15,7 @@ from unittest.mock import MagicMock
 from arcjet._client import ArcjetSync
 from arcjet._context import RequestContext
 from arcjet._enums import Mode
-from arcjet._rules import Mode, (
-    BotDetection,
-    EmailType,
-    EmailValidation,
-    Shield,
-)
+from arcjet._rules import BotDetection, EmailType, EmailValidation, Shield
 
 
 def _make_aj(mock_client: MagicMock, *rules) -> ArcjetSync:

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -22,7 +22,7 @@ from arcjet._analyze import (
 from arcjet._context import RequestContext
 from arcjet._enums import Mode
 from arcjet._local import _get_component
-from arcjet._rules import BotDetection, EmailType, EmailValidation, Shield
+from arcjet._rules import BotDetection, EmailType, EmailValidation, Mode, Shield
 
 # ---------------------------------------------------------------------------
 # WASM component fixtures

--- a/tests/fixtures/protobuf_stubs.py
+++ b/tests/fixtures/protobuf_stubs.py
@@ -6,6 +6,7 @@ It uses proper fixture scoping to avoid cross-contamination between tests.
 
 from __future__ import annotations
 
+import copy
 import sys
 import types
 from collections.abc import Generator
@@ -98,7 +99,7 @@ class StubShieldRule:
 class StubPromptInjectionDetectionRule:
     """Stub for protobuf PromptInjectionDetectionRule message."""
 
-    def __init__(self, mode: int, threshold: float) -> None:
+    def __init__(self, mode: int, threshold: float = 0.0) -> None:
         self.mode = mode
         self.threshold = threshold
 
@@ -274,6 +275,27 @@ class StubRuleResult:
         self.ttl = ttl
 
 
+class StubRateLimitReason:
+    """Stub for protobuf RateLimitReason message."""
+
+    def __init__(
+        self,
+        max: int = 0,
+        remaining: int = 0,
+        reset_in_seconds: int = 0,
+        window_in_seconds: int = 0,
+        reset_time: Any = None,
+    ) -> None:
+        self.max = max
+        self.remaining = remaining
+        self.reset_in_seconds = reset_in_seconds
+        self.window_in_seconds = window_in_seconds
+        self.reset_time = reset_time
+
+    def HasField(self, name: str) -> bool:
+        return name == "reset_time" and self.reset_time is not None
+
+
 class StubDecision:
     """Stub for protobuf Decision message."""
 
@@ -294,6 +316,16 @@ class StubDecision:
         self.ip = ip
         self.ip_details = ip_details
         self.rule_results: list[StubRuleResult] = list(rule_results or [])
+
+    def CopyFrom(self, other: StubDecision) -> None:
+        """Copy fields from *other* so cache hits can clone without aliasing."""
+        self.id = other.id
+        self.conclusion = other.conclusion
+        self.ttl = other.ttl
+        self.reason = copy.deepcopy(other.reason)
+        self.ip = other.ip
+        self.ip_details = copy.deepcopy(other.ip_details)
+        self.rule_results = copy.deepcopy(other.rule_results)
 
     def HasField(self, name: str) -> bool:
         """Check if a field has a value."""
@@ -522,6 +554,7 @@ def mock_protobuf_modules(
         Rule=StubRule,
         PromptInjectionReason=StubPromptInjectionReason,
         ErrorReason=StubErrorReason,
+        RateLimitReason=StubRateLimitReason,
         Reason=StubReason,
         IpDetails=StubIpDetails,
         RuleResult=StubRuleResult,

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -15,26 +15,26 @@ from arcjet._rules import Filter, filter_request
 from arcjet.proto.decide.v1alpha1 import decide_pb2
 
 # ---------------------------------------------------------------------------
-# filter_request() factory — validation
+# filter_request(mode=Mode.LIVE) factory — validation
 # ---------------------------------------------------------------------------
 
 
 class TestFilterRequestFactory:
     def test_creates_rule_with_deny(self):
-        rule = filter_request(deny=['ip.src == "1.2.3.4"'])
+        rule = filter_request(mode=Mode.LIVE, deny=['ip.src == "1.2.3.4"'])
         assert isinstance(rule, Filter)
         assert rule.mode == Mode.LIVE
         assert rule.deny == ('ip.src == "1.2.3.4"',)
         assert rule.allow == ()
 
     def test_creates_rule_with_allow(self):
-        rule = filter_request(allow=['http.host == "example.com"'])
+        rule = filter_request(mode=Mode.LIVE, allow=['http.host == "example.com"'])
         assert isinstance(rule, Filter)
         assert rule.allow == ('http.host == "example.com"',)
         assert rule.deny == ()
 
     def test_default_mode_is_live(self):
-        rule = filter_request(deny=["ip.src == 1"])
+        rule = filter_request(mode=Mode.LIVE, deny=["ip.src == 1"])
         assert rule.mode == Mode.LIVE
 
     def test_dry_run_mode(self):
@@ -43,18 +43,18 @@ class TestFilterRequestFactory:
 
     def test_rejects_both_allow_and_deny(self):
         with pytest.raises(ValueError, match="not both"):
-            filter_request(allow=["a"], deny=["b"])
+            filter_request(mode=Mode.LIVE, allow=["a"], deny=["b"])
 
     def test_rejects_empty_allow_and_deny(self):
         with pytest.raises(ValueError, match="one or more expressions"):
-            filter_request()
+            filter_request(mode=Mode.LIVE)
 
     def test_rejects_empty_string_expression(self):
         with pytest.raises(ValueError, match="cannot be empty"):
-            filter_request(deny=[""])
+            filter_request(mode=Mode.LIVE, deny=[""])
 
     def test_multiple_expressions(self):
-        rule = filter_request(deny=["ip.src == 1", 'http.host == "x"'])
+        rule = filter_request(mode=Mode.LIVE, deny=["ip.src == 1", 'http.host == "x"'])
         assert len(rule.deny) == 2
 
 
@@ -65,14 +65,14 @@ class TestFilterRequestFactory:
 
 class TestFilterToProto:
     def test_deny_to_proto(self):
-        rule = filter_request(deny=['ip.src == "1.2.3.4"'])
+        rule = filter_request(mode=Mode.LIVE, deny=['ip.src == "1.2.3.4"'])
         proto = rule.to_proto()
         assert proto.HasField("filter")
         assert list(proto.filter.deny) == ['ip.src == "1.2.3.4"']
         assert list(proto.filter.allow) == []
 
     def test_allow_to_proto(self):
-        rule = filter_request(allow=['http.host == "example.com"'])
+        rule = filter_request(mode=Mode.LIVE, allow=['http.host == "example.com"'])
         proto = rule.to_proto()
         assert proto.HasField("filter")
         assert list(proto.filter.allow) == ['http.host == "example.com"']
@@ -87,7 +87,7 @@ class TestFilterToProto:
 class TestEvaluateFilterLocally:
     def test_returns_none_when_component_unavailable(self):
         ctx = RequestContext(ip="1.2.3.4")
-        rule = filter_request(deny=["ip.src == 1"])
+        rule = filter_request(mode=Mode.LIVE, deny=["ip.src == 1"])
         with patch("arcjet._local._get_component", return_value=None):
             result = evaluate_filter_locally(ctx, rule)
         assert result is None
@@ -103,7 +103,7 @@ class TestEvaluateFilterLocally:
         )
 
         ctx = RequestContext(ip="1.2.3.4")
-        rule = filter_request(deny=['ip.src == "1.2.3.4"'])
+        rule = filter_request(mode=Mode.LIVE, deny=['ip.src == "1.2.3.4"'])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = evaluate_filter_locally(ctx, rule)
@@ -122,7 +122,7 @@ class TestEvaluateFilterLocally:
         )
 
         ctx = RequestContext(ip="5.6.7.8")
-        rule = filter_request(deny=['ip.src == "1.2.3.4"'])
+        rule = filter_request(mode=Mode.LIVE, deny=['ip.src == "1.2.3.4"'])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = evaluate_filter_locally(ctx, rule)
@@ -141,7 +141,7 @@ class TestEvaluateFilterLocally:
         )
 
         ctx = RequestContext(ip="1.2.3.4")
-        rule = filter_request(allow=['ip.src == "1.2.3.4"'])
+        rule = filter_request(mode=Mode.LIVE, allow=['ip.src == "1.2.3.4"'])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = evaluate_filter_locally(ctx, rule)
@@ -158,7 +158,7 @@ class TestEvaluateFilterLocally:
         )
 
         ctx = RequestContext(ip="5.6.7.8")
-        rule = filter_request(allow=['ip.src == "1.2.3.4"'])
+        rule = filter_request(mode=Mode.LIVE, allow=['ip.src == "1.2.3.4"'])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = evaluate_filter_locally(ctx, rule)
@@ -195,7 +195,7 @@ class TestEvaluateFilterLocally:
         )
 
         ctx = RequestContext(ip="1.2.3.4")
-        rule = filter_request(deny=["ip.src.country == US"])
+        rule = filter_request(mode=Mode.LIVE, deny=["ip.src.country == US"])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = evaluate_filter_locally(ctx, rule)
@@ -214,7 +214,7 @@ class TestEvaluateFilterLocally:
         )
 
         ctx = RequestContext(ip="1.2.3.4", filter_local={"user_role": "admin"})
-        rule = filter_request(allow=['local.user_role == "admin"'])
+        rule = filter_request(mode=Mode.LIVE, allow=['local.user_role == "admin"'])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             evaluate_filter_locally(ctx, rule)
@@ -233,7 +233,7 @@ class TestEvaluateFilterLocally:
         )
 
         ctx = RequestContext(ip="1.2.3.4")
-        rule = filter_request(allow=["x"])
+        rule = filter_request(mode=Mode.LIVE, allow=["x"])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             evaluate_filter_locally(ctx, rule)
@@ -250,7 +250,7 @@ class TestEvaluateFilterLocally:
         )
 
         ctx = RequestContext(ip="1.2.3.4")
-        rule = filter_request(deny=["x"])
+        rule = filter_request(mode=Mode.LIVE, deny=["x"])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             evaluate_filter_locally(ctx, rule)
@@ -262,7 +262,7 @@ class TestEvaluateFilterLocally:
         mock_component.match_filters.return_value = Err("parse error")
 
         ctx = RequestContext(ip="1.2.3.4")
-        rule = filter_request(deny=["bad expression"])
+        rule = filter_request(mode=Mode.LIVE, deny=["bad expression"])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = evaluate_filter_locally(ctx, rule)
@@ -274,7 +274,7 @@ class TestEvaluateFilterLocally:
         mock_component.match_filters.side_effect = RuntimeError("wasm error")
 
         ctx = RequestContext(ip="1.2.3.4")
-        rule = filter_request(deny=["x"])
+        rule = filter_request(mode=Mode.LIVE, deny=["x"])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = evaluate_filter_locally(ctx, rule)
@@ -286,7 +286,7 @@ class TestEvaluateFilterLocally:
 
         # Pass a non-JSON-serializable value in filter_local
         ctx = RequestContext(ip="1.2.3.4", filter_local={"key": object()})  # type: ignore[arg-type]
-        rule = filter_request(deny=["x"])
+        rule = filter_request(mode=Mode.LIVE, deny=["x"])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = evaluate_filter_locally(ctx, rule)
@@ -313,7 +313,7 @@ class TestRunLocalRulesFilter:
             ),
         )
         ctx = RequestContext(ip="1.2.3.4")
-        rule = filter_request(deny=['ip.src == "1.2.3.4"'])
+        rule = filter_request(mode=Mode.LIVE, deny=['ip.src == "1.2.3.4"'])
 
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=None),

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -146,9 +146,7 @@ class TestGetComponent:
 class TestEvaluateBotLocally:
     def test_returns_none_when_component_unavailable(self):
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
         with patch("arcjet._local._get_component", return_value=None):
             result = _local.evaluate_bot_locally(ctx, rule)
         assert result is None
@@ -163,9 +161,7 @@ class TestEvaluateBotLocally:
         ctx = RequestContext(
             ip="1.2.3.4", headers={"User-Agent": "curl/7.0"}, method="GET"
         )
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=("CURL",), deny=(), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, allow=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -184,9 +180,7 @@ class TestEvaluateBotLocally:
         ctx = RequestContext(
             ip="1.2.3.4", headers={"User-Agent": "curl/7.0"}, method="GET"
         )
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -203,9 +197,7 @@ class TestEvaluateBotLocally:
         mock_component.detect_bot.return_value = Ok(bot_result)
 
         ctx = RequestContext(ip="1.2.3.4", method="GET")
-        rule = BotDetection(
-            mode=Mode.DRY_RUN, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.DRY_RUN, deny=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -219,9 +211,7 @@ class TestEvaluateBotLocally:
         mock_component.detect_bot.side_effect = RuntimeError("wasm error")
 
         ctx = RequestContext(ip="1.2.3.4", method="GET")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -233,9 +223,7 @@ class TestEvaluateBotLocally:
         mock_component.detect_bot.return_value = Err("some error")
 
         ctx = RequestContext(ip="1.2.3.4", method="GET")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -253,8 +241,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -267,8 +254,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext()
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -285,8 +271,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -306,8 +291,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="bad-email")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -327,8 +311,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@disposable.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -351,8 +334,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="bad@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -376,8 +358,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -397,7 +378,6 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
             allow=(EmailType.DISPOSABLE,),
             require_top_level_domain=True,
             allow_domain_literal=False,
@@ -426,7 +406,6 @@ class TestEvaluateEmailLocally:
         rule = EmailValidation(
             mode=Mode.LIVE,
             deny=(EmailType.DISPOSABLE, EmailType.FREE),
-            allow=(),
             require_top_level_domain=False,
             allow_domain_literal=True,
             characteristics=(),
@@ -454,7 +433,7 @@ class TestEvaluateEmailLocally:
             ip="1.2.3.4", headers={"User-Agent": "curl/7.0"}, method="GET"
         )
         rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL", "GOOGLEBOT"), characteristics=()
+            mode=Mode.LIVE, deny=("CURL", "GOOGLEBOT"), characteristics=()
         )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
@@ -477,9 +456,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(
             ip="1.2.3.4", headers={"User-Agent": "curl/7.0"}, method="GET"
         )
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=("CURL",), deny=(), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, allow=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             _local.evaluate_bot_locally(ctx, rule)
@@ -513,9 +490,7 @@ class TestRunLocalRules:
             conclusion=decide_pb2.CONCLUSION_ALLOW,
         )
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=("CURL",), deny=(), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, allow=("CURL",), characteristics=())
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=allow_result),
             patch("arcjet._client.evaluate_email_locally", return_value=None),
@@ -531,9 +506,7 @@ class TestRunLocalRules:
             reason=decide_pb2.Reason(bot_v2=decide_pb2.BotV2Reason(denied=["CURL"])),
         )
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=deny_result),
             patch("arcjet._client.evaluate_email_locally", return_value=None),
@@ -549,9 +522,7 @@ class TestRunLocalRules:
             conclusion=decide_pb2.CONCLUSION_DENY,
         )
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.DRY_RUN, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.DRY_RUN, deny=("CURL",), characteristics=())
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=deny_dry_run),
             patch("arcjet._client.evaluate_email_locally", return_value=None),
@@ -562,9 +533,7 @@ class TestRunLocalRules:
     def test_returns_none_when_evaluator_returns_none(self):
         """When WASM component fails to load, evaluators return None."""
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=None),
             patch("arcjet._client.evaluate_email_locally", return_value=None),
@@ -587,9 +556,7 @@ class TestBuildLocalDenyReport:
         )
         local_decision = Decision(deny_proto)
         ctx = RequestContext(ip="1.2.3.4", method="GET")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
 
         rep = _build_local_deny_report(None, "0.4.1", ctx, local_decision, (rule,))
 
@@ -608,11 +575,10 @@ class TestBuildLocalDenyReport:
         local_decision = Decision(deny_proto)
         ctx = RequestContext(ip="1.2.3.4")
         rules = (
-            BotDetection(mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()),
+            BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=()),
             EmailValidation(
                 mode=Mode.LIVE,
-                deny=(),
-                allow=(),
+                deny=(EmailType.INVALID,),
                 require_top_level_domain=True,
                 allow_domain_literal=False,
                 characteristics=(),

--- a/tests/test_sensitive_info.py
+++ b/tests/test_sensitive_info.py
@@ -35,7 +35,7 @@ from arcjet._rules import (
 from arcjet.proto.decide.v1alpha1 import decide_pb2
 
 # ---------------------------------------------------------------------------
-# detect_sensitive_info() factory — validation
+# detect_sensitive_info(mode=Mode.LIVE) factory — validation
 # ---------------------------------------------------------------------------
 
 
@@ -45,6 +45,7 @@ class TestDetectSensitiveInfoFactory:
     def test_creates_rule_with_deny(self):
         """JS: 'allows specifying sensitive info entities to allow'."""
         rule = detect_sensitive_info(
+            mode=Mode.LIVE,
             deny=[
                 SensitiveInfoEntityType.EMAIL,
                 SensitiveInfoEntityType.CREDIT_CARD_NUMBER,
@@ -57,6 +58,7 @@ class TestDetectSensitiveInfoFactory:
 
     def test_creates_rule_with_allow(self):
         rule = detect_sensitive_info(
+            mode=Mode.LIVE,
             allow=[SensitiveInfoEntityType.EMAIL, SensitiveInfoEntityType.PHONE_NUMBER],
         )
         assert isinstance(rule, SensitiveInfoDetection)
@@ -64,15 +66,17 @@ class TestDetectSensitiveInfoFactory:
         assert rule.deny == ()
 
     def test_accepts_string_entity_types(self):
-        rule = detect_sensitive_info(deny=["EMAIL", "CUSTOM_TYPE"])
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL", "CUSTOM_TYPE"])
         assert rule.deny == ("EMAIL", "CUSTOM_TYPE")
 
     def test_accepts_enum_entity_types(self):
-        rule = detect_sensitive_info(deny=[SensitiveInfoEntityType.EMAIL])
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=[SensitiveInfoEntityType.EMAIL]
+        )
         assert rule.deny == (SensitiveInfoEntityType.EMAIL,)
 
     def test_default_mode_is_live(self):
-        rule = detect_sensitive_info(deny=["EMAIL"])
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"])
         assert rule.mode == Mode.LIVE
 
     def test_dry_run_mode(self):
@@ -84,17 +88,21 @@ class TestDetectSensitiveInfoFactory:
         assert rule.mode == Mode.DRY_RUN
 
     def test_context_window_size(self):
-        rule = detect_sensitive_info(deny=["EMAIL"], context_window_size=3)
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=["EMAIL"], context_window_size=3
+        )
         assert rule.context_window_size == 3
 
     def test_characteristics(self):
-        rule = detect_sensitive_info(deny=["EMAIL"], characteristics=["user_id"])
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=["EMAIL"], characteristics=["user_id"]
+        )
         assert rule.characteristics == ("user_id",)
 
     def test_empty_string_entity_rejected(self):
         """JS: validates entity types contain non-empty strings."""
         with pytest.raises(ValueError, match="cannot be empty"):
-            detect_sensitive_info(deny=[""])
+            detect_sensitive_info(mode=Mode.LIVE, deny=[""])
 
 
 class _StubBackend:
@@ -114,41 +122,49 @@ class TestBackendOption:
 
     def test_factory_stores_backend(self):
         backend = _StubBackend()
-        rule = detect_sensitive_info(deny=["EMAIL"], backend=backend)
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"], backend=backend)
         assert rule.backend is backend
 
     def test_factory_default_backend_is_none(self):
-        rule = detect_sensitive_info(deny=["EMAIL"])
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"])
         assert rule.backend is None
 
     def test_backend_only_type_without_backend_raises(self):
         with pytest.raises(ValueError, match="GIVEN_NAME"):
-            detect_sensitive_info(deny=[SensitiveInfoEntityType.GIVEN_NAME])
+            detect_sensitive_info(
+                mode=Mode.LIVE, deny=[SensitiveInfoEntityType.GIVEN_NAME]
+            )
 
     def test_backend_only_type_in_allow_without_backend_raises(self):
         # Validation covers the allow list too, not just deny.
         with pytest.raises(ValueError, match="GIVEN_NAME"):
-            detect_sensitive_info(allow=[SensitiveInfoEntityType.GIVEN_NAME])
+            detect_sensitive_info(
+                mode=Mode.LIVE, allow=[SensitiveInfoEntityType.GIVEN_NAME]
+            )
 
     def test_backend_only_type_lists_all_unsupported(self):
         with pytest.raises(ValueError, match="SSN.*GIVEN_NAME|GIVEN_NAME.*SSN"):
-            detect_sensitive_info(deny=["GIVEN_NAME", "SSN", "EMAIL"])
+            detect_sensitive_info(mode=Mode.LIVE, deny=["GIVEN_NAME", "SSN", "EMAIL"])
 
     def test_backend_only_type_with_backend_ok(self):
         rule = detect_sensitive_info(
-            deny=[SensitiveInfoEntityType.GIVEN_NAME], backend=_StubBackend()
+            mode=Mode.LIVE,
+            deny=[SensitiveInfoEntityType.GIVEN_NAME],
+            backend=_StubBackend(),
         )
         assert rule.deny == (SensitiveInfoEntityType.GIVEN_NAME,)
 
     def test_backend_only_type_with_custom_detect_ok(self):
         rule = detect_sensitive_info(
-            deny=["GIVEN_NAME"], detect=lambda tokens: [None] * len(tokens)
+            mode=Mode.LIVE,
+            deny=["GIVEN_NAME"],
+            detect=lambda tokens: [None] * len(tokens),
         )
         assert rule.deny == ("GIVEN_NAME",)
 
     def test_custom_string_type_without_backend_ok(self):
         # Free-form custom strings (not built-in backend-only types) still pass.
-        rule = detect_sensitive_info(deny=["MY_CUSTOM_TYPE"])
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["MY_CUSTOM_TYPE"])
         assert rule.deny == ("MY_CUSTOM_TYPE",)
 
     def test_non_callable_backend_rejected(self):
@@ -200,7 +216,7 @@ class TestBackendOption:
             )
         )
         ctx = RequestContext(sensitive_info_value="Alex")
-        rule = detect_sensitive_info(deny=["GIVEN_NAME"], backend=stub)
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["GIVEN_NAME"], backend=stub)
 
         # No WASM component is needed when a backend is provided.
         with patch("arcjet._local._get_component", return_value=None):
@@ -218,7 +234,9 @@ class TestBackendOption:
                 raise RuntimeError("backend failed")
 
         ctx = RequestContext(sensitive_info_value="Alex")
-        rule = detect_sensitive_info(deny=["GIVEN_NAME"], backend=Boom())
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=["GIVEN_NAME"], backend=Boom()
+        )
         result = evaluate_sensitive_info_locally(ctx, rule)
         assert result is None
 
@@ -232,6 +250,7 @@ class TestBackendOption:
 
         ctx = RequestContext(sensitive_info_value="Alex")
         rule = detect_sensitive_info(
+            mode=Mode.LIVE,
             deny=["GIVEN_NAME"],
             backend=Malformed(),  # pyright: ignore[reportArgumentType]
         )
@@ -254,7 +273,7 @@ class TestBackendOption:
             )
         )
         ctx = RequestContext(sensitive_info_value="Alex")
-        rule = detect_sensitive_info(deny=["GIVEN_NAME"], backend=stub)
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["GIVEN_NAME"], backend=stub)
         result = evaluate_sensitive_info_locally(ctx, rule)
         assert result is not None
         assert result.conclusion == decide_pb2.CONCLUSION_ALLOW
@@ -278,7 +297,9 @@ class TestBackendOption:
             )
         )
         ctx = RequestContext(sensitive_info_value="Alex")
-        rule = detect_sensitive_info(deny=["MY_CUSTOM_TYPE"], backend=stub)
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=["MY_CUSTOM_TYPE"], backend=stub
+        )
         result = evaluate_sensitive_info_locally(ctx, rule)
         assert result is not None
         assert result.conclusion == decide_pb2.CONCLUSION_DENY
@@ -324,6 +345,7 @@ class TestSensitiveInfoDetectionValidation:
 class TestSensitiveInfoToProto:
     def test_deny_to_proto(self):
         rule = detect_sensitive_info(
+            mode=Mode.LIVE,
             deny=[
                 SensitiveInfoEntityType.EMAIL,
                 SensitiveInfoEntityType.CREDIT_CARD_NUMBER,
@@ -336,6 +358,7 @@ class TestSensitiveInfoToProto:
 
     def test_allow_to_proto(self):
         rule = detect_sensitive_info(
+            mode=Mode.LIVE,
             allow=[SensitiveInfoEntityType.EMAIL, SensitiveInfoEntityType.PHONE_NUMBER],
         )
         proto = rule.to_proto()
@@ -344,7 +367,7 @@ class TestSensitiveInfoToProto:
         assert list(proto.sensitive_info.deny) == []
 
     def test_custom_entity_type_to_proto(self):
-        rule = detect_sensitive_info(deny=["CUSTOM_SSN"])
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["CUSTOM_SSN"])
         proto = rule.to_proto()
         assert list(proto.sensitive_info.deny) == ["CUSTOM_SSN"]
 
@@ -360,7 +383,9 @@ class TestEvaluateSensitiveInfoLocally:
 
     def test_returns_none_when_component_unavailable(self):
         ctx = RequestContext(sensitive_info_value="test@example.com")
-        rule = detect_sensitive_info(deny=[SensitiveInfoEntityType.EMAIL])
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=[SensitiveInfoEntityType.EMAIL]
+        )
         with patch("arcjet._local._get_component", return_value=None):
             result = evaluate_sensitive_info_locally(ctx, rule)
         assert result is None
@@ -369,7 +394,9 @@ class TestEvaluateSensitiveInfoLocally:
         """JS: 'it returns an error decision when body is not available'.
         In Python, missing content means the evaluator returns None (skip)."""
         ctx = RequestContext()
-        rule = detect_sensitive_info(deny=[SensitiveInfoEntityType.EMAIL])
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=[SensitiveInfoEntityType.EMAIL]
+        )
         with patch("arcjet._local._get_component", return_value=MagicMock()):
             result = evaluate_sensitive_info_locally(ctx, rule)
         assert result is None
@@ -662,7 +689,9 @@ class TestEvaluateSensitiveInfoLocally:
         mock_component.detect_sensitive_info.side_effect = RuntimeError("wasm error")
 
         ctx = RequestContext(sensitive_info_value="test@example.com")
-        rule = detect_sensitive_info(deny=[SensitiveInfoEntityType.EMAIL])
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=[SensitiveInfoEntityType.EMAIL]
+        )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = evaluate_sensitive_info_locally(ctx, rule)
@@ -678,7 +707,8 @@ class TestEvaluateSensitiveInfoLocally:
 
         ctx = RequestContext(sensitive_info_value="test content")
         rule = detect_sensitive_info(
-            allow=[SensitiveInfoEntityType.EMAIL, SensitiveInfoEntityType.PHONE_NUMBER]
+            mode=Mode.LIVE,
+            allow=[SensitiveInfoEntityType.EMAIL, SensitiveInfoEntityType.PHONE_NUMBER],
         )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
@@ -702,10 +732,11 @@ class TestEvaluateSensitiveInfoLocally:
 
         ctx = RequestContext(sensitive_info_value="test content")
         rule = detect_sensitive_info(
+            mode=Mode.LIVE,
             deny=[
                 SensitiveInfoEntityType.CREDIT_CARD_NUMBER,
                 SensitiveInfoEntityType.IP_ADDRESS,
-            ]
+            ],
         )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
@@ -729,7 +760,7 @@ class TestEvaluateSensitiveInfoLocally:
         )
 
         ctx = RequestContext(sensitive_info_value="my email is test@example.com")
-        rule = detect_sensitive_info(allow=[], context_window_size=3)
+        rule = detect_sensitive_info(mode=Mode.LIVE, allow=[], context_window_size=3)
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             evaluate_sensitive_info_locally(ctx, rule)
@@ -745,7 +776,7 @@ class TestEvaluateSensitiveInfoLocally:
         )
 
         ctx = RequestContext(sensitive_info_value="test")
-        rule = detect_sensitive_info(deny=["MY_CUSTOM_TYPE"])
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["MY_CUSTOM_TYPE"])
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             evaluate_sensitive_info_locally(ctx, rule)
@@ -781,7 +812,9 @@ class TestRunLocalRulesSensitiveInfo:
             ),
         )
         ctx = RequestContext(sensitive_info_value="test@example.com")
-        rule = detect_sensitive_info(deny=[SensitiveInfoEntityType.EMAIL])
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=[SensitiveInfoEntityType.EMAIL]
+        )
 
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=None),
@@ -823,7 +856,9 @@ class TestRunLocalRulesSensitiveInfo:
     def test_returns_none_when_evaluator_returns_none(self):
         """When WASM component fails, evaluator returns None → proceed to remote."""
         ctx = RequestContext(sensitive_info_value="test@example.com")
-        rule = detect_sensitive_info(deny=[SensitiveInfoEntityType.EMAIL])
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=[SensitiveInfoEntityType.EMAIL]
+        )
 
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=None),
@@ -844,16 +879,16 @@ class TestDetectCallback:
     """Tests for the custom detect callback on SensitiveInfoDetection."""
 
     def test_factory_accepts_detect_callback(self):
-        """detect_sensitive_info() stores the callback on the rule."""
+        """detect_sensitive_info(mode=Mode.LIVE) stores the callback on the rule."""
 
         def my_detect(tokens: list[str]) -> list[str | None]:
             return [None] * len(tokens)
 
-        rule = detect_sensitive_info(deny=["CUSTOM"], detect=my_detect)
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["CUSTOM"], detect=my_detect)
         assert rule.detect is my_detect
 
     def test_factory_default_detect_is_none(self):
-        rule = detect_sensitive_info(deny=["EMAIL"])
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"])
         assert rule.detect is None
 
     def test_skip_custom_detect_true_without_callback(self):
@@ -864,7 +899,9 @@ class TestDetectCallback:
         )
 
         ctx = RequestContext(sensitive_info_value="test")
-        rule = detect_sensitive_info(deny=[SensitiveInfoEntityType.EMAIL])
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=[SensitiveInfoEntityType.EMAIL]
+        )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             evaluate_sensitive_info_locally(ctx, rule)
@@ -881,7 +918,7 @@ class TestDetectCallback:
 
         ctx = RequestContext(sensitive_info_value="test")
         rule = detect_sensitive_info(
-            deny=["CUSTOM"], detect=lambda tokens: [None] * len(tokens)
+            mode=Mode.LIVE, deny=["CUSTOM"], detect=lambda tokens: [None] * len(tokens)
         )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
@@ -899,7 +936,7 @@ class TestDetectCallback:
 
         ctx = RequestContext(sensitive_info_value="test")
         rule = detect_sensitive_info(
-            deny=["CUSTOM"], detect=lambda tokens: [None] * len(tokens)
+            mode=Mode.LIVE, deny=["CUSTOM"], detect=lambda tokens: [None] * len(tokens)
         )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
@@ -918,7 +955,9 @@ class TestDetectCallback:
         )
 
         ctx = RequestContext(sensitive_info_value="test")
-        rule = detect_sensitive_info(deny=[SensitiveInfoEntityType.EMAIL])
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=[SensitiveInfoEntityType.EMAIL]
+        )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             evaluate_sensitive_info_locally(ctx, rule)
@@ -937,7 +976,9 @@ class TestDetectCallback:
             return ["CUSTOM_PII" if "secret" in t else None for t in tokens]
 
         ctx = RequestContext(sensitive_info_value="this is secret data")
-        rule = detect_sensitive_info(deny=["CUSTOM_PII"], detect=my_detect)
+        rule = detect_sensitive_info(
+            mode=Mode.LIVE, deny=["CUSTOM_PII"], detect=my_detect
+        )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             evaluate_sensitive_info_locally(ctx, rule)
@@ -963,7 +1004,7 @@ class TestDetectCallback:
             return ["EMAIL" if "@" in t else None for t in tokens]
 
         ctx = RequestContext(sensitive_info_value="test@example.com hello")
-        rule = detect_sensitive_info(deny=["EMAIL"], detect=my_detect)
+        rule = detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"], detect=my_detect)
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             evaluate_sensitive_info_locally(ctx, rule)

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -31,7 +31,9 @@ def test_cache_set_and_get(mock_protobuf_modules):
         decide_pb2.Decision(id="d1", conclusion=decide_pb2.CONCLUSION_DENY, ttl=10)
     )
     cache.set("k", d, ttl_seconds=10)
-    assert cache.get("k") is d
+    hit = cache.get("k")
+    assert hit is not None
+    assert hit[0] is d
 
 
 def test_cache_get_missing_key(mock_protobuf_modules):
@@ -85,7 +87,9 @@ def test_cache_set_overwrites_existing(mock_protobuf_modules):
     )
     cache.set("k", d1, ttl_seconds=10)
     cache.set("k", d2, ttl_seconds=10)
-    assert cache.get("k") is d2
+    hit = cache.get("k")
+    assert hit is not None
+    assert hit[0] is d2
 
 
 def test_cache_empty_string_key(mock_protobuf_modules):
@@ -98,7 +102,9 @@ def test_cache_empty_string_key(mock_protobuf_modules):
         decide_pb2.Decision(id="d1", conclusion=decide_pb2.CONCLUSION_DENY, ttl=10)
     )
     cache.set("", d, ttl_seconds=10)
-    assert cache.get("") is d
+    hit = cache.get("")
+    assert hit is not None
+    assert hit[0] is d
 
 
 def test_cache_expired_entry_removal_exception(mock_protobuf_modules):
@@ -188,7 +194,7 @@ def test_should_cache_deny_result_with_ttl(
     (JS: "should cache a deny result w/ `ttl`")
     """
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     decide_calls = {"count": 0}
@@ -209,7 +215,7 @@ def test_should_cache_deny_result_with_ttl(
 
     aj = arcjet_sync(
         key="ajkey_test",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
 
     # First call: hits the API
@@ -234,7 +240,7 @@ def test_should_not_cache_allow_result_with_ttl(
     (JS: "should not cache an allow result w/ `ttl`")
     """
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     decide_calls = {"count": 0}
@@ -255,7 +261,7 @@ def test_should_not_cache_allow_result_with_ttl(
 
     aj = arcjet_sync(
         key="ajkey_test",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
 
     d1 = aj.protect({"headers": [], "type": "http"})
@@ -279,7 +285,7 @@ def test_should_not_cache_deny_result_without_ttl(
     (JS: "should not cache a deny result w/o `ttl`")
     """
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     decide_calls = {"count": 0}
@@ -300,7 +306,7 @@ def test_should_not_cache_deny_result_without_ttl(
 
     aj = arcjet_sync(
         key="ajkey_test",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
 
     d1 = aj.protect({"headers": [], "type": "http"})
@@ -323,7 +329,7 @@ def test_should_not_cache_error_result_with_ttl(
     Only DENY decisions are cached, matching JS semantics.
     """
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     decide_calls = {"count": 0}
@@ -344,7 +350,7 @@ def test_should_not_cache_error_result_with_ttl(
 
     aj = arcjet_sync(
         key="ajkey_test",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
 
     d1 = aj.protect({"headers": [], "type": "http"})
@@ -370,7 +376,7 @@ def test_async_should_cache_deny_result_with_ttl(
     import asyncio
 
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     decide_calls = {"count": 0}
@@ -391,7 +397,7 @@ def test_async_should_cache_deny_result_with_ttl(
 
     aj = arcjet(
         key="ajkey_test",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
 
     d1 = asyncio.run(aj.protect({"headers": [], "type": "http"}))
@@ -412,7 +418,7 @@ def test_async_should_not_cache_allow_result_with_ttl(
     import asyncio
 
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     decide_calls = {"count": 0}
@@ -433,7 +439,7 @@ def test_async_should_not_cache_allow_result_with_ttl(
 
     aj = arcjet(
         key="ajkey_test",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
 
     d1 = asyncio.run(aj.protect({"headers": [], "type": "http"}))

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -12,7 +12,7 @@ def test_fail_open_false_raises(mock_protobuf_modules, monkeypatch: pytest.Monke
     """Test that fail_open=False raises ArcjetTransportError on network error."""
     from arcjet import arcjet
     from arcjet._errors import ArcjetTransportError
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     def raise_decide(req):
@@ -23,7 +23,7 @@ def test_fail_open_false_raises(mock_protobuf_modules, monkeypatch: pytest.Monke
     )
     aj = arcjet(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         fail_open=False,
     )
     with pytest.raises(ArcjetTransportError):
@@ -36,9 +36,9 @@ def test_email_required_for_validate_email_rule(mock_protobuf_modules):
     """Test that validate_email rule raises error when email is missing."""
     from arcjet import arcjet
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import validate_email
+    from arcjet._rules import Mode, validate_email
 
-    aj = arcjet(key="ajkey_x", rules=[validate_email()])
+    aj = arcjet(key="ajkey_x", rules=[validate_email(mode=Mode.LIVE, deny=["INVALID"])])
     import asyncio
 
     with pytest.raises(ArcjetMisconfiguration):
@@ -49,9 +49,9 @@ def test_message_required_for_detect_prompt_injection_rule(mock_protobuf_modules
     """Test that detect_prompt_injection rule raises error when message is missing."""
     from arcjet import arcjet
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import detect_prompt_injection
+    from arcjet._rules import Mode, detect_prompt_injection
 
-    aj = arcjet(key="ajkey_x", rules=[detect_prompt_injection()])
+    aj = arcjet(key="ajkey_x", rules=[detect_prompt_injection(mode=Mode.LIVE)])
     import asyncio
 
     with pytest.raises(ArcjetMisconfiguration):
@@ -61,7 +61,7 @@ def test_message_required_for_detect_prompt_injection_rule(mock_protobuf_modules
 def test_fail_open_true_errors(mock_protobuf_modules, monkeypatch: pytest.MonkeyPatch):
     """Test that fail_open=True returns error decision on network error."""
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     def raise_decide(req):
@@ -72,7 +72,7 @@ def test_fail_open_true_errors(mock_protobuf_modules, monkeypatch: pytest.Monkey
     )
     aj = arcjet(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         fail_open=True,
     )
     import asyncio
@@ -93,7 +93,7 @@ def test_requested_default_and_characteristics_in_extra(
 ):
     """Test that requested default and characteristics are passed in extra metadata."""
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     captured = {}
@@ -106,7 +106,7 @@ def test_requested_default_and_characteristics_in_extra(
     monkeypatch.setattr(
         DecideServiceClient, "decide_behavior", capture_decide, raising=False
     )
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet(key="ajkey_x", rules=rules)
     import asyncio
 
@@ -125,7 +125,7 @@ def test_ip_override_with_ip_src(
 ):
     """Test that ip_src overrides automatic IP detection when configured."""
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     captured = {}
@@ -138,7 +138,7 @@ def test_ip_override_with_ip_src(
     monkeypatch.setattr(
         DecideServiceClient, "decide_behavior", capture_decide, raising=False
     )
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet(key="ajkey_x", rules=rules, disable_automatic_ip_detection=True)
     import asyncio
 
@@ -160,7 +160,7 @@ def test_correlation_id_sent_in_decide_request(
 ):
     """correlation_id is forwarded on RequestDetails, not placed in extra."""
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     captured = {}
@@ -174,7 +174,7 @@ def test_correlation_id_sent_in_decide_request(
     monkeypatch.setattr(
         DecideServiceClient, "decide_behavior", capture_decide, raising=False
     )
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet(key="ajkey_x", rules=rules)
     import asyncio
 
@@ -189,9 +189,9 @@ def test_disable_automatic_ip_detection_requires_ip_src(mock_protobuf_modules):
     """Test that ip_src is required when automatic IP detection is disabled."""
     from arcjet import arcjet
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet(key="ajkey_x", rules=rules, disable_automatic_ip_detection=True)
     import asyncio
 
@@ -203,9 +203,9 @@ def test_disable_automatic_ip_detection_with_proxies(mock_protobuf_modules):
     """Test that proxies cannot be used with manual IP detection."""
     from arcjet import arcjet
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet(
         key="ajkey_x",
         rules=rules,
@@ -222,9 +222,9 @@ def test_ip_src_disallowed_when_automatic_ip_detection_enabled(mock_protobuf_mod
     """Test that ip_src cannot be used when automatic IP detection is enabled."""
     from arcjet import arcjet
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet(
         key="ajkey_x",
         rules=rules,
@@ -238,12 +238,12 @@ def test_ip_src_disallowed_when_automatic_ip_detection_enabled(mock_protobuf_mod
 def test_base_url_trailing_slash_is_stripped(mock_protobuf_modules):
     """Test that base_url parameter strips trailing slashes."""
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     # Create client with trailing slash in base_url
     aj = arcjet(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         base_url="https://example.com/",
     )
     # Access the internal client to verify the base_url
@@ -253,12 +253,12 @@ def test_base_url_trailing_slash_is_stripped(mock_protobuf_modules):
 def test_base_url_multiple_trailing_slashes_are_stripped(mock_protobuf_modules):
     """Test that base_url parameter strips multiple trailing slashes."""
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     # Create client with multiple trailing slashes
     aj = arcjet(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         base_url="https://example.com///",
     )
     # Access the internal client to verify the base_url
@@ -268,12 +268,12 @@ def test_base_url_multiple_trailing_slashes_are_stripped(mock_protobuf_modules):
 def test_base_url_without_trailing_slash_unchanged(mock_protobuf_modules):
     """Test that base_url without trailing slash is unchanged."""
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     # Create client without trailing slash
     aj = arcjet(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         base_url="https://example.com",
     )
     # Access the internal client to verify the base_url
@@ -287,14 +287,14 @@ def test_default_base_url_from_env_trailing_slash_is_stripped(
     import importlib
 
     import arcjet._client as client_module
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     with monkeypatch.context() as m:
         m.setenv("ARCJET_BASE_URL", "https://example.com/")
         reloaded_module = importlib.reload(client_module)
         aj = reloaded_module.arcjet(
             key="ajkey_x",
-            rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+            rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         )
         assert getattr(aj._client, "base_url") == "https://example.com"
 
@@ -304,11 +304,11 @@ def test_default_base_url_from_env_trailing_slash_is_stripped(
 def test_default_timeout_is_2000_ms(mock_protobuf_modules):
     """Test that the default timeout is 2000ms for every rule set."""
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     aj = arcjet(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
     assert aj._timeout_ms == 2000
 
@@ -316,11 +316,11 @@ def test_default_timeout_is_2000_ms(mock_protobuf_modules):
 def test_default_timeout_is_2000_ms_with_prompt_injection(mock_protobuf_modules):
     """Test that detect_prompt_injection uses the same 2000ms default."""
     from arcjet import arcjet
-    from arcjet._rules import detect_prompt_injection
+    from arcjet._rules import Mode, detect_prompt_injection
 
     aj = arcjet(
         key="ajkey_x",
-        rules=[detect_prompt_injection()],
+        rules=[detect_prompt_injection(mode=Mode.LIVE)],
     )
     assert aj._timeout_ms == 2000
 
@@ -330,11 +330,11 @@ def test_default_timeout_is_2000_ms_in_development(
 ):
     """Test that the default timeout is 2000ms in development as well."""
     from arcjet import arcjet
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     aj = arcjet(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
     assert aj._timeout_ms == 2000
 
@@ -342,11 +342,11 @@ def test_default_timeout_is_2000_ms_in_development(
 def test_explicit_timeout_overrides_default(mock_protobuf_modules):
     """Test that an explicit timeout_ms replaces the 2000ms default."""
     from arcjet import arcjet
-    from arcjet._rules import detect_prompt_injection
+    from arcjet._rules import Mode, detect_prompt_injection
 
     aj = arcjet(
         key="ajkey_x",
-        rules=[detect_prompt_injection()],
+        rules=[detect_prompt_injection(mode=Mode.LIVE)],
         timeout_ms=200,
     )
     assert aj._timeout_ms == 200
@@ -360,14 +360,14 @@ def test_global_characteristics_applied_to_rules_by_factory(mock_protobuf_module
     This test catches if that wiring is accidentally removed (e.g. during rebase).
     """
     from arcjet import arcjet
-    from arcjet._rules import fixed_window, shield, token_bucket
+    from arcjet._rules import Mode, fixed_window, shield, token_bucket
 
     aj = arcjet(
         key="ajkey_x",
         rules=[
-            token_bucket(refill_rate=1, interval=1, capacity=1),
-            fixed_window(max=10, window=60),
-            shield(),
+            token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1),
+            fixed_window(mode=Mode.LIVE, max=10, window=60),
+            shield(mode=Mode.LIVE),
         ],
         characteristics=["userId"],
     )
@@ -393,7 +393,7 @@ def test_sensitive_info_value_survives_context_reconstruction(
     import asyncio
 
     from arcjet import arcjet
-    from arcjet._rules import detect_sensitive_info
+    from arcjet._rules import Mode, detect_sensitive_info
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     captured_ctx = {}
@@ -416,7 +416,7 @@ def test_sensitive_info_value_survives_context_reconstruction(
 
     aj = arcjet(
         key="ajkey_x",
-        rules=[detect_sensitive_info(deny=["EMAIL"])],
+        rules=[detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"])],
     )
     asyncio.run(
         aj.protect(
@@ -442,7 +442,7 @@ def test_filter_local_survives_context_reconstruction(
     import asyncio
 
     from arcjet import arcjet
-    from arcjet._rules import filter_request
+    from arcjet._rules import Mode, filter_request
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     captured_ctx = {}
@@ -465,7 +465,7 @@ def test_filter_local_survives_context_reconstruction(
 
     aj = arcjet(
         key="ajkey_x",
-        rules=[filter_request(deny=["x == 1"])],
+        rules=[filter_request(mode=Mode.LIVE, deny=["x == 1"])],
     )
     asyncio.run(
         aj.protect(
@@ -491,7 +491,7 @@ def test_decide_call_sends_prompt_injection_message_unredacted(
     import asyncio
 
     from arcjet import arcjet
-    from arcjet._rules import detect_prompt_injection
+    from arcjet._rules import Mode, detect_prompt_injection
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     captured = {}
@@ -504,7 +504,7 @@ def test_decide_call_sends_prompt_injection_message_unredacted(
         DecideServiceClient, "decide_behavior", capture_decide, raising=False
     )
 
-    aj = arcjet(key="ajkey_x", rules=[detect_prompt_injection()])
+    aj = arcjet(key="ajkey_x", rules=[detect_prompt_injection(mode=Mode.LIVE)])
     asyncio.run(
         aj.protect(
             {"headers": [], "type": "http"},
@@ -563,7 +563,7 @@ def test_local_deny_report_redacts_prompt_injection_message(
 
     import arcjet._client as client_module
     from arcjet import arcjet
-    from arcjet._rules import detect_prompt_injection, detect_sensitive_info
+    from arcjet._rules import Mode, detect_prompt_injection, detect_sensitive_info
 
     captured = {}
     real_redact = client_module._redact_report_details
@@ -592,8 +592,8 @@ def test_local_deny_report_redacts_prompt_injection_message(
     aj = arcjet(
         key="ajkey_x",
         rules=[
-            detect_sensitive_info(deny=["EMAIL"]),
-            detect_prompt_injection(),
+            detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"]),
+            detect_prompt_injection(mode=Mode.LIVE),
         ],
     )
     asyncio.run(
@@ -626,7 +626,7 @@ def test_cache_hit_report_redacts_prompt_injection_message(
 
     import arcjet._client as client_module
     from arcjet import arcjet
-    from arcjet._rules import detect_prompt_injection, token_bucket
+    from arcjet._rules import Mode, detect_prompt_injection, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
     captured = {}
@@ -652,8 +652,8 @@ def test_cache_hit_report_redacts_prompt_injection_message(
     aj = arcjet(
         key="ajkey_x",
         rules=[
-            detect_prompt_injection(),
-            token_bucket(refill_rate=1, interval=1, capacity=1),
+            detect_prompt_injection(mode=Mode.LIVE),
+            token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1),
         ],
     )
 
@@ -680,7 +680,7 @@ class TestArcjetFactoryEnvironmentKwarg:
     def test_kwarg_reaches_dataclass(self, monkeypatch: pytest.MonkeyPatch):
         from arcjet import arcjet
         from arcjet._enums import Mode
-        from arcjet._rules import shield
+        from arcjet._rules import Mode, shield
 
         monkeypatch.delenv("ARCJET_ENV", raising=False)
         aj = arcjet(
@@ -694,7 +694,7 @@ class TestArcjetFactoryEnvironmentKwarg:
     def test_kwarg_production_beats_env_var(self, monkeypatch: pytest.MonkeyPatch):
         from arcjet import arcjet
         from arcjet._enums import Mode
-        from arcjet._rules import shield
+        from arcjet._rules import Mode, shield
 
         monkeypatch.setenv("ARCJET_ENV", "development")
         aj = arcjet(
@@ -712,7 +712,7 @@ class TestArcjetFactoryEnvironmentKwarg:
         """
         from arcjet import arcjet
         from arcjet._enums import Mode
-        from arcjet._rules import shield
+        from arcjet._rules import Mode, shield
 
         monkeypatch.setenv("ARCJET_ENV", "development")
         aj = arcjet(key="ajkey_x", rules=[shield(mode=Mode.LIVE)])
@@ -724,7 +724,7 @@ class TestArcjetFactoryEnvironmentKwarg:
     ):
         from arcjet import arcjet
         from arcjet._enums import Mode
-        from arcjet._rules import shield
+        from arcjet._rules import Mode, shield
 
         monkeypatch.delenv("ARCJET_ENV", raising=False)
         aj = arcjet(
@@ -749,7 +749,7 @@ class TestArcjetFactoryEnvironmentKwarg:
 
         from arcjet import arcjet
         from arcjet._enums import Mode
-        from arcjet._rules import shield
+        from arcjet._rules import Mode, shield
         from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
 
         monkeypatch.delenv("ARCJET_ENV", raising=False)

--- a/tests/unit/test_client_metadata.py
+++ b/tests/unit/test_client_metadata.py
@@ -151,7 +151,7 @@ def test_metadata_is_attached_to_the_cache_hit_report(
     )
 
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     reports: list[Any] = []
@@ -172,7 +172,8 @@ def test_metadata_is_attached_to_the_cache_hit_report(
     )
 
     aj = arcjet_sync(
-        key="ajkey_x", rules=[token_bucket(refill_rate=1, interval=1, capacity=1)]
+        key="ajkey_x",
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
     scope = {**_SCOPE, "client": ("1.2.3.4", 1234)}
     aj.protect(scope, metadata={"attempt": 1})
@@ -234,7 +235,7 @@ def test_metadata_is_not_part_of_the_cache_key(
     )
 
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     calls: list[Any] = []
@@ -249,7 +250,8 @@ def test_metadata_is_not_part_of_the_cache_key(
         DecideServiceClientSync, "decide_behavior", behavior, raising=False
     )
     aj = arcjet_sync(
-        key="ajkey_x", rules=[token_bucket(refill_rate=1, interval=1, capacity=1)]
+        key="ajkey_x",
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
     # The cache key falls back to the client IP, so the scope needs one.
     scope = {**_SCOPE, "client": ("1.2.3.4", 1234)}

--- a/tests/unit/test_client_sync.py
+++ b/tests/unit/test_client_sync.py
@@ -14,7 +14,7 @@ def test_fail_open_false_raises(mock_protobuf_modules, monkeypatch: pytest.Monke
     """Test that fail_open=False raises ArcjetTransportError on network error."""
     from arcjet import arcjet_sync
     from arcjet._errors import ArcjetTransportError
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     def raise_decide(req):
@@ -25,7 +25,7 @@ def test_fail_open_false_raises(mock_protobuf_modules, monkeypatch: pytest.Monke
     )
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         fail_open=False,
     )
     with pytest.raises(ArcjetTransportError):
@@ -36,9 +36,11 @@ def test_email_required_for_validate_email_rule(mock_protobuf_modules):
     """Test that validate_email rule raises error when email is missing."""
     from arcjet import arcjet_sync
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import validate_email
+    from arcjet._rules import Mode, validate_email
 
-    aj = arcjet_sync(key="ajkey_x", rules=[validate_email()])
+    aj = arcjet_sync(
+        key="ajkey_x", rules=[validate_email(mode=Mode.LIVE, deny=["INVALID"])]
+    )
     with pytest.raises(ArcjetMisconfiguration):
         aj.protect({"headers": [], "type": "http"})
 
@@ -47,9 +49,9 @@ def test_message_required_for_detect_prompt_injection_rule(mock_protobuf_modules
     """Test that detect_prompt_injection rule raises error when message is missing."""
     from arcjet import arcjet_sync
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import detect_prompt_injection
+    from arcjet._rules import Mode, detect_prompt_injection
 
-    aj = arcjet_sync(key="ajkey_x", rules=[detect_prompt_injection()])
+    aj = arcjet_sync(key="ajkey_x", rules=[detect_prompt_injection(mode=Mode.LIVE)])
     with pytest.raises(ArcjetMisconfiguration):
         aj.protect({"headers": [], "type": "http"})
 
@@ -57,7 +59,7 @@ def test_message_required_for_detect_prompt_injection_rule(mock_protobuf_modules
 def test_fail_open_true_errors(mock_protobuf_modules, monkeypatch: pytest.MonkeyPatch):
     """Test that fail_open=True returns error decision on network error."""
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     def raise_decide(req):
@@ -68,7 +70,7 @@ def test_fail_open_true_errors(mock_protobuf_modules, monkeypatch: pytest.Monkey
     )
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         fail_open=True,
     )
     d = aj.protect({"headers": [], "type": "http"})
@@ -87,7 +89,7 @@ def test_requested_default_and_characteristics_in_extra(
 ):
     """Test that requested default and characteristics are passed in extra metadata."""
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     captured = {}
@@ -100,7 +102,7 @@ def test_requested_default_and_characteristics_in_extra(
     monkeypatch.setattr(
         DecideServiceClientSync, "decide_behavior", capture_decide, raising=False
     )
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet_sync(key="ajkey_x", rules=rules)
 
     aj.protect({"headers": [], "type": "http"}, characteristics={"uid": "123"})
@@ -124,7 +126,7 @@ def test_caching_hits_trigger_background_report(
     real implementation and are not easily testable with sync stubs.
     """
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     calls = {"n": 0}
@@ -138,7 +140,7 @@ def test_caching_hits_trigger_background_report(
     monkeypatch.setattr(
         DecideServiceClientSync, "decide_behavior", deny_once, raising=False
     )
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet_sync(key="ajkey_x", rules=rules)
 
     ctx = {"type": "http", "headers": [(b"host", b"ex")], "client": ("203.0.113.5", 1)}
@@ -157,7 +159,7 @@ def test_ip_override_with_ip_src(
 ):
     """Test that ip_src overrides automatic IP detection when configured."""
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     captured = {}
@@ -170,7 +172,7 @@ def test_ip_override_with_ip_src(
     monkeypatch.setattr(
         DecideServiceClientSync, "decide_behavior", capture_decide, raising=False
     )
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet_sync(key="ajkey_x", rules=rules, disable_automatic_ip_detection=True)
 
     ctx = {
@@ -187,9 +189,9 @@ def test_disable_automatic_ip_detection_requires_ip_src(mock_protobuf_modules):
     """Test that ip_src is required when automatic IP detection is disabled."""
     from arcjet import arcjet_sync
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet_sync(key="ajkey_x", rules=rules, disable_automatic_ip_detection=True)
 
     with pytest.raises(ArcjetMisconfiguration, match="ip_src is required"):
@@ -200,9 +202,9 @@ def test_disable_automatic_ip_detection_with_proxies(mock_protobuf_modules):
     """Test that proxies cannot be used with manual IP detection."""
     from arcjet import arcjet_sync
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet_sync(
         key="ajkey_x",
         rules=rules,
@@ -218,9 +220,9 @@ def test_ip_src_disallowed_when_automatic_ip_detection_enabled(mock_protobuf_mod
     """Test that ip_src cannot be used when automatic IP detection is enabled."""
     from arcjet import arcjet_sync
     from arcjet._errors import ArcjetMisconfiguration
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
-    rules = [token_bucket(refill_rate=1, interval=1, capacity=1)]
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     aj = arcjet_sync(
         key="ajkey_x",
         rules=rules,
@@ -233,12 +235,12 @@ def test_ip_src_disallowed_when_automatic_ip_detection_enabled(mock_protobuf_mod
 def test_base_url_trailing_slash_is_stripped(mock_protobuf_modules):
     """Test that base_url parameter strips trailing slashes."""
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     # Create client with trailing slash in base_url
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         base_url="https://example.com/",
     )
     # Access the internal client to verify the base_url
@@ -248,12 +250,12 @@ def test_base_url_trailing_slash_is_stripped(mock_protobuf_modules):
 def test_base_url_multiple_trailing_slashes_are_stripped(mock_protobuf_modules):
     """Test that base_url parameter strips multiple trailing slashes."""
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     # Create client with multiple trailing slashes
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         base_url="https://example.com///",
     )
     # Access the internal client to verify the base_url
@@ -263,12 +265,12 @@ def test_base_url_multiple_trailing_slashes_are_stripped(mock_protobuf_modules):
 def test_base_url_without_trailing_slash_unchanged(mock_protobuf_modules):
     """Test that base_url without trailing slash is unchanged."""
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     # Create client without trailing slash
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
         base_url="https://example.com",
     )
     # Access the internal client to verify the base_url
@@ -292,11 +294,11 @@ def test_default_base_url_from_env_trailing_slash_is_stripped(
 def test_default_timeout_is_2000_ms(mock_protobuf_modules):
     """Test that the default timeout is 2000ms for every rule set."""
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
     assert aj._timeout_ms == 2000
 
@@ -304,11 +306,11 @@ def test_default_timeout_is_2000_ms(mock_protobuf_modules):
 def test_default_timeout_is_2000_ms_with_prompt_injection(mock_protobuf_modules):
     """Test that detect_prompt_injection uses the same 2000ms default."""
     from arcjet import arcjet_sync
-    from arcjet._rules import detect_prompt_injection
+    from arcjet._rules import Mode, detect_prompt_injection
 
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[detect_prompt_injection()],
+        rules=[detect_prompt_injection(mode=Mode.LIVE)],
     )
     assert aj._timeout_ms == 2000
 
@@ -318,11 +320,11 @@ def test_default_timeout_is_2000_ms_in_development(
 ):
     """Test that the default timeout is 2000ms in development as well."""
     from arcjet import arcjet_sync
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[token_bucket(refill_rate=1, interval=1, capacity=1)],
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
     )
     assert aj._timeout_ms == 2000
 
@@ -330,11 +332,11 @@ def test_default_timeout_is_2000_ms_in_development(
 def test_explicit_timeout_overrides_default(mock_protobuf_modules):
     """Test that an explicit timeout_ms replaces the 2000ms default."""
     from arcjet import arcjet_sync
-    from arcjet._rules import detect_prompt_injection
+    from arcjet._rules import Mode, detect_prompt_injection
 
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[detect_prompt_injection()],
+        rules=[detect_prompt_injection(mode=Mode.LIVE)],
         timeout_ms=200,
     )
     assert aj._timeout_ms == 200
@@ -349,14 +351,14 @@ def test_global_characteristics_applied_to_rules_by_factory(mock_protobuf_module
     rebase).
     """
     from arcjet import arcjet_sync
-    from arcjet._rules import fixed_window, shield, token_bucket
+    from arcjet._rules import Mode, fixed_window, shield, token_bucket
 
     aj = arcjet_sync(
         key="ajkey_x",
         rules=[
-            token_bucket(refill_rate=1, interval=1, capacity=1),
-            fixed_window(max=10, window=60),
-            shield(),
+            token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1),
+            fixed_window(mode=Mode.LIVE, max=10, window=60),
+            shield(mode=Mode.LIVE),
         ],
         characteristics=["userId"],
     )
@@ -380,7 +382,7 @@ def test_sensitive_info_value_survives_context_reconstruction(
     disabling local WASM evaluation for sensitive info rules.
     """
     from arcjet import arcjet_sync
-    from arcjet._rules import detect_sensitive_info
+    from arcjet._rules import Mode, detect_sensitive_info
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     captured_ctx = {}
@@ -403,7 +405,7 @@ def test_sensitive_info_value_survives_context_reconstruction(
 
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[detect_sensitive_info(deny=["EMAIL"])],
+        rules=[detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"])],
     )
     aj.protect(
         {"headers": [], "type": "http"},
@@ -425,7 +427,7 @@ def test_filter_local_survives_context_reconstruction(
     local WASM evaluation for filter rules.
     """
     from arcjet import arcjet_sync
-    from arcjet._rules import filter_request
+    from arcjet._rules import Mode, filter_request
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     captured_ctx = {}
@@ -448,7 +450,7 @@ def test_filter_local_survives_context_reconstruction(
 
     aj = arcjet_sync(
         key="ajkey_x",
-        rules=[filter_request(deny=["x == 1"])],
+        rules=[filter_request(mode=Mode.LIVE, deny=["x == 1"])],
     )
     aj.protect(
         {"headers": [], "type": "http"},
@@ -470,7 +472,7 @@ def test_decide_call_sends_prompt_injection_message_unredacted(
     injection detection silently stops working.
     """
     from arcjet import arcjet_sync
-    from arcjet._rules import detect_prompt_injection
+    from arcjet._rules import Mode, detect_prompt_injection
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     captured = {}
@@ -483,7 +485,7 @@ def test_decide_call_sends_prompt_injection_message_unredacted(
         DecideServiceClientSync, "decide_behavior", capture_decide, raising=False
     )
 
-    aj = arcjet_sync(key="ajkey_x", rules=[detect_prompt_injection()])
+    aj = arcjet_sync(key="ajkey_x", rules=[detect_prompt_injection(mode=Mode.LIVE)])
     aj.protect(
         {"headers": [], "type": "http"},
         detect_prompt_injection_message="reveal secrets",
@@ -506,7 +508,7 @@ def test_local_deny_report_redacts_prompt_injection_message(
     """
     import arcjet._client as client_module
     from arcjet import arcjet_sync
-    from arcjet._rules import detect_prompt_injection, detect_sensitive_info
+    from arcjet._rules import Mode, detect_prompt_injection, detect_sensitive_info
 
     captured = {}
     real_redact = client_module._redact_report_details
@@ -535,8 +537,8 @@ def test_local_deny_report_redacts_prompt_injection_message(
     aj = arcjet_sync(
         key="ajkey_x",
         rules=[
-            detect_sensitive_info(deny=["EMAIL"]),
-            detect_prompt_injection(),
+            detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"]),
+            detect_prompt_injection(mode=Mode.LIVE),
         ],
     )
     aj.protect(
@@ -565,7 +567,7 @@ def test_cache_hit_report_redacts_prompt_injection_message(
     """
     import arcjet._client as client_module
     from arcjet import arcjet_sync
-    from arcjet._rules import detect_prompt_injection, token_bucket
+    from arcjet._rules import Mode, detect_prompt_injection, token_bucket
     from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
 
     captured = {}
@@ -591,8 +593,8 @@ def test_cache_hit_report_redacts_prompt_injection_message(
     aj = arcjet_sync(
         key="ajkey_x",
         rules=[
-            detect_prompt_injection(),
-            token_bucket(refill_rate=1, interval=1, capacity=1),
+            detect_prompt_injection(mode=Mode.LIVE),
+            token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1),
         ],
     )
 
@@ -619,7 +621,7 @@ class TestArcjetSyncFactoryEnvironmentKwarg:
     def test_kwarg_reaches_dataclass(self, monkeypatch: pytest.MonkeyPatch):
         from arcjet import arcjet_sync
         from arcjet._enums import Mode
-        from arcjet._rules import shield
+        from arcjet._rules import Mode, shield
 
         monkeypatch.delenv("ARCJET_ENV", raising=False)
         aj = arcjet_sync(
@@ -633,7 +635,7 @@ class TestArcjetSyncFactoryEnvironmentKwarg:
     def test_kwarg_production_beats_env_var(self, monkeypatch: pytest.MonkeyPatch):
         from arcjet import arcjet_sync
         from arcjet._enums import Mode
-        from arcjet._rules import shield
+        from arcjet._rules import Mode, shield
 
         monkeypatch.setenv("ARCJET_ENV", "development")
         aj = arcjet_sync(
@@ -656,7 +658,7 @@ class TestArcjetSyncFactoryEnvironmentKwarg:
         """
         from arcjet import arcjet_sync
         from arcjet._enums import Mode
-        from arcjet._rules import shield
+        from arcjet._rules import Mode, shield
         from arcjet.proto.decide.v1alpha1.decide_connect import (
             DecideServiceClientSync,
         )

--- a/tests/unit/test_parity.py
+++ b/tests/unit/test_parity.py
@@ -21,7 +21,6 @@ from arcjet._decision import (
 )
 from arcjet._decision import RuleResult as SDKRuleResult
 
-
 # ---------------------------------------------------------------------------
 # 1. Cache hits: remaining TTL, isolated copy, rate-limit reset rewrite
 # ---------------------------------------------------------------------------
@@ -34,7 +33,9 @@ class TestCacheHitMaterialization:
 
         cache = DecisionCache()
         stored = Decision(
-            decide_pb2.Decision(id="orig", conclusion=decide_pb2.CONCLUSION_DENY, ttl=60)
+            decide_pb2.Decision(
+                id="orig", conclusion=decide_pb2.CONCLUSION_DENY, ttl=60
+            )
         )
         cache.set("k", stored, ttl_seconds=2)
         hit = cache.get("k")
@@ -50,7 +51,9 @@ class TestCacheHitMaterialization:
             id="orig", conclusion=decide_pb2.CONCLUSION_DENY, ttl=60
         )
         cached = Decision(proto)
-        served = materialize_cached_decision(cached, remaining_ttl=12, request_id="lreq_x")
+        served = materialize_cached_decision(
+            cached, remaining_ttl=12, request_id="lreq_x"
+        )
 
         assert served is not cached
         assert served.id == "lreq_x"
@@ -61,7 +64,7 @@ class TestCacheHitMaterialization:
         assert cached.id == "orig"
 
     def test_materialize_rewrites_rate_limit_reset(self, mock_protobuf_modules):
-        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+        from fixtures.protobuf_stubs import StubRateLimitReason
 
         from arcjet.proto.decide.v1alpha1 import decide_pb2
 
@@ -72,10 +75,12 @@ class TestCacheHitMaterialization:
             id="orig",
             conclusion=decide_pb2.CONCLUSION_DENY,
             ttl=60,
-            reason=decide_pb2.Reason(rate_limit=rl),
+            reason=decide_pb2.Reason(rate_limit=rl),  # type: ignore[arg-type]
         )
         cached = Decision(proto)
-        served = materialize_cached_decision(cached, remaining_ttl=7, request_id="lreq_y")
+        served = materialize_cached_decision(
+            cached, remaining_ttl=7, request_id="lreq_y"
+        )
 
         assert served.ttl == 7
         assert served.to_proto().reason.rate_limit.reset_in_seconds == 7
@@ -190,9 +195,7 @@ class TestExplicitMode:
             inspect.signature(TokenBucket.__init__).parameters["mode"].default == "LIVE"
         )
         assert (
-            inspect.signature(DetectPromptInjection.__init__)
-            .parameters["mode"]
-            .default
+            inspect.signature(DetectPromptInjection.__init__).parameters["mode"].default
             == "LIVE"
         )
 
@@ -258,10 +261,8 @@ class TestAllowDenyExclusivity:
 
 
 class TestLocalRulePriority:
-    def test_sensitive_info_denies_before_later_bot(
-        self, mock_protobuf_modules
-    ):
-                from arcjet._client import _run_local_rules, _sort_rules_for_local
+    def test_sensitive_info_denies_before_later_bot(self, mock_protobuf_modules):
+        from arcjet._client import _run_local_rules, _sort_rules_for_local
         from arcjet._context import RequestContext
         from arcjet._rules import (
             BotDetection,
@@ -323,7 +324,9 @@ class TestLocalRulePriority:
 
         ctx = RequestContext(ip="1.2.3.4")
         with (
-            patch("arcjet._client.evaluate_sensitive_info_locally", side_effect=track_si),
+            patch(
+                "arcjet._client.evaluate_sensitive_info_locally", side_effect=track_si
+            ),
             patch("arcjet._client.evaluate_filter_locally", return_value=None),
             patch("arcjet._client.evaluate_bot_locally", side_effect=track_bot),
             patch("arcjet._client.evaluate_email_locally", return_value=None),
@@ -349,7 +352,7 @@ class TestInspectHelpers:
             rule_id="r1",
             state=state,
             conclusion=decide_pb2.CONCLUSION_DENY,
-            reason=decide_pb2.Reason(bot_v2=bot_v2),
+            reason=decide_pb2.Reason(bot_v2=bot_v2),  # type: ignore[arg-type]
         )
         return SDKRuleResult(rr)
 
@@ -471,9 +474,7 @@ class TestWithRule:
 
         base = arcjet_sync(key="ajkey_test", rules=[shield(mode=Mode.LIVE)])
         assert base._needs_email is False
-        clone = base.with_rule(
-            validate_email(mode=Mode.LIVE, deny=[EmailType.INVALID])
-        )
+        clone = base.with_rule(validate_email(mode=Mode.LIVE, deny=[EmailType.INVALID]))
         assert clone._needs_email is True
         assert base._needs_email is False
 
@@ -494,9 +495,7 @@ class TestWithRule:
         assert len(clone._rules) == 4
         assert clone._needs_email is True
 
-    def test_async_with_rule_shares_cache(
-        self, mock_protobuf_modules, dev_environment
-    ):
+    def test_async_with_rule_shares_cache(self, mock_protobuf_modules, dev_environment):
         from arcjet import arcjet
         from arcjet._rules import Mode, detect_bot, shield
 
@@ -516,7 +515,7 @@ class TestWithRule:
 
 class TestProtectSignup:
     def test_returns_three_rules(self, mock_protobuf_modules):
-        from arcjet._rules import Mode, (
+        from arcjet._rules import (
             BotDetection,
             EmailType,
             EmailValidation,
@@ -569,7 +568,7 @@ class TestProtectSignup:
 
 class TestRateLimitHeaders:
     def test_sets_ietf_headers(self, mock_protobuf_modules):
-        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+        from fixtures.protobuf_stubs import StubRateLimitReason
 
         from arcjet import set_rate_limit_headers
         from arcjet.proto.decide.v1alpha1 import decide_pb2
@@ -581,7 +580,7 @@ class TestRateLimitHeaders:
             decide_pb2.Decision(
                 id="d1",
                 conclusion=decide_pb2.CONCLUSION_ALLOW,
-                reason=decide_pb2.Reason(rate_limit=rl),
+                reason=decide_pb2.Reason(rate_limit=rl),  # type: ignore[arg-type]
             )
         )
         headers: dict[str, str] = {}
@@ -590,7 +589,7 @@ class TestRateLimitHeaders:
         assert headers["RateLimit-Policy"] == "100;w=60"
 
     def test_uses_response_headers_attribute(self, mock_protobuf_modules):
-        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+        from fixtures.protobuf_stubs import StubRateLimitReason
 
         from arcjet import set_rate_limit_headers
         from arcjet.proto.decide.v1alpha1 import decide_pb2
@@ -606,7 +605,7 @@ class TestRateLimitHeaders:
             decide_pb2.Decision(
                 id="d1",
                 conclusion=decide_pb2.CONCLUSION_DENY,
-                reason=decide_pb2.Reason(rate_limit=rl),
+                reason=decide_pb2.Reason(rate_limit=rl),  # type: ignore[arg-type]
             )
         )
         response = Response()
@@ -645,7 +644,7 @@ class TestRateLimitHeaders:
         )
 
     def test_nearest_remaining_wins(self, mock_protobuf_modules):
-        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+        from fixtures.protobuf_stubs import StubRateLimitReason
 
         from arcjet import set_rate_limit_headers
 
@@ -664,7 +663,7 @@ class TestRateLimitHeaders:
         assert headers["RateLimit-Policy"] == "10;w=10, 100;w=60"
 
     def test_duplicate_max_aborts(self, mock_protobuf_modules):
-        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+        from fixtures.protobuf_stubs import StubRateLimitReason
 
         from arcjet import set_rate_limit_headers
 
@@ -682,7 +681,7 @@ class TestRateLimitHeaders:
         assert headers == {}
 
     def test_fetch_style_headers(self, mock_protobuf_modules):
-        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+        from fixtures.protobuf_stubs import StubRateLimitReason
 
         from arcjet import set_rate_limit_headers
         from arcjet.proto.decide.v1alpha1 import decide_pb2
@@ -707,7 +706,7 @@ class TestRateLimitHeaders:
             decide_pb2.Decision(
                 id="d1",
                 conclusion=decide_pb2.CONCLUSION_ALLOW,
-                reason=decide_pb2.Reason(rate_limit=rl),
+                reason=decide_pb2.Reason(rate_limit=rl),  # type: ignore[arg-type]
             )
         )
         headers = FetchHeaders()
@@ -716,7 +715,7 @@ class TestRateLimitHeaders:
         assert headers.get("RateLimit-Policy") == "10;w=10"
 
     def test_set_header_style_response(self, mock_protobuf_modules):
-        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+        from fixtures.protobuf_stubs import StubRateLimitReason
 
         from arcjet import set_rate_limit_headers
         from arcjet.proto.decide.v1alpha1 import decide_pb2
@@ -742,7 +741,7 @@ class TestRateLimitHeaders:
             decide_pb2.Decision(
                 id="d1",
                 conclusion=decide_pb2.CONCLUSION_DENY,
-                reason=decide_pb2.Reason(rate_limit=rl),
+                reason=decide_pb2.Reason(rate_limit=rl),  # type: ignore[arg-type]
             )
         )
         response = Outgoing()
@@ -766,9 +765,13 @@ class TestPromptInjectionThresholdRemoved:
         from arcjet._rules import Mode, detect_prompt_injection
 
         rule = detect_prompt_injection(mode=Mode.LIVE)
-        assert not hasattr(rule, "threshold") or getattr(rule, "threshold", None) is None
+        assert (
+            not hasattr(rule, "threshold") or getattr(rule, "threshold", None) is None
+        )
         pb = rule.to_proto()
-        assert pb.prompt_injection_detection.mode == mock_protobuf_modules["pb2"].MODE_LIVE
+        assert (
+            pb.prompt_injection_detection.mode == mock_protobuf_modules["pb2"].MODE_LIVE
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_parity.py
+++ b/tests/unit/test_parity.py
@@ -1,0 +1,788 @@
+"""Parity tests for JS-aligned SDK behavior.
+
+Each class maps to one item in the core-SDK parity review (items 6 and 9
+were out of scope). Tests use the protobuf stubs so they stay isolated.
+"""
+
+from __future__ import annotations
+
+import inspect
+import types
+from typing import Any
+
+import pytest
+
+from arcjet._decision import (
+    Decision,
+    is_missing_user_agent,
+    is_spoofed_bot,
+    is_verified_bot,
+    materialize_cached_decision,
+)
+from arcjet._decision import RuleResult as SDKRuleResult
+
+
+# ---------------------------------------------------------------------------
+# 1. Cache hits: remaining TTL, isolated copy, rate-limit reset rewrite
+# ---------------------------------------------------------------------------
+
+
+class TestCacheHitMaterialization:
+    def test_get_returns_remaining_ttl(self, mock_protobuf_modules):
+        from arcjet._cache import DecisionCache
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        cache = DecisionCache()
+        stored = Decision(
+            decide_pb2.Decision(id="orig", conclusion=decide_pb2.CONCLUSION_DENY, ttl=60)
+        )
+        cache.set("k", stored, ttl_seconds=2)
+        hit = cache.get("k")
+        assert hit is not None
+        decision, remaining = hit
+        assert decision is stored
+        assert 1 <= remaining <= 2
+
+    def test_materialize_does_not_mutate_cached_proto(self, mock_protobuf_modules):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        proto = decide_pb2.Decision(
+            id="orig", conclusion=decide_pb2.CONCLUSION_DENY, ttl=60
+        )
+        cached = Decision(proto)
+        served = materialize_cached_decision(cached, remaining_ttl=12, request_id="lreq_x")
+
+        assert served is not cached
+        assert served.id == "lreq_x"
+        assert served.ttl == 12
+        assert cached.id == "orig"
+        assert cached.ttl == 60
+        served.to_proto().id = "mutated"
+        assert cached.id == "orig"
+
+    def test_materialize_rewrites_rate_limit_reset(self, mock_protobuf_modules):
+        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        rl = StubRateLimitReason(
+            max=10, remaining=0, reset_in_seconds=60, window_in_seconds=60
+        )
+        proto = decide_pb2.Decision(
+            id="orig",
+            conclusion=decide_pb2.CONCLUSION_DENY,
+            ttl=60,
+            reason=decide_pb2.Reason(rate_limit=rl),
+        )
+        cached = Decision(proto)
+        served = materialize_cached_decision(cached, remaining_ttl=7, request_id="lreq_y")
+
+        assert served.ttl == 7
+        assert served.to_proto().reason.rate_limit.reset_in_seconds == 7
+        assert cached.to_proto().reason.rate_limit.reset_in_seconds == 60
+
+    def test_protect_cache_hit_is_isolated(
+        self, mock_protobuf_modules, dev_environment, monkeypatch
+    ):
+        from arcjet import arcjet_sync
+        from arcjet._rules import Mode, token_bucket
+        from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
+
+        def deny_with_ttl(_req):
+            return mock_protobuf_modules["DecideResponse"](
+                mock_protobuf_modules["Decision"](
+                    id="deny1",
+                    conclusion=mock_protobuf_modules["pb2"].CONCLUSION_DENY,
+                    ttl=10,
+                )
+            )
+
+        monkeypatch.setattr(
+            DecideServiceClientSync, "decide_behavior", deny_with_ttl, raising=False
+        )
+
+        aj = arcjet_sync(
+            key="ajkey_test",
+            rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
+        )
+        d1 = aj.protect({"headers": [], "type": "http"})
+        d2 = aj.protect({"headers": [], "type": "http"})
+
+        assert d1.is_denied() and d2.is_denied()
+        assert d1.id == "deny1"
+        assert d2.id != d1.id
+        assert d2.id.startswith("lreq_")
+        assert d2.ttl <= 10
+        d2.to_proto().id = "mutated-by-caller"
+        assert d1.id == "deny1"
+
+    def test_async_protect_cache_hit_is_isolated(
+        self, mock_protobuf_modules, dev_environment, monkeypatch
+    ):
+        import asyncio
+
+        from arcjet import arcjet
+        from arcjet._rules import Mode, token_bucket
+        from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
+
+        def deny_with_ttl(_req):
+            return mock_protobuf_modules["DecideResponse"](
+                mock_protobuf_modules["Decision"](
+                    id="deny1",
+                    conclusion=mock_protobuf_modules["pb2"].CONCLUSION_DENY,
+                    ttl=10,
+                )
+            )
+
+        monkeypatch.setattr(
+            DecideServiceClient, "decide_behavior", deny_with_ttl, raising=False
+        )
+
+        aj = arcjet(
+            key="ajkey_test",
+            rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
+        )
+
+        async def _run() -> None:
+            d1 = await aj.protect({"headers": [], "type": "http"})
+            d2 = await aj.protect({"headers": [], "type": "http"})
+            assert d1.is_denied() and d2.is_denied()
+            assert d1.id == "deny1"
+            assert d2.id != d1.id
+            assert d2.id.startswith("lreq_")
+            d2.to_proto().id = "mutated-by-caller"
+            assert d1.id == "deny1"
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# 2. Explicit mode
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitMode:
+    @pytest.mark.parametrize(
+        "factory,kwargs",
+        [
+            ("shield", {}),
+            ("detect_bot", {"allow": ["CURL"]}),
+            ("token_bucket", {"refill_rate": 1, "interval": 1, "capacity": 1}),
+            ("fixed_window", {"max": 1, "window": 1}),
+            ("sliding_window", {"max": 1, "interval": 1}),
+            ("validate_email", {"deny": ["INVALID"]}),
+            ("detect_prompt_injection", {}),
+            ("detect_sensitive_info", {"deny": ["EMAIL"]}),
+            ("filter_request", {"deny": ["ip.src == 1"]}),
+        ],
+    )
+    def test_http_factory_requires_mode(self, mock_protobuf_modules, factory, kwargs):
+        import arcjet._rules as rules
+
+        fn = getattr(rules, factory)
+        with pytest.raises(TypeError, match="mode"):
+            fn(**kwargs)
+
+    def test_guard_mode_defaults_to_live_matching_js(self):
+        from arcjet.guard import DetectPromptInjection, TokenBucket
+
+        assert (
+            inspect.signature(TokenBucket.__init__).parameters["mode"].default == "LIVE"
+        )
+        assert (
+            inspect.signature(DetectPromptInjection.__init__)
+            .parameters["mode"]
+            .default
+            == "LIVE"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. detect_bot / validate_email allow XOR deny
+# ---------------------------------------------------------------------------
+
+
+class TestAllowDenyExclusivity:
+    def test_detect_bot_rejects_neither(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, detect_bot
+
+        with pytest.raises(ValueError, match="either `allow` or `deny`"):
+            detect_bot(mode=Mode.LIVE)
+
+    def test_detect_bot_rejects_both(self, mock_protobuf_modules):
+        from arcjet._rules import BotCategory, Mode, detect_bot
+
+        with pytest.raises(ValueError, match="cannot be provided together"):
+            detect_bot(mode=Mode.LIVE, allow=[BotCategory.GOOGLE], deny=["CURL"])
+
+    def test_detect_bot_empty_allow_blocks_all_bots(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, detect_bot
+
+        rule = detect_bot(mode=Mode.LIVE, allow=[])
+        assert rule.allow == ()
+        assert rule.deny is None
+
+    def test_bot_detection_dataclass_rejects_neither(self, mock_protobuf_modules):
+        from arcjet._rules import BotDetection, Mode
+
+        with pytest.raises(ValueError, match="either `allow` or `deny`"):
+            BotDetection(mode=Mode.LIVE)
+
+    def test_validate_email_rejects_neither(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, validate_email
+
+        with pytest.raises(ValueError, match="either `allow` or `deny`"):
+            validate_email(mode=Mode.LIVE)
+
+    def test_validate_email_rejects_both(self, mock_protobuf_modules):
+        from arcjet._rules import EmailType, Mode, validate_email
+
+        with pytest.raises(ValueError, match="cannot be provided together"):
+            validate_email(
+                mode=Mode.LIVE,
+                allow=[EmailType.FREE],
+                deny=[EmailType.DISPOSABLE],
+            )
+
+    def test_validate_email_empty_allow_is_valid(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, validate_email
+
+        rule = validate_email(mode=Mode.LIVE, allow=[])
+        assert rule.allow == ()
+        assert rule.deny is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Local rules evaluate in JS priority order
+# ---------------------------------------------------------------------------
+
+
+class TestLocalRulePriority:
+    def test_sensitive_info_denies_before_later_bot(
+        self, mock_protobuf_modules
+    ):
+                from arcjet._client import _run_local_rules, _sort_rules_for_local
+        from arcjet._context import RequestContext
+        from arcjet._rules import (
+            BotDetection,
+            EmailValidation,
+            Filter,
+            Mode,
+            SensitiveInfoDetection,
+            Shield,
+            SlidingWindow,
+            detect_bot,
+            detect_sensitive_info,
+            filter_request,
+            shield,
+            sliding_window,
+            validate_email,
+        )
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        bot = detect_bot(mode=Mode.LIVE, deny=["CURL"])
+        filt = filter_request(mode=Mode.LIVE, deny=["ip.src == 1"])
+        sensi = detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"])
+        email = validate_email(mode=Mode.LIVE, deny=["INVALID"])
+        sh = shield(mode=Mode.LIVE)
+        rl = sliding_window(mode=Mode.LIVE, max=5, interval=60)
+        ordered = _sort_rules_for_local((bot, email, filt, rl, sh, sensi))
+        assert [type(r) for r in ordered] == [
+            SensitiveInfoDetection,
+            Filter,
+            Shield,
+            SlidingWindow,
+            BotDetection,
+            EmailValidation,
+        ]
+
+        si_deny = decide_pb2.RuleResult(
+            rule_id="si",
+            state=decide_pb2.RULE_STATE_RUN,
+            conclusion=decide_pb2.CONCLUSION_DENY,
+            reason=decide_pb2.Reason(error=decide_pb2.ErrorReason(message="pii")),
+        )
+        bot_deny = decide_pb2.RuleResult(
+            rule_id="bot",
+            state=decide_pb2.RULE_STATE_RUN,
+            conclusion=decide_pb2.CONCLUSION_DENY,
+            reason=decide_pb2.Reason(error=decide_pb2.ErrorReason(message="bot")),
+        )
+
+        calls: list[str] = []
+
+        def track_si(_ctx, _rule):
+            calls.append("si")
+            return si_deny
+
+        def track_bot(_ctx, _rule):
+            calls.append("bot")
+            return bot_deny
+
+        from unittest.mock import patch
+
+        ctx = RequestContext(ip="1.2.3.4")
+        with (
+            patch("arcjet._client.evaluate_sensitive_info_locally", side_effect=track_si),
+            patch("arcjet._client.evaluate_filter_locally", return_value=None),
+            patch("arcjet._client.evaluate_bot_locally", side_effect=track_bot),
+            patch("arcjet._client.evaluate_email_locally", return_value=None),
+        ):
+            decision = _run_local_rules(ctx, (bot, sensi))
+
+        assert calls == ["si"]
+        assert decision is not None
+        assert decision.results[0].rule_id == "si"
+
+
+# ---------------------------------------------------------------------------
+# 5. Inspect helpers skip DRY_RUN
+# ---------------------------------------------------------------------------
+
+
+class TestInspectHelpers:
+    def _bot_result(self, mock_protobuf_modules, *, spoofed, verified, state):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        bot_v2 = types.SimpleNamespace(spoofed=spoofed, verified=verified)
+        rr = decide_pb2.RuleResult(
+            rule_id="r1",
+            state=state,
+            conclusion=decide_pb2.CONCLUSION_DENY,
+            reason=decide_pb2.Reason(bot_v2=bot_v2),
+        )
+        return SDKRuleResult(rr)
+
+    def test_is_spoofed_bot_live(self, mock_protobuf_modules):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        rr = self._bot_result(
+            mock_protobuf_modules,
+            spoofed=True,
+            verified=False,
+            state=decide_pb2.RULE_STATE_RUN,
+        )
+        assert is_spoofed_bot(rr) is True
+
+    def test_is_spoofed_bot_ignores_dry_run(self, mock_protobuf_modules):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        rr = self._bot_result(
+            mock_protobuf_modules,
+            spoofed=True,
+            verified=False,
+            state=decide_pb2.RULE_STATE_DRY_RUN,
+        )
+        assert is_spoofed_bot(rr) is False
+
+    def test_is_verified_bot_live(self, mock_protobuf_modules):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        rr = self._bot_result(
+            mock_protobuf_modules,
+            spoofed=False,
+            verified=True,
+            state=decide_pb2.RULE_STATE_RUN,
+        )
+        assert is_verified_bot(rr) is True
+        assert is_spoofed_bot(rr) is False
+
+    def test_is_verified_bot_ignores_dry_run(self, mock_protobuf_modules):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        rr = self._bot_result(
+            mock_protobuf_modules,
+            spoofed=False,
+            verified=True,
+            state=decide_pb2.RULE_STATE_DRY_RUN,
+        )
+        assert is_verified_bot(rr) is False
+
+    def test_is_missing_user_agent(self, mock_protobuf_modules):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        rr = decide_pb2.RuleResult(
+            rule_id="r1",
+            state=decide_pb2.RULE_STATE_RUN,
+            conclusion=decide_pb2.CONCLUSION_ERROR,
+            reason=decide_pb2.Reason(
+                error=decide_pb2.ErrorReason(message="missing User-Agent header")
+            ),
+        )
+        assert is_missing_user_agent(SDKRuleResult(rr)) is True
+
+    def test_is_missing_user_agent_ignores_dry_run(self, mock_protobuf_modules):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        rr = decide_pb2.RuleResult(
+            rule_id="r1",
+            state=decide_pb2.RULE_STATE_DRY_RUN,
+            conclusion=decide_pb2.CONCLUSION_ERROR,
+            reason=decide_pb2.Reason(
+                error=decide_pb2.ErrorReason(message="missing User-Agent header")
+            ),
+        )
+        assert is_missing_user_agent(SDKRuleResult(rr)) is False
+
+    def test_helpers_false_for_non_bot_reason(self, mock_protobuf_modules):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        rr = decide_pb2.RuleResult(
+            rule_id="r1",
+            state=decide_pb2.RULE_STATE_RUN,
+            conclusion=decide_pb2.CONCLUSION_DENY,
+            reason=decide_pb2.Reason(
+                error=decide_pb2.ErrorReason(message="something else")
+            ),
+        )
+        wrapped = SDKRuleResult(rr)
+        assert is_spoofed_bot(wrapped) is False
+        assert is_verified_bot(wrapped) is False
+        assert is_missing_user_agent(wrapped) is False
+
+
+# ---------------------------------------------------------------------------
+# 7. with_rule shares the cache
+# ---------------------------------------------------------------------------
+
+
+class TestWithRule:
+    def test_with_rule_appends_and_shares_cache(
+        self, mock_protobuf_modules, dev_environment
+    ):
+        from arcjet import arcjet_sync
+        from arcjet._rules import Mode, detect_bot, shield
+
+        base = arcjet_sync(key="ajkey_test", rules=[shield(mode=Mode.LIVE)])
+        clone = base.with_rule(
+            detect_bot(mode=Mode.LIVE, allow=["CATEGORY:SEARCH_ENGINE"])
+        )
+
+        assert clone is not base
+        assert len(base._rules) == 1
+        assert len(clone._rules) == 2
+        assert clone._cache is base._cache
+
+    def test_with_rule_recomputes_email_flag(
+        self, mock_protobuf_modules, dev_environment
+    ):
+        from arcjet import arcjet_sync
+        from arcjet._rules import EmailType, Mode, shield, validate_email
+
+        base = arcjet_sync(key="ajkey_test", rules=[shield(mode=Mode.LIVE)])
+        assert base._needs_email is False
+        clone = base.with_rule(
+            validate_email(mode=Mode.LIVE, deny=[EmailType.INVALID])
+        )
+        assert clone._needs_email is True
+        assert base._needs_email is False
+
+    def test_with_rule_accepts_protect_signup_tuple(
+        self, mock_protobuf_modules, dev_environment
+    ):
+        from arcjet import arcjet_sync
+        from arcjet._rules import EmailType, Mode, protect_signup, shield
+
+        base = arcjet_sync(key="ajkey_test", rules=[shield(mode=Mode.LIVE)])
+        clone = base.with_rule(
+            protect_signup(
+                rate_limit={"mode": Mode.LIVE, "max": 5, "interval": 60},
+                bots={"mode": Mode.LIVE, "allow": []},
+                email={"mode": Mode.LIVE, "deny": [EmailType.DISPOSABLE]},
+            )
+        )
+        assert len(clone._rules) == 4
+        assert clone._needs_email is True
+
+    def test_async_with_rule_shares_cache(
+        self, mock_protobuf_modules, dev_environment
+    ):
+        from arcjet import arcjet
+        from arcjet._rules import Mode, detect_bot, shield
+
+        base = arcjet(key="ajkey_test", rules=[shield(mode=Mode.LIVE)])
+        clone = base.with_rule(
+            detect_bot(mode=Mode.LIVE, allow=["CATEGORY:SEARCH_ENGINE"])
+        )
+        assert clone is not base
+        assert clone._cache is base._cache
+        assert len(clone._rules) == 2
+
+
+# ---------------------------------------------------------------------------
+# 8. protect_signup
+# ---------------------------------------------------------------------------
+
+
+class TestProtectSignup:
+    def test_returns_three_rules(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, (
+            BotDetection,
+            EmailType,
+            EmailValidation,
+            Mode,
+            SlidingWindow,
+            protect_signup,
+        )
+
+        rules = protect_signup(
+            rate_limit={"mode": Mode.LIVE, "max": 5, "interval": 600},
+            bots={"mode": Mode.LIVE, "allow": []},
+            email={
+                "mode": Mode.LIVE,
+                "deny": [EmailType.DISPOSABLE, EmailType.INVALID],
+            },
+        )
+        assert len(rules) == 3
+        assert isinstance(rules[0], SlidingWindow)
+        assert isinstance(rules[1], BotDetection)
+        assert isinstance(rules[2], EmailValidation)
+        assert rules[0].max == 5
+        assert rules[1].allow == ()
+        assert rules[2].deny is not None
+
+    def test_rejects_bot_without_allow_or_deny(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, protect_signup
+
+        with pytest.raises(ValueError, match="either `allow` or `deny`"):
+            protect_signup(
+                rate_limit={"mode": Mode.LIVE, "max": 5, "interval": 60},
+                bots={"mode": Mode.LIVE},
+                email={"mode": Mode.LIVE, "deny": ["INVALID"]},
+            )
+
+    def test_requires_mode_on_nested_factories(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, protect_signup
+
+        with pytest.raises(TypeError, match="mode"):
+            protect_signup(
+                rate_limit={"max": 5, "interval": 60},
+                bots={"mode": Mode.LIVE, "allow": []},
+                email={"mode": Mode.LIVE, "deny": ["INVALID"]},
+            )
+
+
+# ---------------------------------------------------------------------------
+# 10. Rate-limit header helper
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitHeaders:
+    def test_sets_ietf_headers(self, mock_protobuf_modules):
+        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+
+        from arcjet import set_rate_limit_headers
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        rl = StubRateLimitReason(
+            max=100, remaining=3, reset_in_seconds=9, window_in_seconds=60
+        )
+        decision = Decision(
+            decide_pb2.Decision(
+                id="d1",
+                conclusion=decide_pb2.CONCLUSION_ALLOW,
+                reason=decide_pb2.Reason(rate_limit=rl),
+            )
+        )
+        headers: dict[str, str] = {}
+        set_rate_limit_headers(headers, decision)
+        assert headers["RateLimit"] == "limit=100, remaining=3, reset=9"
+        assert headers["RateLimit-Policy"] == "100;w=60"
+
+    def test_uses_response_headers_attribute(self, mock_protobuf_modules):
+        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+
+        from arcjet import set_rate_limit_headers
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        class Response:
+            def __init__(self) -> None:
+                self.headers: dict[str, str] = {}
+
+        rl = StubRateLimitReason(
+            max=10, remaining=0, reset_in_seconds=4, window_in_seconds=10
+        )
+        decision = Decision(
+            decide_pb2.Decision(
+                id="d1",
+                conclusion=decide_pb2.CONCLUSION_DENY,
+                reason=decide_pb2.Reason(rate_limit=rl),
+            )
+        )
+        response = Response()
+        set_rate_limit_headers(response, decision)
+        assert "RateLimit" in response.headers
+
+    def test_noop_when_not_rate_limited(self, mock_protobuf_modules):
+        from arcjet import set_rate_limit_headers
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        decision = Decision(
+            decide_pb2.Decision(id="d1", conclusion=decide_pb2.CONCLUSION_ALLOW)
+        )
+        headers: dict[str, str] = {}
+        set_rate_limit_headers(headers, decision)
+        assert headers == {}
+
+    def _decision_with_reasons(self, mock_protobuf_modules, *reasons):
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        results = [
+            decide_pb2.RuleResult(
+                rule_id=f"r{i}",
+                state=decide_pb2.RULE_STATE_RUN,
+                conclusion=decide_pb2.CONCLUSION_ALLOW,
+                reason=decide_pb2.Reason(rate_limit=reason),
+            )
+            for i, reason in enumerate(reasons)
+        ]
+        return Decision(
+            decide_pb2.Decision(
+                id="d1",
+                conclusion=decide_pb2.CONCLUSION_ALLOW,
+                rule_results=results,
+            )
+        )
+
+    def test_nearest_remaining_wins(self, mock_protobuf_modules):
+        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+
+        from arcjet import set_rate_limit_headers
+
+        decision = self._decision_with_reasons(
+            mock_protobuf_modules,
+            StubRateLimitReason(
+                max=100, remaining=5, reset_in_seconds=20, window_in_seconds=60
+            ),
+            StubRateLimitReason(
+                max=10, remaining=1, reset_in_seconds=30, window_in_seconds=10
+            ),
+        )
+        headers: dict[str, str] = {}
+        set_rate_limit_headers(headers, decision)
+        assert headers["RateLimit"] == "limit=10, remaining=1, reset=30"
+        assert headers["RateLimit-Policy"] == "10;w=10, 100;w=60"
+
+    def test_duplicate_max_aborts(self, mock_protobuf_modules):
+        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+
+        from arcjet import set_rate_limit_headers
+
+        decision = self._decision_with_reasons(
+            mock_protobuf_modules,
+            StubRateLimitReason(
+                max=10, remaining=5, reset_in_seconds=9, window_in_seconds=60
+            ),
+            StubRateLimitReason(
+                max=10, remaining=1, reset_in_seconds=4, window_in_seconds=10
+            ),
+        )
+        headers: dict[str, str] = {}
+        set_rate_limit_headers(headers, decision)
+        assert headers == {}
+
+    def test_fetch_style_headers(self, mock_protobuf_modules):
+        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+
+        from arcjet import set_rate_limit_headers
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        class FetchHeaders:
+            def __init__(self) -> None:
+                self._data: dict[str, str] = {}
+
+            def has(self, name: str) -> bool:
+                return name in self._data
+
+            def get(self, name: str) -> str | None:
+                return self._data.get(name)
+
+            def set(self, name: str, value: str) -> None:
+                self._data[name] = value
+
+        rl = StubRateLimitReason(
+            max=10, remaining=2, reset_in_seconds=8, window_in_seconds=10
+        )
+        decision = Decision(
+            decide_pb2.Decision(
+                id="d1",
+                conclusion=decide_pb2.CONCLUSION_ALLOW,
+                reason=decide_pb2.Reason(rate_limit=rl),
+            )
+        )
+        headers = FetchHeaders()
+        set_rate_limit_headers(headers, decision)
+        assert headers.get("RateLimit") == "limit=10, remaining=2, reset=8"
+        assert headers.get("RateLimit-Policy") == "10;w=10"
+
+    def test_set_header_style_response(self, mock_protobuf_modules):
+        from tests.fixtures.protobuf_stubs import StubRateLimitReason
+
+        from arcjet import set_rate_limit_headers
+        from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+        class Outgoing:
+            def __init__(self) -> None:
+                self.headersSent = False
+                self._data: dict[str, str] = {}
+
+            def hasHeader(self, name: str) -> bool:
+                return name in self._data
+
+            def getHeader(self, name: str) -> str | None:
+                return self._data.get(name)
+
+            def setHeader(self, name: str, value: str) -> None:
+                self._data[name] = value
+
+        rl = StubRateLimitReason(
+            max=5, remaining=0, reset_in_seconds=3, window_in_seconds=5
+        )
+        decision = Decision(
+            decide_pb2.Decision(
+                id="d1",
+                conclusion=decide_pb2.CONCLUSION_DENY,
+                reason=decide_pb2.Reason(rate_limit=rl),
+            )
+        )
+        response = Outgoing()
+        set_rate_limit_headers(response, decision)
+        assert response.getHeader("RateLimit") == "limit=5, remaining=0, reset=3"
+
+
+# ---------------------------------------------------------------------------
+# 11. Prompt-injection threshold removed
+# ---------------------------------------------------------------------------
+
+
+class TestPromptInjectionThresholdRemoved:
+    def test_factory_rejects_threshold(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, detect_prompt_injection
+
+        with pytest.raises(TypeError, match="threshold"):
+            detect_prompt_injection(mode=Mode.LIVE, threshold=0.8)  # type: ignore[call-arg]
+
+    def test_proto_omits_custom_threshold(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, detect_prompt_injection
+
+        rule = detect_prompt_injection(mode=Mode.LIVE)
+        assert not hasattr(rule, "threshold") or getattr(rule, "threshold", None) is None
+        pb = rule.to_proto()
+        assert pb.prompt_injection_detection.mode == mock_protobuf_modules["pb2"].MODE_LIVE
+
+
+# ---------------------------------------------------------------------------
+# 12. Guard does not read ARCJET_KEY
+# ---------------------------------------------------------------------------
+
+
+class TestGuardKeyPolicy:
+    def test_empty_key_rejected_even_when_env_set(self, monkeypatch: Any):
+        from arcjet._errors import ArcjetMisconfiguration
+        from arcjet.guard import launch_arcjet, launch_arcjet_sync
+
+        monkeypatch.setenv("ARCJET_KEY", "ajkey_from_env")
+        with pytest.raises(ArcjetMisconfiguration, match="required"):
+            launch_arcjet(key="")
+        with pytest.raises(ArcjetMisconfiguration, match="required"):
+            launch_arcjet_sync(key="")

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -21,9 +21,9 @@ def test_shield_to_proto_and_characteristics(mock_protobuf_modules):
 
 def test_detect_bot_allows_categories_and_names(mock_protobuf_modules):
     """Test detect_bot rule accepts both categories and string names."""
-    from arcjet._rules import BotCategory, detect_bot
+    from arcjet._rules import BotCategory, Mode, detect_bot
 
-    r = detect_bot(allow=(BotCategory.GOOGLE, "OPENAI_CRAWLER_SEARCH"))
+    r = detect_bot(mode=Mode.LIVE, allow=(BotCategory.GOOGLE, "OPENAI_CRAWLER_SEARCH"))
     pb = r.to_proto()
     assert pb.bot_v2.allow == [BotCategory.GOOGLE.value, "OPENAI_CRAWLER_SEARCH"]
 
@@ -40,35 +40,35 @@ def test_rate_limit_builders_validation_and_proto(mock_protobuf_modules):
     )
     assert pb.rate_limit.interval == 60
 
-    fw = fixed_window(max=100, window=60)
+    fw = fixed_window(mode=Mode.LIVE, max=100, window=60)
     pb2 = fw.to_proto()
     assert pb2.rate_limit.max == 100
 
-    sw = sliding_window(max=77, interval=30)
+    sw = sliding_window(mode=Mode.LIVE, max=77, interval=30)
     pb3 = sw.to_proto()
     assert pb3.rate_limit.interval == 30
 
     with pytest.raises(ValueError):
-        token_bucket(refill_rate=0, interval=1, capacity=1)
+        token_bucket(mode=Mode.LIVE, refill_rate=0, interval=1, capacity=1)
 
     with pytest.raises(ValueError):
-        fixed_window(max=0, window=1)
+        fixed_window(mode=Mode.LIVE, max=0, window=1)
 
     with pytest.raises(ValueError):
-        sliding_window(max=1, interval=0)
+        sliding_window(mode=Mode.LIVE, max=1, interval=0)
 
 
 def test_validate_email_coercion_and_proto(mock_protobuf_modules):
     """Test validate_email rule coerces string/enum types and converts to protobuf."""
-    from arcjet._rules import EmailType, validate_email
+    from arcjet._rules import EmailType, Mode, validate_email
 
-    r = validate_email(deny=(EmailType.DISPOSABLE, "INVALID"))
+    r = validate_email(mode=Mode.LIVE, deny=(EmailType.DISPOSABLE, "INVALID"))
     pb = r.to_proto()
     assert mock_protobuf_modules["pb2"].EMAIL_TYPE_DISPOSABLE in pb.email.deny
     assert mock_protobuf_modules["pb2"].EMAIL_TYPE_INVALID in pb.email.deny
     assert pb.email.allow == []
 
-    r = validate_email(allow=(EmailType.NO_MX_RECORDS, "FREE"))
+    r = validate_email(mode=Mode.LIVE, allow=(EmailType.NO_MX_RECORDS, "FREE"))
     pb = r.to_proto()
     assert mock_protobuf_modules["pb2"].EMAIL_TYPE_NO_MX_RECORDS in pb.email.allow
     assert mock_protobuf_modules["pb2"].EMAIL_TYPE_FREE in pb.email.allow
@@ -77,7 +77,7 @@ def test_validate_email_coercion_and_proto(mock_protobuf_modules):
 
 def test_rule_spec_get_characteristics_with_non_tuple():
     """Test get_characteristics with non-tuple characteristics."""
-    from arcjet._rules import RuleSpec
+    from arcjet._rules import Mode, RuleSpec
     from arcjet.proto.decide.v1alpha1 import decide_pb2
 
     # Create a mock RuleSpec subclass with non-tuple characteristics
@@ -98,7 +98,7 @@ def test_rule_spec_get_characteristics_with_non_tuple():
 
 def test_rule_spec_get_characteristics_with_invalid_items():
     """Test get_characteristics filters out invalid items."""
-    from arcjet._rules import RuleSpec
+    from arcjet._rules import Mode, RuleSpec
     from arcjet.proto.decide.v1alpha1 import decide_pb2
 
     class TestRule(RuleSpec):
@@ -117,7 +117,7 @@ def test_rule_spec_get_characteristics_with_invalid_items():
 
 def test_rule_spec_get_characteristics_conversion_fails():
     """Test get_characteristics when conversion to tuple fails."""
-    from arcjet._rules import RuleSpec
+    from arcjet._rules import Mode, RuleSpec
     from arcjet.proto.decide.v1alpha1 import decide_pb2
 
     class NonIterableCharacteristics:
@@ -149,9 +149,9 @@ def test_apply_global_characteristics_to_rate_limit_rules():
         token_bucket,
     )
 
-    tb = token_bucket(refill_rate=1, interval=1, capacity=1)
-    fw = fixed_window(max=10, window=60)
-    sw = sliding_window(max=10, interval=60)
+    tb = token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)
+    fw = fixed_window(mode=Mode.LIVE, max=10, window=60)
+    sw = sliding_window(mode=Mode.LIVE, max=10, interval=60)
     sh = shield(mode=Mode.LIVE)
 
     rules = (tb, fw, sw, sh)
@@ -168,10 +168,14 @@ def test_apply_global_characteristics_to_rate_limit_rules():
 def test_apply_global_characteristics_does_not_override_per_rule():
     """Per-rule characteristics take precedence over global characteristics."""
     from arcjet._client import _apply_global_characteristics
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
     tb = token_bucket(
-        refill_rate=1, interval=1, capacity=1, characteristics=("ip.src",)
+        mode=Mode.LIVE,
+        refill_rate=1,
+        interval=1,
+        capacity=1,
+        characteristics=("ip.src",),
     )
     result = _apply_global_characteristics((tb,), ("userId",))
 
@@ -182,47 +186,30 @@ def test_apply_global_characteristics_does_not_override_per_rule():
 def test_apply_global_characteristics_noop_when_empty():
     """Empty global characteristics returns rules unchanged."""
     from arcjet._client import _apply_global_characteristics
-    from arcjet._rules import token_bucket
+    from arcjet._rules import Mode, token_bucket
 
-    tb = token_bucket(refill_rate=1, interval=1, capacity=1)
+    tb = token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)
     result = _apply_global_characteristics((tb,), ())
 
     assert result[0].get_characteristics() == ()
 
 
 def test_detect_prompt_injection_to_proto(mock_protobuf_modules):
-    """Test detect_prompt_injection rule converts to protobuf with mode and threshold."""
+    """Test detect_prompt_injection rule converts to protobuf with mode."""
     from arcjet._rules import Mode, detect_prompt_injection
 
-    r = detect_prompt_injection(mode=Mode.LIVE, threshold=0.9)
+    r = detect_prompt_injection(mode=Mode.LIVE)
     pb = r.to_proto()
     assert pb.prompt_injection_detection is not None
     assert pb.prompt_injection_detection.mode == mock_protobuf_modules["pb2"].MODE_LIVE
-    assert pb.prompt_injection_detection.threshold == 0.9
 
 
-def test_detect_prompt_injection_default_threshold(mock_protobuf_modules):
-    """Test detect_prompt_injection uses default threshold of 0.5."""
+def test_detect_prompt_injection_dry_run(mock_protobuf_modules):
+    """Test detect_prompt_injection accepts DRY_RUN mode."""
     from arcjet._rules import Mode, detect_prompt_injection
 
     r = detect_prompt_injection(mode=Mode.DRY_RUN)
     pb = r.to_proto()
-    assert pb.prompt_injection_detection.threshold == 0.5
-
-
-def test_detect_prompt_injection_validation(mock_protobuf_modules):
-    """Test detect_prompt_injection validates threshold range."""
-    from arcjet._rules import detect_prompt_injection
-
-    with pytest.raises(ValueError, match="between 0.0 and 1.0"):
-        detect_prompt_injection(threshold=1.5)
-
-    with pytest.raises(ValueError, match="between 0.0 and 1.0"):
-        detect_prompt_injection(threshold=-0.1)
-
-    # Edge cases should work
-    r1 = detect_prompt_injection(threshold=0.0)
-    assert r1.threshold == 0.0
-
-    r2 = detect_prompt_injection(threshold=1.0)
-    assert r2.threshold == 1.0
+    assert (
+        pb.prompt_injection_detection.mode == mock_protobuf_modules["pb2"].MODE_DRY_RUN
+    )

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -77,7 +77,7 @@ def test_validate_email_coercion_and_proto(mock_protobuf_modules):
 
 def test_rule_spec_get_characteristics_with_non_tuple():
     """Test get_characteristics with non-tuple characteristics."""
-    from arcjet._rules import Mode, RuleSpec
+    from arcjet._rules import RuleSpec
     from arcjet.proto.decide.v1alpha1 import decide_pb2
 
     # Create a mock RuleSpec subclass with non-tuple characteristics
@@ -98,7 +98,7 @@ def test_rule_spec_get_characteristics_with_non_tuple():
 
 def test_rule_spec_get_characteristics_with_invalid_items():
     """Test get_characteristics filters out invalid items."""
-    from arcjet._rules import Mode, RuleSpec
+    from arcjet._rules import RuleSpec
     from arcjet.proto.decide.v1alpha1 import decide_pb2
 
     class TestRule(RuleSpec):
@@ -117,7 +117,7 @@ def test_rule_spec_get_characteristics_with_invalid_items():
 
 def test_rule_spec_get_characteristics_conversion_fails():
     """Test get_characteristics when conversion to tuple fails."""
-    from arcjet._rules import Mode, RuleSpec
+    from arcjet._rules import RuleSpec
     from arcjet.proto.decide.v1alpha1 import decide_pb2
 
     class NonIterableCharacteristics:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the remaining JS/Python core-SDK parity gaps (items 6 and 9 were out of scope). Pattern is the JS SDK (`arcjet-js` v1.10.0) wherever the Python API had to choose a direction.

## Before

- Cache hits returned the same mutable `Decision` the cache held. `ttl` and rate-limit `reset` stayed frozen at write time, and mutating `.id` on one caller changed every later hit.
- HTTP rule factories defaulted `mode` to `LIVE`. Porting `detectBot({ allow: [...] })` from JS silently switched observe-only to live blocking.
- `detect_bot()` / `validate_email()` accepted both `allow` and `deny`, or neither (allow-all-bots).
- Local WASM rules ran in declaration order. A later Sensitive Info LIVE DENY could lose to an earlier Bot DENY.
- `is_spoofed_bot()` treated `DRY_RUN` results as live. No `is_verified_bot`, `is_missing_user_agent`, `with_rule`, `protect_signup`, or rate-limit header helper.
- `detect_prompt_injection(threshold=...)` was still accepted even though the server ignores it.

## After

- Cache hits deep-copy the proto, assign a fresh `lreq_…` id, set `ttl` to remaining lifetime (floored at 1s), and rewrite rate-limit `reset`.
- HTTP factories require `mode=`. Guard keeps the JS default of `LIVE`.
- `detect_bot` / `validate_email` require exactly one of `allow` or `deny`. `allow=[]` blocks every bot, matching JS.
- Local evaluation order is JS priority: Sensitive Info → Filter → Shield → Rate Limit → Bot → Email → Prompt Injection.
- Inspect helpers skip `DRY_RUN`. New exports: `is_verified_bot`, `is_missing_user_agent`, `set_rate_limit_headers`, `protect_signup`, `Arcjet.with_rule()` / `ArcjetSync.with_rule()` (shared `DecisionCache`).
- Prompt-injection `threshold` is removed. Guard docs state it never reads `ARCJET_KEY`.

## Why

Wrong `Retry-After` / TTL on cache hits is a correctness bug in any language. Defaulting HTTP `mode` to `LIVE` is a silent security footgun when porting from JS (`DRY_RUN`). Allow/deny exclusivity, Sensitive Info-first local eval, and dry-run-aware inspect helpers are the JS contracts callers already write against. `with_rule` exists so per-route clones do not throw away the denial cache.

## Example

```python
from arcjet import (
    EmailType,
    Mode,
    arcjet,
    is_spoofed_bot,
    protect_signup,
    set_rate_limit_headers,
)

aj = arcjet(key="ajkey_...", rules=[])
signup = aj.with_rule(
    protect_signup(
        rate_limit={"mode": Mode.LIVE, "max": 5, "interval": 600},
        bots={"mode": Mode.LIVE, "allow": []},
        email={
            "mode": Mode.LIVE,
            "deny": [EmailType.DISPOSABLE, EmailType.INVALID],
        },
    )
)

decision = await signup.protect(request, email=email, requested=1)
set_rate_limit_headers(response, decision)
if decision.is_denied() or any(is_spoofed_bot(r) for r in decision.results):
    return JSONResponse({"error": "Forbidden"}, status_code=403)
```

**Breaking:** HTTP rule factories now require `mode`. `detect_bot` / `validate_email` require exactly one of `allow` or `deny`. `detect_prompt_injection` no longer accepts `threshold`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90757ce-8fcd-498c-9afc-acfa39095e80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90757ce-8fcd-498c-9afc-acfa39095e80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

