### PR TITLE
fix: evaluate local rules in JS priority order

### DIFF
--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -66,6 +66,7 @@ from ._rules import (
     PromptInjectionDetection,
     RuleSpec,
     SensitiveInfoDetection,
+    Shield,
     SlidingWindow,
     TokenBucket,
 )
@@ -205,6 +206,27 @@ def _sdk_version(default: str = "0.0.0") -> str:
         return default
 
 
+# Local evaluation order matches the JS SDK priority table. The first LIVE
+# DENY wins, so Sensitive Info must run before any rule that might forward
+# the payload.
+_LOCAL_RULE_PRIORITY: dict[type[RuleSpec], int] = {
+    SensitiveInfoDetection: 1,
+    Filter: 2,
+    Shield: 3,
+    TokenBucket: 4,
+    FixedWindow: 4,
+    SlidingWindow: 4,
+    BotDetection: 5,
+    EmailValidation: 6,
+    PromptInjectionDetection: 7,
+}
+
+
+def _sort_rules_for_local(rules: Sequence[RuleSpec]) -> list[RuleSpec]:
+    """Sort rules by JS local-evaluation priority (stable for equal ranks)."""
+    return sorted(rules, key=lambda rule: _LOCAL_RULE_PRIORITY.get(type(rule), 100))
+
+
 def _run_local_rules(
     ctx: RequestContext,
     rules: tuple[RuleSpec, ...],
@@ -213,10 +235,13 @@ def _run_local_rules(
 
     Returns a DENY Decision if any rule denies in LIVE mode (short-circuit),
     or None if all locally-evaluated rules allow (proceed to remote API).
+
+    Rules are evaluated in JS priority order, not declaration order, so a
+    Sensitive Info LIVE DENY is reported before a later Bot/Email DENY.
     """
     local_results: list[decide_pb2.RuleResult] = []
 
-    for rule in rules:
+    for rule in _sort_rules_for_local(rules):
         result: decide_pb2.RuleResult | None = None
         if isinstance(rule, BotDetection):
             result = evaluate_bot_locally(ctx, rule)

--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -209,6 +209,10 @@ def _sdk_version(default: str = "0.0.0") -> str:
 # Local evaluation order matches the JS SDK priority table. The first LIVE
 # DENY wins, so Sensitive Info must run before any rule that might forward
 # the payload.
+#
+# PromptInjectionDetection is listed for JS-order parity only. It is not
+# evaluated locally today — ``_run_local_rules`` has no PI branch — so the
+# rank is reserved until a local evaluator is wired up.
 _LOCAL_RULE_PRIORITY: dict[type[RuleSpec], int] = {
     SensitiveInfoDetection: 1,
     Filter: 2,
@@ -220,11 +224,24 @@ _LOCAL_RULE_PRIORITY: dict[type[RuleSpec], int] = {
     EmailValidation: 6,
     PromptInjectionDetection: 7,
 }
+_UNMAPPED_LOCAL_PRIORITY = 100
+
+
+def _local_rule_priority(rule: RuleSpec) -> int:
+    """Return the JS local-evaluation rank, or the unmapped fallback."""
+    priority = _LOCAL_RULE_PRIORITY.get(type(rule))
+    if priority is not None:
+        return priority
+    logger.debug(
+        "No local-evaluation priority for %s; sorting after mapped rules",
+        type(rule).__name__,
+    )
+    return _UNMAPPED_LOCAL_PRIORITY
 
 
 def _sort_rules_for_local(rules: Sequence[RuleSpec]) -> list[RuleSpec]:
     """Sort rules by JS local-evaluation priority (stable for equal ranks)."""
-    return sorted(rules, key=lambda rule: _LOCAL_RULE_PRIORITY.get(type(rule), 100))
+    return sorted(rules, key=_local_rule_priority)
 
 
 def _run_local_rules(

--- a/tests/unit/test_local_rule_priority.py
+++ b/tests/unit/test_local_rule_priority.py
@@ -4,26 +4,25 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from arcjet._client import _run_local_rules, _sort_rules_for_local
-from arcjet._context import RequestContext
-from arcjet._rules import (
-    BotDetection,
-    EmailValidation,
-    Filter,
-    Mode,
-    SensitiveInfoDetection,
-    Shield,
-    SlidingWindow,
-    detect_bot,
-    detect_sensitive_info,
-    filter_request,
-    shield,
-    sliding_window,
-    validate_email,
-)
-
 
 def test_sort_matches_js_priority(mock_protobuf_modules):
+    from arcjet._client import _sort_rules_for_local
+    from arcjet._rules import (
+        BotDetection,
+        EmailValidation,
+        Filter,
+        Mode,
+        SensitiveInfoDetection,
+        Shield,
+        SlidingWindow,
+        detect_bot,
+        detect_sensitive_info,
+        filter_request,
+        shield,
+        sliding_window,
+        validate_email,
+    )
+
     bot = detect_bot(mode=Mode.LIVE, deny=["CURL"])
     email = validate_email(mode=Mode.LIVE, deny=["INVALID"])
     filt = filter_request(mode=Mode.LIVE, deny=["ip.src == 1"])
@@ -42,6 +41,9 @@ def test_sort_matches_js_priority(mock_protobuf_modules):
 
 
 def test_sensitive_info_denies_before_later_bot(mock_protobuf_modules):
+    from arcjet._client import _run_local_rules
+    from arcjet._context import RequestContext
+    from arcjet._rules import Mode, detect_bot, detect_sensitive_info
     from arcjet.proto.decide.v1alpha1 import decide_pb2
 
     bot = detect_bot(mode=Mode.LIVE, deny=["CURL"])

--- a/tests/unit/test_local_rule_priority.py
+++ b/tests/unit/test_local_rule_priority.py
@@ -1,0 +1,82 @@
+"""Local WASM rules evaluate in JS priority order."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from arcjet._client import _run_local_rules, _sort_rules_for_local
+from arcjet._context import RequestContext
+from arcjet._rules import (
+    BotDetection,
+    EmailValidation,
+    Filter,
+    Mode,
+    SensitiveInfoDetection,
+    Shield,
+    SlidingWindow,
+    detect_bot,
+    detect_sensitive_info,
+    filter_request,
+    shield,
+    sliding_window,
+    validate_email,
+)
+
+
+def test_sort_matches_js_priority(mock_protobuf_modules):
+    bot = detect_bot(mode=Mode.LIVE, deny=["CURL"])
+    email = validate_email(mode=Mode.LIVE, deny=["INVALID"])
+    filt = filter_request(mode=Mode.LIVE, deny=["ip.src == 1"])
+    rl = sliding_window(mode=Mode.LIVE, max=5, interval=60)
+    sh = shield(mode=Mode.LIVE)
+    sensi = detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"])
+    ordered = _sort_rules_for_local((bot, email, filt, rl, sh, sensi))
+    assert [type(r) for r in ordered] == [
+        SensitiveInfoDetection,
+        Filter,
+        Shield,
+        SlidingWindow,
+        BotDetection,
+        EmailValidation,
+    ]
+
+
+def test_sensitive_info_denies_before_later_bot(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    bot = detect_bot(mode=Mode.LIVE, deny=["CURL"])
+    sensi = detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"])
+    si_deny = decide_pb2.RuleResult(
+        rule_id="si",
+        state=decide_pb2.RULE_STATE_RUN,
+        conclusion=decide_pb2.CONCLUSION_DENY,
+        reason=decide_pb2.Reason(error=decide_pb2.ErrorReason(message="pii")),
+    )
+    bot_deny = decide_pb2.RuleResult(
+        rule_id="bot",
+        state=decide_pb2.RULE_STATE_RUN,
+        conclusion=decide_pb2.CONCLUSION_DENY,
+        reason=decide_pb2.Reason(error=decide_pb2.ErrorReason(message="bot")),
+    )
+    calls: list[str] = []
+
+    def track_si(_ctx, _rule):
+        calls.append("si")
+        return si_deny
+
+    def track_bot(_ctx, _rule):
+        calls.append("bot")
+        return bot_deny
+
+    ctx = RequestContext(ip="1.2.3.4")
+    with (
+        patch("arcjet._client.evaluate_sensitive_info_locally", side_effect=track_si),
+        patch("arcjet._client.evaluate_filter_locally", return_value=None),
+        patch("arcjet._client.evaluate_bot_locally", side_effect=track_bot),
+        patch("arcjet._client.evaluate_email_locally", return_value=None),
+    ):
+        decision = _run_local_rules(ctx, (bot, sensi))
+
+    assert calls == ["si"]
+    assert decision is not None
+    assert decision.results[0].rule_id == "si"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Local WASM evaluation now sorts rules by the JS priority table instead of declaration order. The first LIVE DENY still short-circuits, so Sensitive Info is reported before a later Bot or Email DENY.

Order: Sensitive Info → Filter → Shield → rate-limit → Bot → Email → Prompt Injection.

### Before

```python
# bot declared first, so a bot DENY won even if sensitive info also denied
aj = arcjet(rules=[detect_bot(...), detect_sensitive_info(...)])
```

### After

```python
# same declaration; local eval still runs Sensitive Info first
aj = arcjet(
    key="ajkey_...",
    rules=[
        detect_bot(mode=Mode.LIVE, deny=["CURL"]),
        detect_sensitive_info(mode=Mode.LIVE, deny=["EMAIL"]),
    ],
)
```

### Why

JS always evaluates local rules in a fixed priority so the reason the user sees is stable across SDKs, not dependent on how the `rules` list was written.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90757ce-8fcd-498c-9afc-acfa39095e80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90757ce-8fcd-498c-9afc-acfa39095e80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

