### PR TITLE
feat: add inspect helpers and `set_rate_limit_headers`

### DIFF
--- a/src/arcjet/__init__.py
+++ b/src/arcjet/__init__.py
@@ -7,9 +7,12 @@ from ._decision import (
     IpInfo,
     Reason,  # type: ignore -- intentionally deprecated
     RuleResult,
+    is_missing_user_agent,
     is_spoofed_bot,
+    is_verified_bot,
 )
 from ._enums import Mode
+from ._headers import set_rate_limit_headers
 from ._metadata import Metadata, MetadataValue
 from ._rules import (
     BotCategory,
@@ -53,7 +56,10 @@ __all__ = [
     "IpInfo",
     "IpDetails",
     "ThreatIntelligence",
+    "is_missing_user_agent",
     "is_spoofed_bot",
+    "is_verified_bot",
+    "set_rate_limit_headers",
     "Metadata",
     "MetadataValue",
     "Mode",

--- a/src/arcjet/_decision.py
+++ b/src/arcjet/_decision.py
@@ -419,3 +419,71 @@ def is_spoofed_bot(result: RuleResult) -> bool:
     if r.WhichOneof("reason") == "bot_v2":
         return bool(r.bot_v2.spoofed)
     return False
+
+
+def _is_active_result(result: RuleResult) -> bool:
+    """Return ``True`` when a rule result is not a dry-run observation."""
+    return result.state != decide_pb2.RULE_STATE_DRY_RUN
+
+
+def is_verified_bot(result: RuleResult) -> bool:
+    """Return ``True`` if a live bot rule verified a known legitimate bot.
+
+    Verified bots are identified by matching the client IP against official
+    ranges for that crawler (e.g. Googlebot). Results from ``DRY_RUN`` rules
+    are ignored.
+
+    Args:
+        result: A single ``RuleResult`` from ``decision.results``.
+
+    Returns:
+        ``True`` when a live bot rule verified the client as a known bot.
+
+    Example::
+
+        from arcjet import is_verified_bot
+
+        if any(is_verified_bot(r) for r in decision.results):
+            return jsonify(message="Hello bot")
+    """
+    if not _is_active_result(result):
+        return False
+    r = result.raw.reason
+    if not r:
+        return False
+    if r.WhichOneof("reason") == "bot_v2":
+        return bool(r.bot_v2.verified)
+    return False
+
+
+def is_missing_user_agent(result: RuleResult) -> bool:
+    """Return ``True`` if a live bot rule failed because ``User-Agent`` was missing.
+
+    A missing ``User-Agent`` is a strong signal of a non-browser client.
+    Results from ``DRY_RUN`` rules are ignored.
+
+    Args:
+        result: A single ``RuleResult`` from ``decision.results``.
+
+    Returns:
+        ``True`` when a live bot rule reported a missing ``User-Agent`` header.
+
+    Example::
+
+        from arcjet import is_missing_user_agent
+
+        if any(is_missing_user_agent(r) for r in decision.results):
+            return jsonify(error="User-Agent required"), 403
+    """
+    if not _is_active_result(result):
+        return False
+    r = result.raw.reason
+    if not r:
+        return False
+    if r.WhichOneof("reason") != "error":
+        return False
+    message = getattr(r.error, "message", "") or ""
+    return (
+        "missing User-Agent header" in message
+        or "requires user-agent header" in message
+    )

--- a/src/arcjet/_headers.py
+++ b/src/arcjet/_headers.py
@@ -1,0 +1,212 @@
+"""Helpers for applying Arcjet decisions to HTTP response headers.
+
+Mirrors ``@arcjet/decorate`` ``setRateLimitHeaders`` in the JS SDK: emit
+``RateLimit`` and ``RateLimit-Policy`` from the IETF Rate Limit Fields draft.
+"""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any
+
+from arcjet._dataclasses import RateLimitReason
+from arcjet._decision import Decision
+from arcjet._logging import logger
+
+
+def _to_limit_string(reason: RateLimitReason) -> str:
+    return (
+        f"limit={reason.max}, remaining={reason.remaining}, "
+        f"reset={int(reason.reset.total_seconds())}"
+    )
+
+
+def _to_policy_string(max_requests: int, window_seconds: int) -> str:
+    return f"{max_requests};w={window_seconds}"
+
+
+def _nearest_limit(current: RateLimitReason, nxt: RateLimitReason) -> RateLimitReason:
+    if current.remaining < nxt.remaining:
+        return current
+    if current.remaining > nxt.remaining:
+        return nxt
+    if current.reset < nxt.reset:
+        return current
+    if current.reset > nxt.reset:
+        return nxt
+    if current.max < nxt.max:
+        return current
+    return nxt
+
+
+def _as_rate_limit_reason(holder: Any) -> RateLimitReason | None:
+    """Return a ``RateLimitReason`` if *holder* has one, else ``None``.
+
+    ``Decision.reason_v2`` assumes a proto reason is present; ALLOW
+    decisions often have none, so we check before converting.
+    """
+    raw = getattr(holder, "raw", None)
+    if raw is None:
+        to_proto = getattr(holder, "to_proto", None)
+        raw = to_proto() if callable(to_proto) else None
+    if raw is None or getattr(raw, "reason", None) is None:
+        return None
+    typed = holder.reason_v2
+    # Discriminate on the public ``type`` field rather than ``isinstance``.
+    # Tests reload ``arcjet.*`` after stubbing protobuf, which can create a
+    # second ``RateLimitReason`` class object with the same name.
+    if getattr(typed, "type", None) == "RATE_LIMIT":
+        return typed
+    return None
+
+
+def _rate_limit_reasons(decision: Decision) -> list[RateLimitReason]:
+    reasons = [
+        reason
+        for result in decision.results
+        if (reason := _as_rate_limit_reason(result)) is not None
+    ]
+    if reasons:
+        return reasons
+    top = _as_rate_limit_reason(decision)
+    return [top] if top is not None else []
+
+
+def _is_header_like(value: Any) -> bool:
+    return (
+        hasattr(value, "has")
+        and callable(value.has)
+        and hasattr(value, "get")
+        and callable(value.get)
+        and hasattr(value, "set")
+        and callable(value.set)
+    )
+
+
+def _is_outgoing_message_like(value: Any) -> bool:
+    return (
+        isinstance(getattr(value, "headersSent", None), bool)
+        and hasattr(value, "hasHeader")
+        and callable(value.hasHeader)
+        and hasattr(value, "getHeader")
+        and callable(value.getHeader)
+        and hasattr(value, "setHeader")
+        and callable(value.setHeader)
+    )
+
+
+def _warn_existing(name: str, original: Any, new: str) -> None:
+    logger.warning(
+        "Response already contains `%s` header (original=%s new=%s)",
+        name,
+        original,
+        new,
+    )
+
+
+def _apply_headers(target: Any, limit: str, policy: str) -> bool:
+    """Write the two IETF headers onto *target*. Return ``False`` if unsupported."""
+    if _is_header_like(target):
+        if target.has("RateLimit"):
+            _warn_existing("RateLimit", target.get("RateLimit"), limit)
+        if target.has("RateLimit-Policy"):
+            _warn_existing("RateLimit-Policy", target.get("RateLimit-Policy"), policy)
+        target.set("RateLimit", limit)
+        target.set("RateLimit-Policy", policy)
+        return True
+
+    headers = getattr(target, "headers", None)
+    if headers is not None and _is_header_like(headers):
+        return _apply_headers(headers, limit, policy)
+
+    if _is_outgoing_message_like(target):
+        if target.headersSent:
+            logger.error("Headers have already been sent—cannot set RateLimit header")
+            return True
+        if target.hasHeader("RateLimit"):
+            _warn_existing("RateLimit", target.getHeader("RateLimit"), limit)
+        if target.hasHeader("RateLimit-Policy"):
+            _warn_existing(
+                "RateLimit-Policy", target.getHeader("RateLimit-Policy"), policy
+            )
+        target.setHeader("RateLimit", limit)
+        target.setHeader("RateLimit-Policy", policy)
+        return True
+
+    mapping: MutableMapping[str, str] | None
+    if isinstance(target, MutableMapping):
+        mapping = target
+    elif isinstance(headers, MutableMapping):
+        mapping = headers
+    elif headers is not None and hasattr(headers, "__setitem__"):
+        mapping = headers
+    elif hasattr(target, "__setitem__") and hasattr(target, "__contains__"):
+        mapping = target
+    else:
+        mapping = None
+
+    if mapping is None:
+        return False
+
+    if "RateLimit" in mapping:
+        _warn_existing("RateLimit", mapping["RateLimit"], limit)
+    if "RateLimit-Policy" in mapping:
+        _warn_existing("RateLimit-Policy", mapping["RateLimit-Policy"], policy)
+    mapping["RateLimit"] = limit
+    mapping["RateLimit-Policy"] = policy
+    return True
+
+
+def set_rate_limit_headers(target: Any, decision: Decision) -> None:
+    """Set ``RateLimit`` and ``RateLimit-Policy`` on a response or header map.
+
+    Accepts Fetch-style ``Headers`` (``.has`` / ``.get`` / ``.set``), an
+    object with those methods on ``.headers`` (Starlette / FastAPI /
+    Flask), a Node-style ``setHeader`` response, or a mutable mapping.
+
+    When several rate-limit results are present, the tightest remaining
+    budget is advertised, matching ``@arcjet/decorate``.
+
+    Args:
+        target: Response or header map to decorate.
+        decision: Decision returned from ``protect()``.
+
+    Example::
+
+        from arcjet import set_rate_limit_headers
+
+        decision = await aj.protect(request, requested=1)
+        set_rate_limit_headers(response, decision)
+        if decision.is_denied():
+            return JSONResponse({"error": "Too many requests"}, status_code=429)
+    """
+    reasons = _rate_limit_reasons(decision)
+    if not reasons:
+        return
+
+    policies: dict[int, int] = {}
+    for reason in reasons:
+        window_seconds = int(reason.window.total_seconds())
+        # JS rejects two policies that share the same limit, even when the
+        # windows match — the IETF field cannot disambiguate them.
+        if reason.max in policies:
+            logger.error(
+                "Invalid rate limit policy—two policies should not share the same limit"
+            )
+            return
+        policies[reason.max] = window_seconds
+
+    nearest = reasons[0]
+    for reason in reasons[1:]:
+        nearest = _nearest_limit(nearest, reason)
+
+    limit = _to_limit_string(nearest)
+    policy = ", ".join(
+        _to_policy_string(max_requests, window)
+        for max_requests, window in sorted(policies.items())
+    )
+
+    if not _apply_headers(target, limit, policy):
+        logger.debug(
+            "Cannot determine how to set RateLimit headers on %r", type(target)
+        )

--- a/tests/fixtures/protobuf_stubs.py
+++ b/tests/fixtures/protobuf_stubs.py
@@ -274,6 +274,27 @@ class StubRuleResult:
         self.ttl = ttl
 
 
+class StubRateLimitReason:
+    """Stub for protobuf RateLimitReason message."""
+
+    def __init__(
+        self,
+        max: int = 0,
+        remaining: int = 0,
+        reset_in_seconds: int = 0,
+        window_in_seconds: int = 0,
+        reset_time: Any = None,
+    ) -> None:
+        self.max = max
+        self.remaining = remaining
+        self.reset_in_seconds = reset_in_seconds
+        self.window_in_seconds = window_in_seconds
+        self.reset_time = reset_time
+
+    def HasField(self, name: str) -> bool:
+        return name == "reset_time" and self.reset_time is not None
+
+
 class StubDecision:
     """Stub for protobuf Decision message."""
 

--- a/tests/unit/test_inspect_and_headers.py
+++ b/tests/unit/test_inspect_and_headers.py
@@ -1,0 +1,282 @@
+"""Inspect helpers and IETF rate-limit response headers."""
+
+from __future__ import annotations
+
+import types
+
+from arcjet._decision import (
+    Decision,
+    is_missing_user_agent,
+    is_verified_bot,
+)
+from arcjet._decision import RuleResult as SDKRuleResult
+
+
+def _bot_result(mock_protobuf_modules, *, spoofed, verified, state):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    bot_v2 = types.SimpleNamespace(spoofed=spoofed, verified=verified)
+    rr = decide_pb2.RuleResult(
+        rule_id="r1",
+        state=state,
+        conclusion=decide_pb2.CONCLUSION_DENY,
+        reason=decide_pb2.Reason(bot_v2=bot_v2),  # type: ignore[arg-type]
+    )
+    return SDKRuleResult(rr)
+
+
+def test_is_verified_bot_live(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rr = _bot_result(
+        mock_protobuf_modules,
+        spoofed=False,
+        verified=True,
+        state=decide_pb2.RULE_STATE_RUN,
+    )
+    assert is_verified_bot(rr) is True
+
+
+def test_is_verified_bot_ignores_dry_run(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rr = _bot_result(
+        mock_protobuf_modules,
+        spoofed=False,
+        verified=True,
+        state=decide_pb2.RULE_STATE_DRY_RUN,
+    )
+    assert is_verified_bot(rr) is False
+
+
+def test_is_missing_user_agent(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rr = decide_pb2.RuleResult(
+        rule_id="r1",
+        state=decide_pb2.RULE_STATE_RUN,
+        conclusion=decide_pb2.CONCLUSION_ERROR,
+        reason=decide_pb2.Reason(
+            error=decide_pb2.ErrorReason(message="missing User-Agent header")
+        ),
+    )
+    assert is_missing_user_agent(SDKRuleResult(rr)) is True
+
+
+def test_is_missing_user_agent_ignores_dry_run(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rr = decide_pb2.RuleResult(
+        rule_id="r1",
+        state=decide_pb2.RULE_STATE_DRY_RUN,
+        conclusion=decide_pb2.CONCLUSION_ERROR,
+        reason=decide_pb2.Reason(
+            error=decide_pb2.ErrorReason(message="missing User-Agent header")
+        ),
+    )
+    assert is_missing_user_agent(SDKRuleResult(rr)) is False
+
+
+def test_helpers_false_for_non_bot_reason(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rr = decide_pb2.RuleResult(
+        rule_id="r1",
+        state=decide_pb2.RULE_STATE_RUN,
+        conclusion=decide_pb2.CONCLUSION_DENY,
+        reason=decide_pb2.Reason(
+            error=decide_pb2.ErrorReason(message="something else")
+        ),
+    )
+    wrapped = SDKRuleResult(rr)
+    assert is_verified_bot(wrapped) is False
+    assert is_missing_user_agent(wrapped) is False
+
+
+def test_sets_ietf_headers(mock_protobuf_modules):
+    from fixtures.protobuf_stubs import StubRateLimitReason
+
+    from arcjet import set_rate_limit_headers
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rl = StubRateLimitReason(
+        max=100, remaining=3, reset_in_seconds=9, window_in_seconds=60
+    )
+    decision = Decision(
+        decide_pb2.Decision(
+            id="d1",
+            conclusion=decide_pb2.CONCLUSION_ALLOW,
+            reason=decide_pb2.Reason(rate_limit=rl),  # type: ignore[arg-type]
+        )
+    )
+    headers: dict[str, str] = {}
+    set_rate_limit_headers(headers, decision)
+    assert headers["RateLimit"] == "limit=100, remaining=3, reset=9"
+    assert headers["RateLimit-Policy"] == "100;w=60"
+
+
+def test_uses_response_headers_attribute(mock_protobuf_modules):
+    from fixtures.protobuf_stubs import StubRateLimitReason
+
+    from arcjet import set_rate_limit_headers
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    class Response:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+    rl = StubRateLimitReason(
+        max=10, remaining=0, reset_in_seconds=4, window_in_seconds=10
+    )
+    decision = Decision(
+        decide_pb2.Decision(
+            id="d1",
+            conclusion=decide_pb2.CONCLUSION_DENY,
+            reason=decide_pb2.Reason(rate_limit=rl),  # type: ignore[arg-type]
+        )
+    )
+    response = Response()
+    set_rate_limit_headers(response, decision)
+    assert "RateLimit" in response.headers
+
+
+def test_noop_when_not_rate_limited(mock_protobuf_modules):
+    from arcjet import set_rate_limit_headers
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    decision = Decision(
+        decide_pb2.Decision(id="d1", conclusion=decide_pb2.CONCLUSION_ALLOW)
+    )
+    headers: dict[str, str] = {}
+    set_rate_limit_headers(headers, decision)
+    assert headers == {}
+
+
+def _decision_with_reasons(mock_protobuf_modules, *reasons):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    results = [
+        decide_pb2.RuleResult(
+            rule_id=f"r{i}",
+            state=decide_pb2.RULE_STATE_RUN,
+            conclusion=decide_pb2.CONCLUSION_ALLOW,
+            reason=decide_pb2.Reason(rate_limit=reason),
+        )
+        for i, reason in enumerate(reasons)
+    ]
+    return Decision(
+        decide_pb2.Decision(
+            id="d1",
+            conclusion=decide_pb2.CONCLUSION_ALLOW,
+            rule_results=results,
+        )
+    )
+
+
+def test_nearest_remaining_wins(mock_protobuf_modules):
+    from fixtures.protobuf_stubs import StubRateLimitReason
+
+    from arcjet import set_rate_limit_headers
+
+    decision = _decision_with_reasons(
+        mock_protobuf_modules,
+        StubRateLimitReason(
+            max=100, remaining=5, reset_in_seconds=20, window_in_seconds=60
+        ),
+        StubRateLimitReason(
+            max=10, remaining=1, reset_in_seconds=30, window_in_seconds=10
+        ),
+    )
+    headers: dict[str, str] = {}
+    set_rate_limit_headers(headers, decision)
+    assert headers["RateLimit"] == "limit=10, remaining=1, reset=30"
+    assert headers["RateLimit-Policy"] == "10;w=10, 100;w=60"
+
+
+def test_duplicate_max_aborts(mock_protobuf_modules):
+    from fixtures.protobuf_stubs import StubRateLimitReason
+
+    from arcjet import set_rate_limit_headers
+
+    decision = _decision_with_reasons(
+        mock_protobuf_modules,
+        StubRateLimitReason(
+            max=10, remaining=5, reset_in_seconds=9, window_in_seconds=60
+        ),
+        StubRateLimitReason(
+            max=10, remaining=1, reset_in_seconds=4, window_in_seconds=10
+        ),
+    )
+    headers: dict[str, str] = {}
+    set_rate_limit_headers(headers, decision)
+    assert headers == {}
+
+
+def test_fetch_style_headers(mock_protobuf_modules):
+    from fixtures.protobuf_stubs import StubRateLimitReason
+
+    from arcjet import set_rate_limit_headers
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    class FetchHeaders:
+        def __init__(self) -> None:
+            self._data: dict[str, str] = {}
+
+        def has(self, name: str) -> bool:
+            return name in self._data
+
+        def get(self, name: str) -> str | None:
+            return self._data.get(name)
+
+        def set(self, name: str, value: str) -> None:
+            self._data[name] = value
+
+    rl = StubRateLimitReason(
+        max=10, remaining=2, reset_in_seconds=8, window_in_seconds=10
+    )
+    decision = Decision(
+        decide_pb2.Decision(
+            id="d1",
+            conclusion=decide_pb2.CONCLUSION_ALLOW,
+            reason=decide_pb2.Reason(rate_limit=rl),  # type: ignore[arg-type]
+        )
+    )
+    headers = FetchHeaders()
+    set_rate_limit_headers(headers, decision)
+    assert headers.get("RateLimit") == "limit=10, remaining=2, reset=8"
+    assert headers.get("RateLimit-Policy") == "10;w=10"
+
+
+def test_set_header_style_response(mock_protobuf_modules):
+    from fixtures.protobuf_stubs import StubRateLimitReason
+
+    from arcjet import set_rate_limit_headers
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    class Outgoing:
+        def __init__(self) -> None:
+            self.headersSent = False
+            self._data: dict[str, str] = {}
+
+        def hasHeader(self, name: str) -> bool:
+            return name in self._data
+
+        def getHeader(self, name: str) -> str | None:
+            return self._data.get(name)
+
+        def setHeader(self, name: str, value: str) -> None:
+            self._data[name] = value
+
+    rl = StubRateLimitReason(
+        max=5, remaining=0, reset_in_seconds=3, window_in_seconds=5
+    )
+    decision = Decision(
+        decide_pb2.Decision(
+            id="d1",
+            conclusion=decide_pb2.CONCLUSION_DENY,
+            reason=decide_pb2.Reason(rate_limit=rl),  # type: ignore[arg-type]
+        )
+    )
+    response = Outgoing()
+    set_rate_limit_headers(response, decision)
+    assert response.getHeader("RateLimit") == "limit=5, remaining=0, reset=3"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the remaining JS inspect helpers and the `@arcjet/decorate` header writer:

- `is_verified_bot(result)` — live bot rule verified a known crawler
- `is_missing_user_agent(result)` — live bot rule failed because `User-Agent` was missing
- `set_rate_limit_headers(target, decision)` — writes IETF `RateLimit` and `RateLimit-Policy`

DRY_RUN results are ignored by the new inspect helpers (same as JS `isActive`). `is_spoofed_bot` is unchanged here.

`set_rate_limit_headers` accepts a Fetch-style Headers object, `response.headers`, a Node-style `setHeader` response, or a mutable mapping. When several rate-limit results are present, the tightest remaining budget is advertised. Two policies that share the same `max` abort (IETF cannot disambiguate them).

### Before

```python
# no verified-bot / missing-UA helpers; no IETF RateLimit writer
```

### After

```python
from arcjet import is_missing_user_agent, is_verified_bot, set_rate_limit_headers

if any(is_verified_bot(r) for r in decision.results):
    return jsonify(message="Hello bot")

set_rate_limit_headers(response, decision)
# RateLimit: limit=100, remaining=3, reset=9
# RateLimit-Policy: 100;w=60
```

### Why

These are the public inspect/decorate APIs JS apps already use. Without them, Python users reimplemented fingerprint checks and header formatting by hand.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90757ce-8fcd-498c-9afc-acfa39095e80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90757ce-8fcd-498c-9afc-acfa39095e80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

