### PR TITLE
docs: document that Guard never reads `ARCJET_KEY`

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,7 @@ if not arcjet_key:
     raise RuntimeError("ARCJET_KEY is required")
 
 # Create a single guard client and reuse it.
+# Guard never reads ARCJET_KEY itself — pass key= explicitly (same as JS Guard).
 aj = launch_arcjet(key=arcjet_key)
 
 # Configure rules once at startup

--- a/src/arcjet/guard/_client.py
+++ b/src/arcjet/guard/_client.py
@@ -952,7 +952,11 @@ def launch_arcjet(
     """Create an async Arcjet Guard client.
 
     Args:
-        key: Your Arcjet site key.
+        key: Your Arcjet site key. Required and must be passed explicitly —
+            Guard never reads ``ARCJET_KEY`` (or any other environment
+            variable) for credentials. This matches the JavaScript Guard
+            SDK. The Go Guard SDK falls back to ``ARCJET_KEY`` when ``Key``
+            is empty; Python does not.
         base_url: Override the Arcjet API endpoint.
         timeout_ms: Request timeout in milliseconds (default 2000).
         logger: Where to report capture diagnostics — dropped events, failed
@@ -1007,7 +1011,11 @@ def launch_arcjet_sync(
     """Create a sync Arcjet Guard client.
 
     Args:
-        key: Your Arcjet site key.
+        key: Your Arcjet site key. Required and must be passed explicitly —
+            Guard never reads ``ARCJET_KEY`` (or any other environment
+            variable) for credentials. This matches the JavaScript Guard
+            SDK. The Go Guard SDK falls back to ``ARCJET_KEY`` when ``Key``
+            is empty; Python does not.
         base_url: Override the Arcjet API endpoint.
         timeout_ms: Request timeout in milliseconds (default 2000).
         logger: Where to report capture diagnostics — dropped events, failed

--- a/tests/unit/guard/test_key_policy.py
+++ b/tests/unit/guard/test_key_policy.py
@@ -6,11 +6,11 @@ from typing import Any
 
 import pytest
 
+from arcjet._errors import ArcjetMisconfiguration
+from arcjet.guard import launch_arcjet, launch_arcjet_sync
+
 
 def test_empty_key_rejected_even_when_env_set(monkeypatch: Any):
-    from arcjet._errors import ArcjetMisconfiguration
-    from arcjet.guard import launch_arcjet, launch_arcjet_sync
-
     monkeypatch.setenv("ARCJET_KEY", "ajkey_from_env")
     with pytest.raises(ArcjetMisconfiguration, match="required"):
         launch_arcjet(key="")

--- a/tests/unit/test_guard_key_policy.py
+++ b/tests/unit/test_guard_key_policy.py
@@ -1,0 +1,18 @@
+"""Guard never falls back to ARCJET_KEY (JS Guard policy)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def test_empty_key_rejected_even_when_env_set(monkeypatch: Any):
+    from arcjet._errors import ArcjetMisconfiguration
+    from arcjet.guard import launch_arcjet, launch_arcjet_sync
+
+    monkeypatch.setenv("ARCJET_KEY", "ajkey_from_env")
+    with pytest.raises(ArcjetMisconfiguration, match="required"):
+        launch_arcjet(key="")
+    with pytest.raises(ArcjetMisconfiguration, match="required"):
+        launch_arcjet_sync(key="")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents the existing Guard key policy: `launch_arcjet(key=...)` / `launch_arcjet_sync(key=...)` never fall back to `ARCJET_KEY`. That matches the JS Guard SDK (Go Guard *does* read the env var).

Behavior is unchanged. `key=""` still raises `ArcjetMisconfiguration` even when `ARCJET_KEY` is set.

### Before

```python
# undocumented whether Guard reads ARCJET_KEY
aj = launch_arcjet(key=os.environ["ARCJET_KEY"])
```

### After

```python
import os
from arcjet.guard import launch_arcjet

# Guard never reads ARCJET_KEY itself — pass key= explicitly (same as JS Guard).
aj = launch_arcjet(key=os.environ["ARCJET_KEY"])
```

### Why

JS Guard requires an explicit key. Python already did too, but the docstring and README did not say so, which made the Go fallback look like a missing feature.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90757ce-8fcd-498c-9afc-acfa39095e80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90757ce-8fcd-498c-9afc-acfa39095e80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

