### PR TITLE
fix: ignore DRY_RUN results in `is_spoofed_bot`

### DIFF
--- a/src/arcjet/_decision.py
+++ b/src/arcjet/_decision.py
@@ -429,11 +429,6 @@ def is_spoofed_bot(result: RuleResult) -> bool:
     return False
 
 
-def _is_active_result(result: RuleResult) -> bool:
-    """Return ``True`` when a rule result is not a dry-run observation."""
-    return result.state != decide_pb2.RULE_STATE_DRY_RUN
-
-
 def is_verified_bot(result: RuleResult) -> bool:
     """Return ``True`` if a live bot rule verified a known legitimate bot.
 

--- a/src/arcjet/_decision.py
+++ b/src/arcjet/_decision.py
@@ -393,18 +393,24 @@ class Decision:
         return json.dumps(self.to_dict())
 
 
+def _is_active_result(result: RuleResult) -> bool:
+    """Return ``True`` when a rule result is not a dry-run observation."""
+    return result.state != decide_pb2.RULE_STATE_DRY_RUN
+
+
 def is_spoofed_bot(result: RuleResult) -> bool:
-    """Return ``True`` if a bot detection rule found a spoofed user agent.
+    """Return ``True`` if a live bot rule found a spoofed user agent.
 
     A spoofed bot claims to be a well-known crawler (e.g. Googlebot) but
     originates from an IP address that does not match the verified ranges for
-    that crawler.
+    that crawler. Results from ``DRY_RUN`` rules are ignored so staging a bot
+    rule cannot accidentally block traffic.
 
     Args:
         result: A single ``RuleResult`` from ``decision.results``.
 
     Returns:
-        ``True`` when the bot rule detected a spoofed user agent.
+        ``True`` when a live bot rule detected a spoofed user agent.
 
     Example::
 
@@ -413,6 +419,8 @@ def is_spoofed_bot(result: RuleResult) -> bool:
         if any(is_spoofed_bot(r) for r in decision.results):
             return jsonify(error="Spoofed bot detected"), 403
     """
+    if not _is_active_result(result):
+        return False
     r = result.raw.reason
     if not r:
         return False

--- a/tests/unit/test_spoofed_bot_dry_run.py
+++ b/tests/unit/test_spoofed_bot_dry_run.py
@@ -1,0 +1,43 @@
+"""is_spoofed_bot ignores DRY_RUN results (JS isActive)."""
+
+from __future__ import annotations
+
+import types
+
+from arcjet._decision import RuleResult as SDKRuleResult
+from arcjet._decision import is_spoofed_bot
+
+
+def _bot_result(mock_protobuf_modules, *, spoofed: bool, state: int) -> SDKRuleResult:
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    bot_v2 = types.SimpleNamespace(spoofed=spoofed, verified=False)
+    rr = decide_pb2.RuleResult(
+        rule_id="r1",
+        state=state,
+        conclusion=decide_pb2.CONCLUSION_DENY,
+        reason=decide_pb2.Reason(bot_v2=bot_v2),  # type: ignore[arg-type]
+    )
+    return SDKRuleResult(rr)
+
+
+def test_is_spoofed_bot_live(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rr = _bot_result(
+        mock_protobuf_modules,
+        spoofed=True,
+        state=decide_pb2.RULE_STATE_RUN,
+    )
+    assert is_spoofed_bot(rr) is True
+
+
+def test_is_spoofed_bot_ignores_dry_run(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rr = _bot_result(
+        mock_protobuf_modules,
+        spoofed=True,
+        state=decide_pb2.RULE_STATE_DRY_RUN,
+    )
+    assert is_spoofed_bot(rr) is False

--- a/tests/unit/test_spoofed_bot_dry_run.py
+++ b/tests/unit/test_spoofed_bot_dry_run.py
@@ -42,3 +42,28 @@ def test_is_spoofed_bot_ignores_dry_run(mock_protobuf_modules):
         state=decide_pb2.RULE_STATE_DRY_RUN,
     )
     assert is_spoofed_bot(rr) is False
+
+
+def test_is_spoofed_bot_live_not_spoofed(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rr = _bot_result(
+        mock_protobuf_modules,
+        spoofed=False,
+        state=decide_pb2.RULE_STATE_RUN,
+    )
+    assert is_spoofed_bot(rr) is False
+
+
+def test_is_spoofed_bot_false_for_non_bot_reason(mock_protobuf_modules):
+    from arcjet.proto.decide.v1alpha1 import decide_pb2
+
+    rr = decide_pb2.RuleResult(
+        rule_id="r1",
+        state=decide_pb2.RULE_STATE_RUN,
+        conclusion=decide_pb2.CONCLUSION_DENY,
+        reason=decide_pb2.Reason(
+            error=decide_pb2.ErrorReason(message="something else")
+        ),
+    )
+    assert is_spoofed_bot(SDKRuleResult(rr)) is False

--- a/tests/unit/test_spoofed_bot_dry_run.py
+++ b/tests/unit/test_spoofed_bot_dry_run.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import types
+from typing import Any
 
 from arcjet._decision import RuleResult as SDKRuleResult
 from arcjet._decision import is_spoofed_bot
 
 
-def _bot_result(mock_protobuf_modules, *, spoofed: bool, state: int) -> SDKRuleResult:
+def _bot_result(mock_protobuf_modules, *, spoofed: bool, state: Any) -> SDKRuleResult:
     from arcjet.proto.decide.v1alpha1 import decide_pb2
 
     bot_v2 = types.SimpleNamespace(spoofed=spoofed, verified=False)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`is_spoofed_bot()` now returns `False` for `RULE_STATE_DRY_RUN` results, matching JS `isActive`. Staging a bot rule can no longer look like a live spoofed-bot detection.

The helper still returns `bool` (not JS’s tri-state `undefined`).

### Before

```python
if any(is_spoofed_bot(r) for r in decision.results):
    return forbidden()  # also fired for DRY_RUN bot rules
```

### After

```python
from arcjet import is_spoofed_bot

if any(is_spoofed_bot(r) for r in decision.results):
    return jsonify(error="Spoofed bot detected"), 403
```

### Why

JS inspect helpers ignore dry-run observations so you can ship a bot rule in `DRY_RUN` without changing production control flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90757ce-8fcd-498c-9afc-acfa39095e80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90757ce-8fcd-498c-9afc-acfa39095e80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

