### PR TITLE
fix: require allow XOR deny on `detect_bot` and `validate_email`

### DIFF
--- a/src/arcjet/_local.py
+++ b/src/arcjet/_local.py
@@ -179,13 +179,13 @@ def evaluate_bot_locally(
     request_json = _context_to_analyze_request(ctx)
 
     # Build the WASM config from the rule's allow/deny lists.
-    # allow takes precedence over deny (matches JS SDK); the builder API
-    # prevents both being set, but we handle it defensively here.
-    if rule.allow:
+    # `is not None` so an empty allow list (block every bot) stays an allow
+    # config, matching JS `detectBot({ allow: [] })`.
+    if rule.allow is not None:
         entities = [str(e) for e in rule.allow]
         config = AllowedBotConfig(entities=entities, skip_custom_detect=True)
     else:
-        entities = [str(e) for e in rule.deny]
+        entities = [str(e) for e in (rule.deny or ())]
         config = DeniedBotConfig(entities=entities, skip_custom_detect=True)
 
     try:
@@ -247,7 +247,7 @@ def evaluate_email_locally(
         return None
 
     # Build the WASM config from the rule
-    if rule.allow:
+    if rule.allow is not None:
         email_config = AllowEmailValidationConfig(
             require_top_level_domain=rule.require_top_level_domain,
             allow_domain_literal=rule.allow_domain_literal,
@@ -257,7 +257,7 @@ def evaluate_email_locally(
         email_config = DenyEmailValidationConfig(
             require_top_level_domain=rule.require_top_level_domain,
             allow_domain_literal=rule.allow_domain_literal,
-            deny=[str(t.value) for t in rule.deny],
+            deny=[str(t.value) for t in (rule.deny or ())],
         )
 
     try:

--- a/src/arcjet/_rules.py
+++ b/src/arcjet/_rules.py
@@ -281,14 +281,24 @@ class BotDetection(RuleSpec):
     """
 
     mode: Mode
-    allow: tuple[BotSpecifier, ...] = ()
-    deny: tuple[BotSpecifier, ...] = ()
+    allow: tuple[BotSpecifier, ...] | None = None
+    deny: tuple[BotSpecifier, ...] | None = None
     characteristics: tuple[str, ...] = ()
 
     def __post_init__(self):
         if not isinstance(self.mode, Mode):
             raise TypeError("BotDetection.mode must be a Mode enum")
+        if self.allow is not None and self.deny is not None:
+            raise ValueError(
+                "BotDetection options error: `allow` and `deny` cannot be provided together"
+            )
+        if self.allow is None and self.deny is None:
+            raise ValueError(
+                "BotDetection options error: either `allow` or `deny` must be specified"
+            )
         for seq, name in ((self.allow, "allow"), (self.deny, "deny")):
+            if seq is None:
+                continue
             if not isinstance(seq, tuple):
                 raise TypeError(
                     f"BotDetection.{name} must be a tuple of BotCategory or str"
@@ -310,8 +320,8 @@ class BotDetection(RuleSpec):
 
     def to_proto(self) -> decide_pb2.Rule:
         br = decide_pb2.BotV2Rule(mode=_mode_to_proto(self.mode))
-        br.allow.extend([_bot_category_to_proto(a) for a in self.allow])
-        br.deny.extend([_bot_category_to_proto(d) for d in self.deny])
+        br.allow.extend([_bot_category_to_proto(a) for a in (self.allow or ())])
+        br.deny.extend([_bot_category_to_proto(d) for d in (self.deny or ())])
         return decide_pb2.Rule(bot_v2=br)
 
 
@@ -744,8 +754,8 @@ class EmailValidation(RuleSpec):
     """
 
     mode: Mode
-    deny: tuple[EmailType, ...] = ()
-    allow: tuple[EmailType, ...] = ()
+    deny: tuple[EmailType, ...] | None = None
+    allow: tuple[EmailType, ...] | None = None
     require_top_level_domain: bool = True
     allow_domain_literal: bool = False
     characteristics: tuple[str, ...] = ()
@@ -753,7 +763,17 @@ class EmailValidation(RuleSpec):
     def __post_init__(self):
         if not isinstance(self.mode, Mode):
             raise TypeError("EmailValidation.mode must be a Mode enum")
+        if self.allow is not None and self.deny is not None:
+            raise ValueError(
+                "EmailValidation options error: `allow` and `deny` cannot be provided together"
+            )
+        if self.allow is None and self.deny is None:
+            raise ValueError(
+                "EmailValidation options error: either `allow` or `deny` must be specified"
+            )
         for seq, name in ((self.allow, "allow"), (self.deny, "deny")):
+            if seq is None:
+                continue
             if not isinstance(seq, tuple):
                 raise TypeError(f"EmailValidation.{name} must be a tuple of EmailType")
             for item in seq:
@@ -777,8 +797,8 @@ class EmailValidation(RuleSpec):
             require_top_level_domain=bool(self.require_top_level_domain),
             allow_domain_literal=bool(self.allow_domain_literal),
         )
-        er.allow.extend([_email_type_to_proto(t.value) for t in self.allow])
-        er.deny.extend([_email_type_to_proto(t.value) for t in self.deny])
+        er.allow.extend([_email_type_to_proto(t.value) for t in (self.allow or ())])
+        er.deny.extend([_email_type_to_proto(t.value) for t in (self.deny or ())])
         # Do not set version explicitly; server will use the latest
         return decide_pb2.Rule(email=er)
 
@@ -812,6 +832,23 @@ def _coerce_mode(mode: Union[str, Mode]) -> Mode:
     if m in ("LIVE", "DRY_RUN", "DRYRUN", "DRY-RUN"):
         return Mode.LIVE if m == "LIVE" else Mode.DRY_RUN
     raise ValueError(f"Unknown mode: {mode!r}")
+
+
+def _require_allow_xor_deny(
+    allow: object | None,
+    deny: object | None,
+    *,
+    name: str,
+) -> None:
+    """Reject allow+deny together or neither, matching the JS SDK builders."""
+    if allow is not None and deny is not None:
+        raise ValueError(
+            f"`{name}` options error: `allow` and `deny` cannot be provided together"
+        )
+    if allow is None and deny is None:
+        raise ValueError(
+            f"`{name}` options error: either `allow` or `deny` must be specified"
+        )
 
 
 def shield(
@@ -907,8 +944,8 @@ def _coerce_bot_categories(
 def detect_bot(
     *,
     mode: Union[str, Mode] = Mode.LIVE,
-    allow: Sequence[Union[str, BotCategory]] = (),
-    deny: Sequence[Union[str, BotCategory]] = (),
+    allow: Sequence[Union[str, BotCategory]] | None = None,
+    deny: Sequence[Union[str, BotCategory]] | None = None,
 ) -> BotDetection:
     """Detect and filter automated bot traffic.
 
@@ -927,10 +964,11 @@ def detect_bot(
         mode: Enforcement mode. ``Mode.LIVE`` blocks matching requests;
             ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
             ``Mode.LIVE``.
-        allow: Bots to permit. All other bots are denied. Do not combine
-            with ``deny``.
+        allow: Bots to permit. All other bots are denied. An empty list
+            denies every bot. Do not combine with ``deny``.
         deny: Bots to block. All other bots are allowed. Do not combine
-            with ``allow``.
+            with ``allow``. Exactly one of ``allow`` or ``deny`` must be
+            provided.
 
     Returns:
         A ``BotDetection`` rule to include in the ``rules`` list of
@@ -948,10 +986,11 @@ def detect_bot(
             )
         ]
     """
+    _require_allow_xor_deny(allow, deny, name="detect_bot")
     return BotDetection(
         mode=_coerce_mode(mode),
-        allow=_coerce_bot_categories(allow),
-        deny=_coerce_bot_categories(deny),
+        allow=_coerce_bot_categories(allow) if allow is not None else None,
+        deny=_coerce_bot_categories(deny) if deny is not None else None,
     )
 
 
@@ -1138,8 +1177,8 @@ def _coerce_email_types(
 def validate_email(
     *,
     mode: Union[str, Mode] = Mode.LIVE,
-    deny: Sequence[Union[str, EmailType]] = (),
-    allow: Sequence[Union[str, EmailType]] = (),
+    deny: Sequence[Union[str, EmailType]] | None = None,
+    allow: Sequence[Union[str, EmailType]] | None = None,
     require_top_level_domain: bool = True,
     allow_domain_literal: bool = False,
 ) -> EmailValidation:
@@ -1147,7 +1186,8 @@ def validate_email(
 
     Checks the email passed to ``protect(email=...)`` against configurable
     criteria. Use ``deny`` to block specific email types (e.g. disposable
-    addresses), or ``allow`` to restrict to only certain types.
+    addresses), or ``allow`` to restrict to only certain types. An empty
+    ``allow`` list permits no email types.
 
     When this rule is configured, you **must** pass ``email=...`` to every
     ``protect()`` call, otherwise an ``ArcjetMisconfiguration`` is raised.
@@ -1157,7 +1197,8 @@ def validate_email(
             ``Mode.DRY_RUN`` logs matches without blocking. Defaults to
             ``Mode.LIVE``.
         deny: Email types to reject. Common choices: ``EmailType.DISPOSABLE``,
-            ``EmailType.INVALID``, ``EmailType.NO_MX_RECORDS``.
+            ``EmailType.INVALID``, ``EmailType.NO_MX_RECORDS``. Exactly one of
+            ``allow`` or ``deny`` must be provided.
         allow: Email types to permit. All other types are rejected.
         require_top_level_domain: Reject addresses without a valid TLD.
             Defaults to ``True``.
@@ -1181,10 +1222,11 @@ def validate_email(
         # Then pass the email address on each protect() call:
         # decision = await aj.protect(request, email="alice@example.com")
     """
+    _require_allow_xor_deny(allow, deny, name="validate_email")
     return EmailValidation(
         mode=_coerce_mode(mode),
-        deny=_coerce_email_types(deny),
-        allow=_coerce_email_types(allow),
+        deny=_coerce_email_types(deny) if deny is not None else None,
+        allow=_coerce_email_types(allow) if allow is not None else None,
         require_top_level_domain=require_top_level_domain,
         allow_domain_literal=allow_domain_literal,
     )

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -146,9 +146,7 @@ class TestGetComponent:
 class TestEvaluateBotLocally:
     def test_returns_none_when_component_unavailable(self):
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
         with patch("arcjet._local._get_component", return_value=None):
             result = _local.evaluate_bot_locally(ctx, rule)
         assert result is None
@@ -163,9 +161,7 @@ class TestEvaluateBotLocally:
         ctx = RequestContext(
             ip="1.2.3.4", headers={"User-Agent": "curl/7.0"}, method="GET"
         )
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=("CURL",), deny=(), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, allow=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -184,9 +180,7 @@ class TestEvaluateBotLocally:
         ctx = RequestContext(
             ip="1.2.3.4", headers={"User-Agent": "curl/7.0"}, method="GET"
         )
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -203,9 +197,7 @@ class TestEvaluateBotLocally:
         mock_component.detect_bot.return_value = Ok(bot_result)
 
         ctx = RequestContext(ip="1.2.3.4", method="GET")
-        rule = BotDetection(
-            mode=Mode.DRY_RUN, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.DRY_RUN, deny=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -219,9 +211,7 @@ class TestEvaluateBotLocally:
         mock_component.detect_bot.side_effect = RuntimeError("wasm error")
 
         ctx = RequestContext(ip="1.2.3.4", method="GET")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -233,9 +223,7 @@ class TestEvaluateBotLocally:
         mock_component.detect_bot.return_value = Err("some error")
 
         ctx = RequestContext(ip="1.2.3.4", method="GET")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             result = _local.evaluate_bot_locally(ctx, rule)
@@ -253,8 +241,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -267,8 +254,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext()
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -285,8 +271,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -306,8 +291,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="bad-email")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -327,8 +311,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@disposable.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -351,8 +334,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="bad@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -376,8 +358,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
-            allow=(),
+            deny=(EmailType.INVALID,),
             require_top_level_domain=True,
             allow_domain_literal=False,
             characteristics=(),
@@ -397,7 +378,6 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(email="test@example.com")
         rule = EmailValidation(
             mode=Mode.LIVE,
-            deny=(),
             allow=(EmailType.DISPOSABLE,),
             require_top_level_domain=True,
             allow_domain_literal=False,
@@ -426,7 +406,6 @@ class TestEvaluateEmailLocally:
         rule = EmailValidation(
             mode=Mode.LIVE,
             deny=(EmailType.DISPOSABLE, EmailType.FREE),
-            allow=(),
             require_top_level_domain=False,
             allow_domain_literal=True,
             characteristics=(),
@@ -454,7 +433,7 @@ class TestEvaluateEmailLocally:
             ip="1.2.3.4", headers={"User-Agent": "curl/7.0"}, method="GET"
         )
         rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL", "GOOGLEBOT"), characteristics=()
+            mode=Mode.LIVE, deny=("CURL", "GOOGLEBOT"), characteristics=()
         )
 
         with patch("arcjet._local._get_component", return_value=mock_component):
@@ -477,9 +456,7 @@ class TestEvaluateEmailLocally:
         ctx = RequestContext(
             ip="1.2.3.4", headers={"User-Agent": "curl/7.0"}, method="GET"
         )
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=("CURL",), deny=(), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, allow=("CURL",), characteristics=())
 
         with patch("arcjet._local._get_component", return_value=mock_component):
             _local.evaluate_bot_locally(ctx, rule)
@@ -513,9 +490,7 @@ class TestRunLocalRules:
             conclusion=decide_pb2.CONCLUSION_ALLOW,
         )
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=("CURL",), deny=(), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, allow=("CURL",), characteristics=())
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=allow_result),
             patch("arcjet._client.evaluate_email_locally", return_value=None),
@@ -531,9 +506,7 @@ class TestRunLocalRules:
             reason=decide_pb2.Reason(bot_v2=decide_pb2.BotV2Reason(denied=["CURL"])),
         )
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=deny_result),
             patch("arcjet._client.evaluate_email_locally", return_value=None),
@@ -549,9 +522,7 @@ class TestRunLocalRules:
             conclusion=decide_pb2.CONCLUSION_DENY,
         )
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.DRY_RUN, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.DRY_RUN, deny=("CURL",), characteristics=())
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=deny_dry_run),
             patch("arcjet._client.evaluate_email_locally", return_value=None),
@@ -562,9 +533,7 @@ class TestRunLocalRules:
     def test_returns_none_when_evaluator_returns_none(self):
         """When WASM component fails to load, evaluators return None."""
         ctx = RequestContext(ip="1.2.3.4")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
         with (
             patch("arcjet._client.evaluate_bot_locally", return_value=None),
             patch("arcjet._client.evaluate_email_locally", return_value=None),
@@ -587,9 +556,7 @@ class TestBuildLocalDenyReport:
         )
         local_decision = Decision(deny_proto)
         ctx = RequestContext(ip="1.2.3.4", method="GET")
-        rule = BotDetection(
-            mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()
-        )
+        rule = BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=())
 
         rep = _build_local_deny_report(None, "0.4.1", ctx, local_decision, (rule,))
 
@@ -608,11 +575,10 @@ class TestBuildLocalDenyReport:
         local_decision = Decision(deny_proto)
         ctx = RequestContext(ip="1.2.3.4")
         rules = (
-            BotDetection(mode=Mode.LIVE, allow=(), deny=("CURL",), characteristics=()),
+            BotDetection(mode=Mode.LIVE, deny=("CURL",), characteristics=()),
             EmailValidation(
                 mode=Mode.LIVE,
-                deny=(),
-                allow=(),
+                deny=(EmailType.INVALID,),
                 require_top_level_domain=True,
                 allow_domain_literal=False,
                 characteristics=(),

--- a/tests/unit/guard/test_delivery.py
+++ b/tests/unit/guard/test_delivery.py
@@ -255,13 +255,22 @@ class TestSyncDelivery:
             delivery.capture(event("early"))
             assert in_send.wait(TIMEOUT)
 
-            def capture_late() -> None:
-                time.sleep(0.02)
-                delivery.capture(event("late-1"))
-                delivery.capture(event("late-2"))
+            # Capture only after flush() has snapshotted the queue. A sleep
+            # here races: if the late puts land first, they are this flush's
+            # remainder and `_abandon` drops them.
+            flushed = threading.Event()
 
-            threading.Thread(target=capture_late, daemon=True).start()
-            delivery.flush(100)  # cannot drain: the first send is stuck
+            def run_flush() -> None:
+                try:
+                    delivery.flush(100)  # cannot drain: the first send is stuck
+                finally:
+                    flushed.set()
+
+            threading.Thread(target=run_flush, daemon=True).start()
+            assert delivery._flush_now.wait(TIMEOUT)
+            delivery.capture(event("late-1"))
+            delivery.capture(event("late-2"))
+            assert flushed.wait(TIMEOUT)
 
             assert delivery._queue.qsize() == 2, "late events must still be queued"
         finally:
@@ -542,16 +551,18 @@ class TestAsyncDelivery:
                 delivery.capture(event("early"))
                 await asyncio.wait_for(in_send.wait(), TIMEOUT)
 
-                async def capture_late() -> None:
-                    await asyncio.sleep(0.02)
-                    delivery.capture(event("late-1"))
-                    delivery.capture(event("late-2"))
-
-                task = asyncio.create_task(capture_late())
-                await delivery.flush(100)  # cannot drain: the send is stuck
+                # Same race as the sync test: capture after `_flush_now` so
+                # the snapshot cannot include these events.
+                flush_task = asyncio.create_task(delivery.flush(100))
+                deadline = time.monotonic() + TIMEOUT
+                while not delivery._flush_now:
+                    assert time.monotonic() < deadline, "flush never started"
+                    await asyncio.sleep(0)
+                delivery.capture(event("late-1"))
+                delivery.capture(event("late-2"))
+                await flush_task
 
                 assert len(delivery._queue) == 2, "late events must still be queued"
-                await task
             finally:
                 blocked.set()
             await delivery.flush(TIMEOUT_MS)

--- a/tests/unit/guard/test_delivery.py
+++ b/tests/unit/guard/test_delivery.py
@@ -556,11 +556,15 @@ class TestAsyncDelivery:
                 flush_task = asyncio.create_task(delivery.flush(100))
                 deadline = time.monotonic() + TIMEOUT
                 while not delivery._flush_now:
-                    assert time.monotonic() < deadline, "flush never started"
+                    if time.monotonic() >= deadline:
+                        raise AssertionError("flush never started")
                     await asyncio.sleep(0)
                 delivery.capture(event("late-1"))
                 delivery.capture(event("late-2"))
-                await flush_task
+                try:
+                    await asyncio.wait_for(flush_task, timeout=TIMEOUT)
+                except (asyncio.TimeoutError, TimeoutError) as exc:
+                    raise AssertionError("flush did not finish") from exc
 
                 assert len(delivery._queue) == 2, "late events must still be queued"
             finally:

--- a/tests/unit/test_allow_deny.py
+++ b/tests/unit/test_allow_deny.py
@@ -1,0 +1,55 @@
+"""Tests for detect_bot / validate_email allow XOR deny exclusivity."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestAllowDenyExclusivity:
+    def test_detect_bot_rejects_neither(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, detect_bot
+
+        with pytest.raises(ValueError, match="either `allow` or `deny`"):
+            detect_bot(mode=Mode.LIVE)
+
+    def test_detect_bot_rejects_both(self, mock_protobuf_modules):
+        from arcjet._rules import BotCategory, Mode, detect_bot
+
+        with pytest.raises(ValueError, match="cannot be provided together"):
+            detect_bot(mode=Mode.LIVE, allow=[BotCategory.GOOGLE], deny=["CURL"])
+
+    def test_detect_bot_empty_allow_blocks_all_bots(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, detect_bot
+
+        rule = detect_bot(mode=Mode.LIVE, allow=[])
+        assert rule.allow == ()
+        assert rule.deny is None
+
+    def test_bot_detection_dataclass_rejects_neither(self, mock_protobuf_modules):
+        from arcjet._rules import BotDetection, Mode
+
+        with pytest.raises(ValueError, match="either `allow` or `deny`"):
+            BotDetection(mode=Mode.LIVE)
+
+    def test_validate_email_rejects_neither(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, validate_email
+
+        with pytest.raises(ValueError, match="either `allow` or `deny`"):
+            validate_email(mode=Mode.LIVE)
+
+    def test_validate_email_rejects_both(self, mock_protobuf_modules):
+        from arcjet._rules import EmailType, Mode, validate_email
+
+        with pytest.raises(ValueError, match="cannot be provided together"):
+            validate_email(
+                mode=Mode.LIVE,
+                allow=[EmailType.FREE],
+                deny=[EmailType.DISPOSABLE],
+            )
+
+    def test_validate_email_empty_allow_is_valid(self, mock_protobuf_modules):
+        from arcjet._rules import Mode, validate_email
+
+        rule = validate_email(mode=Mode.LIVE, allow=[])
+        assert rule.allow == ()
+        assert rule.deny is None

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -38,7 +38,7 @@ def test_email_required_for_validate_email_rule(mock_protobuf_modules):
     from arcjet._errors import ArcjetMisconfiguration
     from arcjet._rules import validate_email
 
-    aj = arcjet(key="ajkey_x", rules=[validate_email()])
+    aj = arcjet(key="ajkey_x", rules=[validate_email(deny=["INVALID"])])
     import asyncio
 
     with pytest.raises(ArcjetMisconfiguration):

--- a/tests/unit/test_client_sync.py
+++ b/tests/unit/test_client_sync.py
@@ -38,7 +38,7 @@ def test_email_required_for_validate_email_rule(mock_protobuf_modules):
     from arcjet._errors import ArcjetMisconfiguration
     from arcjet._rules import validate_email
 
-    aj = arcjet_sync(key="ajkey_x", rules=[validate_email()])
+    aj = arcjet_sync(key="ajkey_x", rules=[validate_email(deny=["INVALID"])])
     with pytest.raises(ArcjetMisconfiguration):
         aj.protect({"headers": [], "type": "http"})
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`detect_bot` and `validate_email` now require exactly one of `allow` or `deny`, matching the JS builders.

**Breaking:** calling either factory (or constructing `BotDetection` / `EmailValidation`) with neither list, or with both, raises `ValueError`.

An empty `allow=[]` is valid and means “block every detected bot” / “allow no email types”. Local WASM evaluation uses `is not None` so that empty allow list stays an allow-config.

### Before

```python
detect_bot()  # both lists defaulted to empty tuples
validate_email()  # same
```

### After

```python
from arcjet import BotCategory, EmailType, Mode, detect_bot, validate_email

detect_bot(mode=Mode.LIVE, allow=[BotCategory.SEARCH_ENGINE])
detect_bot(mode=Mode.LIVE, allow=[])  # block every bot
validate_email(mode=Mode.LIVE, deny=[EmailType.DISPOSABLE, EmailType.INVALID])
```

### Why

JS `detectBot` / `validateEmail` reject neither-and-both. Python treated omitted lists as empty, so `detect_bot()` did not mean the same thing as JS `detectBot({ allow: [] })`.

### Test flake

`test_flush_does_not_drop_events_captured_after_it_started` used a 20ms sleep so “late” captures would land after `flush()` snapshotted the queue. On loaded macOS runners those puts often won the race, so `_abandon` dropped them. Both the sync and async tests now wait for `_flush_now` (set after the snapshot) instead of sleeping.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90757ce-8fcd-498c-9afc-acfa39095e80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90757ce-8fcd-498c-9afc-acfa39095e80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

