### PR TITLE
feat(guard): record `degraded` when policy did not judge an action fully

### DIFF
--- a/src/arcjet/guard/_checkpoint.py
+++ b/src/arcjet/guard/_checkpoint.py
@@ -37,7 +37,7 @@ from ._types import Decision
 
 T = TypeVar("T")
 
-Outcome = Literal["success", "denied", "error", "unavailable"]
+Outcome = Literal["success", "degraded", "denied", "error", "unavailable"]
 
 DeniedFactory = Callable[[str, Decision], BaseException]
 UnavailableFactory = Callable[[str, Optional[BaseException]], BaseException]
@@ -85,6 +85,30 @@ def _resolve_correlation_id(explicit: Optional[str]) -> Optional[str]:
     that in before calling, by passing the config's value as *explicit*.
     """
     return explicit if explicit is not None else current_correlation_id()
+
+
+def _outcome_for_completed_action(
+    decision: Optional[Decision],
+    *,
+    degraded: Optional[BaseException],
+) -> Outcome:
+    """The outcome for an action that ran: ``success`` or ``degraded``.
+
+    ``success`` claims that policy judged the action, so it is reserved for the
+    case where policy judged all of it. Everything else here ran only because
+    ``on_guard_error="allow"`` let it: the guard call failed, its answer could
+    not be read, the decision failed open, or an input the decision needed
+    could not be resolved.
+
+    A ``degraded`` event still carries a decision ID when one exists. That is
+    what separates policy judging the action in part from policy never judging
+    it at all, and it is why one value covers three states.
+    """
+    if decision is None:
+        return "degraded"
+    if decision.has_failed_open() or degraded is not None:
+        return "degraded"
+    return "success"
 
 
 def _merged_metadata(explicit: Optional[Metadata], outcome: Outcome) -> Metadata:
@@ -257,6 +281,9 @@ def run_checkpoint_sync(
     # Bound before the attempt, so the classification below reads it whether or
     # not `prepare` got far enough to return one.
     prepared = ResolvedInputs()
+    # Cleared where the guard's answer could not be classified, which keeps
+    # such an answer off the record below.
+    decision_readable = True
 
     try:
         prepared = prepare() if prepare is not None else ResolvedInputs(actor, inputs)
@@ -324,6 +351,7 @@ def run_checkpoint_sync(
                 exc_info=exc,
             )
             failure = None
+            decision_readable = False
         if failure is not None:
             outcome: Outcome = (
                 "denied" if decision.conclusion == "DENY" else "unavailable"
@@ -338,6 +366,13 @@ def run_checkpoint_sync(
             )
             raise failure
 
+    # What goes on the record. It differs from `decision` only for an answer
+    # the engine could not read: nothing correlatable comes off such an object,
+    # and an answer that could not be classified judged nothing, which is
+    # exactly what an absent decision ID reports. Passing it on would lose the
+    # event altogether, because building one reads an id it does not have.
+    recorded = decision if decision_readable else None
+
     try:
         result = fn()
     except Exception:
@@ -346,7 +381,7 @@ def run_checkpoint_sync(
             action=action,
             outcome="error",
             correlation_id=resolved_correlation_id,
-            decision=decision,
+            decision=recorded,
             metadata=metadata,
         )
         raise
@@ -354,9 +389,9 @@ def run_checkpoint_sync(
     _emit_capture(
         client=guard,
         action=action,
-        outcome="success",
+        outcome=_outcome_for_completed_action(recorded, degraded=prepared.degraded),
         correlation_id=resolved_correlation_id,
-        decision=decision,
+        decision=recorded,
         metadata=metadata,
     )
     return result
@@ -383,6 +418,9 @@ async def run_checkpoint(
     # Bound before the attempt, so the classification below reads it whether or
     # not `prepare` got far enough to return one.
     prepared = ResolvedInputs()
+    # Cleared where the guard's answer could not be classified, which keeps
+    # such an answer off the record below.
+    decision_readable = True
 
     try:
         prepared = (
@@ -452,6 +490,7 @@ async def run_checkpoint(
                 exc_info=exc,
             )
             failure = None
+            decision_readable = False
         if failure is not None:
             outcome: Outcome = (
                 "denied" if decision.conclusion == "DENY" else "unavailable"
@@ -466,6 +505,13 @@ async def run_checkpoint(
             )
             raise failure
 
+    # What goes on the record. It differs from `decision` only for an answer
+    # the engine could not read: nothing correlatable comes off such an object,
+    # and an answer that could not be classified judged nothing, which is
+    # exactly what an absent decision ID reports. Passing it on would lose the
+    # event altogether, because building one reads an id it does not have.
+    recorded = decision if decision_readable else None
+
     try:
         result = await fn()
     except Exception:
@@ -474,7 +520,7 @@ async def run_checkpoint(
             action=action,
             outcome="error",
             correlation_id=resolved_correlation_id,
-            decision=decision,
+            decision=recorded,
             metadata=metadata,
         )
         raise
@@ -482,9 +528,9 @@ async def run_checkpoint(
     _emit_capture(
         client=guard,
         action=action,
-        outcome="success",
+        outcome=_outcome_for_completed_action(recorded, degraded=prepared.degraded),
         correlation_id=resolved_correlation_id,
-        decision=decision,
+        decision=recorded,
         metadata=metadata,
     )
     return result

--- a/tests/unit/guard/test_checkpoint.py
+++ b/tests/unit/guard/test_checkpoint.py
@@ -258,7 +258,9 @@ class TestGuardRaisesSync:
         assert call_count == 1
         assert result == "value"
         # Capture the success, not unavailable
-        assert client.captures[0]["metadata"]["outcome"] == "success"
+        # Not `unavailable`, which would mean the action was blocked, and
+        # not `success`, which would claim policy judged it.
+        assert client.captures[0]["metadata"]["outcome"] == "degraded"
 
 
 class TestGuardRaisesAsync:
@@ -343,7 +345,9 @@ class TestFailedOpenSync:
 
         assert call_count == 1
         assert result == "value"
-        assert client.captures[0]["metadata"]["outcome"] == "success"
+        # The action ran only because on_guard_error is 'allow', and the
+        # decision failed open, so policy judged none of it.
+        assert client.captures[0]["metadata"]["outcome"] == "degraded"
 
 
 class TestErrorOutcomeSync:
@@ -1677,7 +1681,9 @@ class TestFailedOpenAsync:
             assert result == "success"
             assert call_count == 1
             assert len(client.captures) >= 1
-            assert client.captures[0]["metadata"]["outcome"] == "success"
+            # The action ran only because on_guard_error is 'allow', and the
+            # decision failed open, so policy judged none of it.
+            assert client.captures[0]["metadata"]["outcome"] == "degraded"
 
         asyncio.run(test())
 
@@ -1800,6 +1806,148 @@ class TestGuardRaiseAllowProceedsAsync:
             assert result == "success"
             # Should capture success, not unavailable
             assert len(client.captures) == 1
-            assert client.captures[0]["metadata"]["outcome"] == "success"
+            # Not `unavailable`, which would mean the action was blocked, and
+            # not `success`, which would claim policy judged it.
+            assert client.captures[0]["metadata"]["outcome"] == "degraded"
+
+        asyncio.run(test())
+
+
+class TestDegradedOutcome:
+    """`success` claims policy judged the action, so a partial judgement is not one.
+
+    Covers the conditions from the capture-outcome ADR that reach the capture
+    with the action already run. The fail-closed halves of the same conditions
+    are covered by the `unavailable` tests above.
+    """
+
+    def test_degraded_inputs_carry_a_decision_id(self, reset_sequence_context):
+        """Policy judged the action in part: it ran, and a real decision exists."""
+        client = StubGuardClient(decision=make_allow_decision(id="gdec_partial"))
+
+        def prepare() -> ResolvedInputs:
+            return ResolvedInputs(
+                actor="user-1", degraded=RuntimeError("inputs unreadable")
+            )
+
+        result = run_checkpoint_sync(
+            lambda: "value",
+            action="thing.done",
+            guard=client,
+            prepare=prepare,
+            on_guard_error="allow",
+        )
+
+        assert result == "value"
+        capture = client.captures[0]
+        assert capture["metadata"]["outcome"] == "degraded"
+        # The half of the three-state reading that says "judged in part".
+        assert capture["decision_id"] == "gdec_partial"
+
+    def test_a_failed_open_decision_carries_no_decision_id(
+        self, reset_sequence_context
+    ):
+        """Policy judged none of it, which the absent decision ID reports."""
+        decision = make_allow_decision(
+            id="", results=(RuleResultError(code="ERR_UNKNOWN", message="broke"),)
+        )
+        client = StubGuardClient(decision=decision)
+
+        run_checkpoint_sync(
+            lambda: "value",
+            action="thing.done",
+            guard=client,
+            on_guard_error="allow",
+        )
+
+        capture = client.captures[0]
+        assert capture["metadata"]["outcome"] == "degraded"
+        assert not capture["decision_id"]
+
+    def test_an_unreadable_decision_is_degraded(self, reset_sequence_context):
+        """A client that answered with something that is not a decision.
+
+        Policy was not evaluated, so the action ran only because
+        `on_guard_error` is 'allow' — the record must say so.
+        """
+        client = StubGuardClient(decision=object())  # type: ignore[arg-type]
+
+        result = run_checkpoint_sync(
+            lambda: "value",
+            action="thing.done",
+            guard=client,
+            on_guard_error="allow",
+        )
+
+        assert result == "value"
+        assert client.captures[0]["metadata"]["outcome"] == "degraded"
+
+    def test_a_clean_allow_is_still_success(self, reset_sequence_context):
+        """The control: nothing degraded, so the claim of a judgement stands."""
+        client = StubGuardClient(decision=make_allow_decision())
+
+        run_checkpoint_sync(
+            lambda: "value",
+            action="thing.done",
+            guard=client,
+            on_guard_error="allow",
+        )
+
+        assert client.captures[0]["metadata"]["outcome"] == "success"
+
+    def test_a_throwing_action_reports_error_over_degraded(
+        self, reset_sequence_context
+    ):
+        """`outcome` holds one value, and the ADR gives `error` precedence.
+
+        A count of `degraded` events therefore excludes the degraded actions
+        that also threw, which is stated in the ADR rather than fixed here.
+        """
+        decision = make_allow_decision(
+            id="", results=(RuleResultError(code="ERR_UNKNOWN", message="broke"),)
+        )
+        client = StubGuardClient(decision=decision)
+
+        def fn() -> str:
+            raise ValueError("the action itself failed")
+
+        with pytest.raises(ValueError):
+            run_checkpoint_sync(
+                fn,
+                action="thing.done",
+                guard=client,
+                on_guard_error="allow",
+            )
+
+        assert client.captures[0]["metadata"]["outcome"] == "error"
+
+    def test_degraded_inputs_are_degraded_on_the_async_path(
+        self, reset_sequence_context
+    ):
+        """Both flavours share the engine, so both report it the same way."""
+
+        async def test() -> None:
+            client = StubGuardClient(decision=make_allow_decision(id="gdec_partial"))
+
+            async def prepare() -> ResolvedInputs:
+                return ResolvedInputs(
+                    actor="user-1", degraded=RuntimeError("inputs unreadable")
+                )
+
+            async def fn() -> str:
+                return "value"
+
+            result = await run_checkpoint(
+                fn,
+                action="thing.done",
+                guard=client,
+                prepare=prepare,
+                on_guard_error="allow",
+            )
+
+            assert result == "value"
+            capture = client.captures[0]
+            assert capture["metadata"]["outcome"] == "degraded"
+            assert capture["decision_id"] == "gdec_partial"
 
         asyncio.run(test())


### PR DESCRIPTION
Every action that ran captured `outcome: "success"`, whether policy judged it or not. An operator reading the capture stream could not separate an approved action from one that ran because `on_guard_error="allow"` let it through during an outage — the calls a post-incident review most needs to find were the ones the record made invisible.

`success` claims policy judged the action, so it is now reserved for the case where policy judged all of it. Four conditions capture `degraded` instead: the guard call failed, its answer could not be read, the decision failed open, or an input the decision needed could not be resolved.

Unchanged: the fail-closed halves of those conditions still capture `unavailable` and still block the action, and an action that runs and then throws still captures `error`, which takes precedence.

A `degraded` event keeps its decision ID when one exists, so one value carries three states — judged fully, judged in part, judged not at all.

An answer the engine could not classify is now kept off the record rather than passed to the capture. Nothing correlatable can be read off such an object, and reading an id it does not have was losing the whole event, so the one condition least likely to be noticed was also the one that emitted nothing.

Implements the decision in the `arcjet` monorepo ADR "Capture outcome for an action that ran without evaluated policy".