### PR TITLE
docs: move client IP warning under installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,6 @@ This is the Python SDK for [Arcjet](https://arcjet.com) — use `arcjet` /
 and `arcjet.guard` for **guard protection** (AI agent tool calls, MCP servers,
 background jobs).
 
-> [!WARNING]
-> Arcjet may use `X-Forwarded-For` when it cannot get a public client IP from
-> the framework request. Clients can spoof this header if they can reach your
-> application directly or your proxy preserves client-supplied values. The
-> `proxies` option tells Arcjet which IPs or CIDRs to skip while walking the
-> header; it does not verify that the connection came through those proxies.
->
-> In production, make the application reachable only through a proxy that
-> overwrites or safely appends `X-Forwarded-For`, and list every trusted hop in
-> `proxies`. If you cannot guarantee the header's provenance, set
-> `disable_automatic_ip_detection=True` and pass a validated `ip_src` to every
-> `protect()` call.
-
 ## Why Arcjet?
 
 Your app's AI features and agents take real actions, calling tools, reading data, hitting APIs. Arcjet runs inside that code and lets you enforce security on each action in real time, then audit what happened.
@@ -252,6 +239,19 @@ together — if **any** rule denies the request, `decision.is_denied()` returns
 `True`. Use `Mode.DRY_RUN` on individual rules to test them before enforcing.
 
 ## Installation
+
+> [!WARNING]
+> Arcjet may use `X-Forwarded-For` when it cannot get a public client IP from
+> the framework request. Clients can spoof this header if they can reach your
+> application directly or your proxy preserves client-supplied values. The
+> `proxies` option tells Arcjet which IPs or CIDRs to skip while walking the
+> header; it does not verify that the connection came through those proxies.
+>
+> In production, make the application reachable only through a proxy that
+> overwrites or safely appends `X-Forwarded-For`, and list every trusted hop in
+> `proxies`. If you cannot guarantee the header's provenance, set
+> `disable_automatic_ip_detection=True` and pass a validated `ip_src` to every
+> `protect()` call.
 
 Install [from PyPI](https://pypi.org/project/arcjet/) with
 [uv](https://docs.astral.sh/uv/):


### PR DESCRIPTION
## Summary

- move the client IP trust warning from the README introduction to the Installation section
- preserve the warning text added in #230

## Validation

- git diff --check