### PR TITLE
feat: expose client IP provenance and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,16 @@ together — if **any** rule denies the request, `decision.is_denied()` returns
 > Arcjet may use `X-Forwarded-For` when it cannot get a public client IP from
 > the framework request. Clients can spoof this header if they can reach your
 > application directly or your proxy preserves client-supplied values. Arcjet
-> continues protecting the request, but logs a warning once per client and marks
-> the source as `unverified-header` in the `client_ip_provenance` debug facet.
+> continues protecting the request, but logs one warning for the lifetime of
+> each Arcjet client instance and marks the source as `unverified-header` in the
+> `client_ip_provenance` debug facet.
 >
 > In production, make the application reachable only through a proxy that
 > overwrites or safely appends `X-Forwarded-For`, and list every trusted hop in
-> `proxies`. Invalid proxy entries and manual `ip_src` values are rejected;
-> trusting `0.0.0.0/0` or `::/0` emits a configuration warning. To inspect the
+> `proxies`. Invalid proxy entries and combining `proxies` with manual IP
+> detection are rejected when the client is created; malformed `ip_src` values
+> are rejected before protection. Trusting `0.0.0.0/0` or `::/0` emits a
+> configuration warning. To inspect the
 > selected address before protection, call `aj.client_ip_details(request)` and
 > check its `ip`, `provenance`, `verified`, and `header` fields. If your
 > application determines the address itself, set

--- a/README.md
+++ b/README.md
@@ -243,15 +243,19 @@ together — if **any** rule denies the request, `decision.is_denied()` returns
 > [!WARNING]
 > Arcjet may use `X-Forwarded-For` when it cannot get a public client IP from
 > the framework request. Clients can spoof this header if they can reach your
-> application directly or your proxy preserves client-supplied values. The
-> `proxies` option tells Arcjet which IPs or CIDRs to skip while walking the
-> header; it does not verify that the connection came through those proxies.
+> application directly or your proxy preserves client-supplied values. Arcjet
+> continues protecting the request, but logs a warning once per client and marks
+> the source as `unverified-header` in the `client_ip_provenance` debug facet.
 >
 > In production, make the application reachable only through a proxy that
 > overwrites or safely appends `X-Forwarded-For`, and list every trusted hop in
-> `proxies`. If you cannot guarantee the header's provenance, set
-> `disable_automatic_ip_detection=True` and pass a validated `ip_src` to every
-> `protect()` call.
+> `proxies`. Invalid proxy entries and manual `ip_src` values are rejected;
+> trusting `0.0.0.0/0` or `::/0` emits a configuration warning. To inspect the
+> selected address before protection, call `aj.client_ip_details(request)` and
+> check its `ip`, `provenance`, `verified`, and `header` fields. If your
+> application determines the address itself, set
+> `disable_automatic_ip_detection=True` and pass that validated value as
+> `ip_src` to both `client_ip_details()` and `protect()`.
 
 Install [from PyPI](https://pypi.org/project/arcjet/) with
 [uv](https://docs.astral.sh/uv/):

--- a/src/arcjet/__init__.py
+++ b/src/arcjet/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ._client import Arcjet, ArcjetSync, arcjet, arcjet_sync
+from ._context import ClientIpDetails, ClientIpProvenance
 from ._dataclasses import IpDetails, ThreatIntelligence
 from ._decision import (
     Decision,
@@ -43,6 +44,8 @@ __all__ = [
     "Arcjet",
     "ArcjetSync",
     "BotCategory",
+    "ClientIpDetails",
+    "ClientIpProvenance",
     "Decision",
     "detect_bot",
     "detect_prompt_injection",

--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -41,10 +41,9 @@ from ._context import (
     ClientIpDetails,
     ClientIpProvenance,
     RequestContext,
+    _validate_proxy_config,
     coerce_request_context,
-    has_trust_all_proxy,
     request_details_from_context,
-    validate_proxies,
 )
 from ._context import (
     client_ip_details as resolve_client_ip_details,
@@ -104,7 +103,7 @@ class _ClientIpWarningState:
 
 
 def _report_client_ip(details: ClientIpDetails, state: _ClientIpWarningState) -> None:
-    """Log client-IP provenance and warn once for an unverified header."""
+    """Log provenance and warn once for this Arcjet client's lifetime."""
     logger.debug(
         "Arcjet client IP resolved",
         extra={
@@ -585,7 +584,32 @@ class Arcjet:
     def client_ip_details(
         self, request: Any, *, ip_src: str | None = None
     ) -> ClientIpDetails:
-        """Explain how this client would resolve an IP without protecting."""
+        """Explain how this client would resolve the request's IP.
+
+        This is a side-effect-free diagnostic: it does not protect the request,
+        emit logs, or consume the once-per-client-instance warning. Automatic
+        mode applies this client's proxy and environment configuration. Manual
+        mode requires the same independently trusted ``ip_src`` that will be
+        passed to ``protect()``.
+
+        Args:
+            request: The same framework request or ``RequestContext`` accepted
+                by ``protect()``.
+            ip_src: Manual client IP when automatic detection is disabled.
+
+        Returns:
+            A ``ClientIpDetails`` value containing the normalized address,
+            provenance, verification signal, and source header.
+
+        Raises:
+            ArcjetMisconfiguration: If manual-IP configuration is inconsistent
+                or an IP is malformed.
+
+        Example::
+
+            details = aj.client_ip_details(request)
+            print(details.ip, details.provenance, details.verified, details.header)
+        """
         return _client_ip_details_for_client(
             request,
             proxies=self._proxies,
@@ -687,6 +711,7 @@ class Arcjet:
             proxies=self._proxies,
             ip_src=ip_src,
             environment=self._environment,
+            resolved_ip_details=ip_details,
         )
 
         if email:
@@ -1197,7 +1222,32 @@ class ArcjetSync:
     def client_ip_details(
         self, request: Any, *, ip_src: str | None = None
     ) -> ClientIpDetails:
-        """Explain how this client would resolve an IP without protecting."""
+        """Explain how this client would resolve the request's IP.
+
+        This is a side-effect-free diagnostic: it does not protect the request,
+        emit logs, or consume the once-per-client-instance warning. Automatic
+        mode applies this client's proxy and environment configuration. Manual
+        mode requires the same independently trusted ``ip_src`` that will be
+        passed to ``protect()``.
+
+        Args:
+            request: The same framework request or ``RequestContext`` accepted
+                by ``protect()``.
+            ip_src: Manual client IP when automatic detection is disabled.
+
+        Returns:
+            A ``ClientIpDetails`` value containing the normalized address,
+            provenance, verification signal, and source header.
+
+        Raises:
+            ArcjetMisconfiguration: If manual-IP configuration is inconsistent
+                or an IP is malformed.
+
+        Example::
+
+            details = aj.client_ip_details(request)
+            print(details.ip, details.provenance, details.verified, details.header)
+        """
         return _client_ip_details_for_client(
             request,
             proxies=self._proxies,
@@ -1240,6 +1290,7 @@ class ArcjetSync:
             proxies=self._proxies,
             ip_src=ip_src,
             environment=self._environment,
+            resolved_ip_details=ip_details,
         )
 
         if email:
@@ -1692,7 +1743,8 @@ def arcjet(
         An ``Arcjet`` async client instance.
 
     Raises:
-        ArcjetMisconfiguration: If ``key`` is empty.
+        ArcjetMisconfiguration: If ``key`` is empty, a proxy entry is invalid,
+            or ``proxies`` is combined with manual IP detection.
 
     Example::
 
@@ -1743,10 +1795,15 @@ def arcjet(
     if not key:
         raise ArcjetMisconfiguration("Arcjet key is required.")
     try:
-        validated_proxies = validate_proxies(proxies)
+        validated_proxies, proxy_networks = _validate_proxy_config(proxies)
     except ValueError as exc:
         raise ArcjetMisconfiguration(str(exc)) from exc
-    if has_trust_all_proxy(validated_proxies):
+    if disable_automatic_ip_detection and validated_proxies:
+        raise ArcjetMisconfiguration(
+            "proxies cannot be used when disable_automatic_ip_detection=True. "
+            "proxies are ignored with manual IP detection so they have no effect."
+        )
+    if any(network.prefixlen == 0 for network in proxy_networks):
         logger.warning(
             "Arcjet proxy configuration trusts an entire IP address family; "
             "use the narrowest proxy CIDRs possible.",
@@ -1833,7 +1890,8 @@ def arcjet_sync(
         An ``ArcjetSync`` sync client instance.
 
     Raises:
-        ArcjetMisconfiguration: If ``key`` is empty.
+        ArcjetMisconfiguration: If ``key`` is empty, a proxy entry is invalid,
+            or ``proxies`` is combined with manual IP detection.
 
     Example::
 
@@ -1884,10 +1942,15 @@ def arcjet_sync(
     if not key:
         raise ArcjetMisconfiguration("Arcjet key is required.")
     try:
-        validated_proxies = validate_proxies(proxies)
+        validated_proxies, proxy_networks = _validate_proxy_config(proxies)
     except ValueError as exc:
         raise ArcjetMisconfiguration(str(exc)) from exc
-    if has_trust_all_proxy(validated_proxies):
+    if disable_automatic_ip_detection and validated_proxies:
+        raise ArcjetMisconfiguration(
+            "proxies cannot be used when disable_automatic_ip_detection=True. "
+            "proxies are ignored with manual IP detection so they have no effect."
+        )
+    if any(network.prefixlen == 0 for network in proxy_networks):
         logger.warning(
             "Arcjet proxy configuration trusts an entire IP address family; "
             "use the narrowest proxy CIDRs possible.",

--- a/src/arcjet/_client.py
+++ b/src/arcjet/_client.py
@@ -38,9 +38,16 @@ from arcjet.proto.decide.v1alpha1.decide_connect import (
 
 from ._cache import DecisionCache, make_cache_key
 from ._context import (
+    ClientIpDetails,
+    ClientIpProvenance,
     RequestContext,
     coerce_request_context,
+    has_trust_all_proxy,
     request_details_from_context,
+    validate_proxies,
+)
+from ._context import (
+    client_ip_details as resolve_client_ip_details,
 )
 from ._decision import Decision, materialize_cached_decision
 from ._errors import ArcjetMisconfiguration, ArcjetTransportError
@@ -88,6 +95,75 @@ def _fire_and_forget(coro: Any) -> None:
 # Initialized on first use so async-only callers don't pay for thread creation.
 _report_pool: ThreadPoolExecutor | None = None
 _report_pool_lock = threading.Lock()
+
+
+@dataclass(slots=True)
+class _ClientIpWarningState:
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    warned_for_unverified_header: bool = False
+
+
+def _report_client_ip(details: ClientIpDetails, state: _ClientIpWarningState) -> None:
+    """Log client-IP provenance and warn once for an unverified header."""
+    logger.debug(
+        "Arcjet client IP resolved",
+        extra={
+            "event": "arcjet_client_ip",
+            "client_ip_provenance": details.provenance.value,
+            "client_ip_verified": details.verified,
+            "client_ip_header": details.header,
+        },
+    )
+    if details.provenance is not ClientIpProvenance.UNVERIFIED_HEADER:
+        return
+    with state.lock:
+        if state.warned_for_unverified_header:
+            return
+        state.warned_for_unverified_header = True
+    logger.warning(
+        "Arcjet resolved the client IP from an unverified forwarding header. "
+        "Ensure a trusted proxy overwrites or safely appends X-Forwarded-For, "
+        "configure proxies, or use manual IP detection. See "
+        "https://docs.arcjet.com/best-practices#configure-proxies-and-load-balancers",
+        extra={
+            "event": "arcjet_client_ip_warning",
+            "client_ip_provenance": details.provenance.value,
+            "client_ip_header": details.header,
+        },
+    )
+
+
+def _client_ip_details_for_client(
+    request: Any,
+    *,
+    proxies: tuple[str, ...],
+    disable_automatic_ip_detection: bool,
+    environment: str | None,
+    ip_src: str | None,
+) -> ClientIpDetails:
+    if disable_automatic_ip_detection and not ip_src:
+        raise ArcjetMisconfiguration(
+            "ip_src is required when disable_automatic_ip_detection=True. "
+            "Pass ip_src=... to aj.protect(...)."
+        )
+    if disable_automatic_ip_detection and proxies:
+        raise ArcjetMisconfiguration(
+            "proxies cannot be used when disable_automatic_ip_detection=True. "
+            "proxies are ignored with manual IP detection so they have no effect."
+        )
+    if not disable_automatic_ip_detection and ip_src:
+        raise ArcjetMisconfiguration(
+            "ip_src cannot be set when disable_automatic_ip_detection=False."
+        )
+    try:
+        return resolve_client_ip_details(
+            request,
+            proxies=proxies,
+            ip_src=ip_src,
+            environment=environment,
+        )
+    except ValueError as exc:
+        raise ArcjetMisconfiguration(str(exc)) from exc
 
 
 def _get_report_pool() -> ThreadPoolExecutor:
@@ -502,6 +578,21 @@ class Arcjet:
     _disable_automatic_ip_detection: bool = False
     _cache: DecisionCache = field(default_factory=DecisionCache)
     _environment: str | None = None
+    _ip_warning_state: _ClientIpWarningState = field(
+        default_factory=_ClientIpWarningState, repr=False
+    )
+
+    def client_ip_details(
+        self, request: Any, *, ip_src: str | None = None
+    ) -> ClientIpDetails:
+        """Explain how this client would resolve an IP without protecting."""
+        return _client_ip_details_for_client(
+            request,
+            proxies=self._proxies,
+            disable_automatic_ip_detection=self._disable_automatic_ip_detection,
+            environment=self._environment,
+            ip_src=ip_src,
+        )
 
     async def protect(
         self,
@@ -589,19 +680,8 @@ class Arcjet:
                 return JSONResponse({"error": "Blocked"}, status_code=403)
         """
         t0 = time.perf_counter()
-        if self._disable_automatic_ip_detection and not ip_src:
-            raise ArcjetMisconfiguration(
-                "ip_src is required when disable_automatic_ip_detection=True. "
-                "Pass ip_src=... to aj.protect(...)."
-            )
-        if self._disable_automatic_ip_detection and self._proxies:
-            raise ArcjetMisconfiguration(
-                "proxies cannot be used when disable_automatic_ip_detection=True. proxies are ignored with manual IP detection so they have no effect."
-            )
-        if not self._disable_automatic_ip_detection and ip_src:
-            raise ArcjetMisconfiguration(
-                "ip_src cannot be set when disable_automatic_ip_detection=False."
-            )
+        ip_details = self.client_ip_details(request, ip_src=ip_src)
+        _report_client_ip(ip_details, self._ip_warning_state)
         ctx = coerce_request_context(
             request,
             proxies=self._proxies,
@@ -1110,6 +1190,21 @@ class ArcjetSync:
     _disable_automatic_ip_detection: bool = False
     _cache: DecisionCache = field(default_factory=DecisionCache)
     _environment: str | None = None
+    _ip_warning_state: _ClientIpWarningState = field(
+        default_factory=_ClientIpWarningState, repr=False
+    )
+
+    def client_ip_details(
+        self, request: Any, *, ip_src: str | None = None
+    ) -> ClientIpDetails:
+        """Explain how this client would resolve an IP without protecting."""
+        return _client_ip_details_for_client(
+            request,
+            proxies=self._proxies,
+            disable_automatic_ip_detection=self._disable_automatic_ip_detection,
+            environment=self._environment,
+            ip_src=ip_src,
+        )
 
     def protect(
         self,
@@ -1138,19 +1233,8 @@ class ArcjetSync:
                 return jsonify(error="Forbidden"), 403
         """
         t0 = time.perf_counter()
-        if self._disable_automatic_ip_detection and not ip_src:
-            raise ArcjetMisconfiguration(
-                "ip_src is required when disable_automatic_ip_detection=True. "
-                "Pass ip_src=... to aj.protect(...)."
-            )
-        if self._disable_automatic_ip_detection and self._proxies:
-            raise ArcjetMisconfiguration(
-                "proxies cannot be used when disable_automatic_ip_detection=True. proxies are ignored with manual IP detection so they have no effect."
-            )
-        if not self._disable_automatic_ip_detection and ip_src:
-            raise ArcjetMisconfiguration(
-                "ip_src cannot be set when disable_automatic_ip_detection=False."
-            )
+        ip_details = self.client_ip_details(request, ip_src=ip_src)
+        _report_client_ip(ip_details, self._ip_warning_state)
         ctx = coerce_request_context(
             request,
             proxies=self._proxies,
@@ -1658,6 +1742,16 @@ def arcjet(
     """
     if not key:
         raise ArcjetMisconfiguration("Arcjet key is required.")
+    try:
+        validated_proxies = validate_proxies(proxies)
+    except ValueError as exc:
+        raise ArcjetMisconfiguration(str(exc)) from exc
+    if has_trust_all_proxy(validated_proxies):
+        logger.warning(
+            "Arcjet proxy configuration trusts an entire IP address family; "
+            "use the narrowest proxy CIDRs possible.",
+            extra={"event": "arcjet_proxy_configuration", "trust_all": True},
+        )
     resolved_rules = _apply_global_characteristics(tuple(rules), tuple(characteristics))
     transport = build_async_transport()
     client = DecideServiceClient(
@@ -1675,7 +1769,7 @@ def arcjet(
         _needs_email=needs_email,
         _needs_message=needs_message,
         _has_token_bucket=has_token_bucket,
-        _proxies=tuple(proxies),
+        _proxies=validated_proxies,
         _disable_automatic_ip_detection=disable_automatic_ip_detection,
         _environment=environment,
     )
@@ -1789,6 +1883,16 @@ def arcjet_sync(
     """
     if not key:
         raise ArcjetMisconfiguration("Arcjet key is required.")
+    try:
+        validated_proxies = validate_proxies(proxies)
+    except ValueError as exc:
+        raise ArcjetMisconfiguration(str(exc)) from exc
+    if has_trust_all_proxy(validated_proxies):
+        logger.warning(
+            "Arcjet proxy configuration trusts an entire IP address family; "
+            "use the narrowest proxy CIDRs possible.",
+            extra={"event": "arcjet_proxy_configuration", "trust_all": True},
+        )
     resolved_rules = _apply_global_characteristics(tuple(rules), tuple(characteristics))
     transport = build_sync_transport()
     client = DecideServiceClientSync(
@@ -1807,7 +1911,7 @@ def arcjet_sync(
         _needs_email=needs_email,
         _needs_message=needs_message,
         _has_token_bucket=has_token_bucket,
-        _proxies=tuple(proxies),
+        _proxies=validated_proxies,
         _disable_automatic_ip_detection=disable_automatic_ip_detection,
         _environment=environment,
     )

--- a/src/arcjet/_context.py
+++ b/src/arcjet/_context.py
@@ -30,11 +30,34 @@ from __future__ import annotations
 import ipaddress
 import os
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Iterable, Mapping, Protocol, Sequence, cast
 
 from arcjet.proto.decide.v1alpha1 import decide_pb2
 
 HeaderValue = str | Sequence[str]
+
+
+class ClientIpProvenance(str, Enum):
+    """Where Arcjet obtained a client IP address."""
+
+    DIRECT = "direct"
+    TRUSTED_PROXY = "trusted-proxy"
+    UNVERIFIED_HEADER = "unverified-header"
+    MANUAL = "manual"
+    DEVELOPMENT = "development"
+    REQUEST = "request"
+    NONE = "none"
+
+
+@dataclass(frozen=True, slots=True)
+class ClientIpDetails:
+    """Debug information about Arcjet's client IP selection."""
+
+    ip: str | None
+    provenance: ClientIpProvenance
+    verified: bool
+    header: str | None = None
 
 
 def _is_development(environment: str | None = None) -> bool:
@@ -190,13 +213,39 @@ def _parse_proxies(
     if not proxies:
         return out
     for p in proxies:
+        if not isinstance(p, str) or not p.strip():
+            raise ValueError(f"invalid proxy IP or CIDR: {p!r}")
         try:
             # Support CIDR or single IP; strict=False allows single IPs.
-            net = ipaddress.ip_network(p, strict=False)
+            net = ipaddress.ip_network(p.strip(), strict=False)
             out.append(net)
-        except Exception:
-            continue
+        except ValueError as exc:
+            raise ValueError(f"invalid proxy IP or CIDR: {p!r}") from exc
     return out
+
+
+def validate_ip(value: str, *, name: str = "IP address") -> str:
+    """Validate and normalize a caller-supplied IPv4 or IPv6 address."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a valid IPv4 or IPv6 address")
+    candidate = value.strip()
+    try:
+        return str(ipaddress.ip_address(candidate))
+    except ValueError as exc:
+        raise ValueError(
+            f"{name} must be a valid IPv4 or IPv6 address: {value!r}"
+        ) from exc
+
+
+def validate_proxies(proxies: Sequence[str]) -> tuple[str, ...]:
+    """Validate proxy IP/CIDR configuration and return stripped values."""
+    _parse_proxies(proxies)
+    return tuple(proxy.strip() for proxy in proxies)
+
+
+def has_trust_all_proxy(proxies: Sequence[str]) -> bool:
+    """Return whether configuration trusts an entire IP address family."""
+    return any(network.prefixlen == 0 for network in _parse_proxies(proxies))
 
 
 def _is_trusted_proxy(
@@ -254,12 +303,12 @@ def _parse_x_forwarded_for_values(values: Sequence[str]) -> list[str]:
     return out
 
 
-def extract_ip_from_headers(
+def extract_ip_details_from_headers(
     headers: Mapping[str, HeaderValue],
     *,
     proxies: Sequence[str] | None = None,
     environment: str | None = None,
-) -> str | None:
+) -> ClientIpDetails:
     """
     Extract a likely client IP from headers with validation and trusted proxies.
 
@@ -275,15 +324,119 @@ def extract_ip_from_headers(
         xaj = _first_header(headers, "x-arcjet-ip")
         if xaj:
             # In development, accept any override to ease local testing.
-            return _normalize_ip_string(xaj)
+            return ClientIpDetails(
+                ip=_normalize_ip_string(xaj),
+                provenance=ClientIpProvenance.DEVELOPMENT,
+                verified=False,
+                header="x-arcjet-ip",
+            )
 
     # X-Forwarded-For may appear multiple times; combine as a single list per MDN.
     xff_values = _all_headers(headers, "x-forwarded-for")
     for item in reversed(_parse_x_forwarded_for_values(xff_values)):
         if _is_global_public_ip(item, proxy_nets):
-            return _normalize_ip_string(item)
+            return ClientIpDetails(
+                ip=_normalize_ip_string(item),
+                provenance=ClientIpProvenance.UNVERIFIED_HEADER,
+                verified=False,
+                header="x-forwarded-for",
+            )
 
-    return None
+    return ClientIpDetails(None, ClientIpProvenance.NONE, False)
+
+
+def extract_ip_from_headers(
+    headers: Mapping[str, HeaderValue],
+    *,
+    proxies: Sequence[str] | None = None,
+    environment: str | None = None,
+) -> str | None:
+    """Extract a likely client IP while preserving the legacy string API."""
+    return extract_ip_details_from_headers(
+        headers, proxies=proxies, environment=environment
+    ).ip
+
+
+def client_ip_details(
+    req: SupportsRequestContext | Any,
+    *,
+    proxies: Sequence[str] | None = None,
+    ip_src: str | None = None,
+    environment: str | None = None,
+) -> ClientIpDetails:
+    """Explain how Arcjet would select the client IP for ``req``."""
+    proxy_nets = _parse_proxies(proxies)
+
+    if ip_src is not None:
+        return ClientIpDetails(
+            validate_ip(ip_src, name="ip_src"), ClientIpProvenance.MANUAL, True
+        )
+
+    if isinstance(req, RequestContext):
+        if req.ip:
+            return ClientIpDetails(req.ip, ClientIpProvenance.REQUEST, True)
+        return ClientIpDetails(None, ClientIpProvenance.NONE, False)
+
+    headers: dict[str, HeaderValue] = {}
+    remote: str | None = None
+
+    if isinstance(req, Mapping):
+        cast_req = cast(Mapping[str, Any], req)
+        if "headers" in req and "type" in req:
+            for k, v in cast_req.get("headers") or []:
+                try:
+                    headers[k.decode("latin-1")] = v.decode("latin-1")
+                except Exception:
+                    continue
+            client = cast_req.get("client")
+            if isinstance(client, (tuple, list)) and client:
+                remote = client[0]
+        else:
+            value = cast_req.get("ip")
+            if isinstance(value, str) and value:
+                return ClientIpDetails(value, ClientIpProvenance.REQUEST, True)
+            return ClientIpDetails(None, ClientIpProvenance.NONE, False)
+    elif hasattr(req, "META") and hasattr(req, "method"):
+        meta = getattr(req, "META", {}) or {}
+        hdrs_obj = getattr(req, "headers", None)
+        headers = dict(hdrs_obj) if hdrs_obj is not None else {}
+        remote = meta.get("REMOTE_ADDR")
+    elif hasattr(req, "headers") and hasattr(req, "method"):
+        try:
+            headers = dict(getattr(req, "headers", {}) or {})
+        except Exception:
+            headers = {}
+        remote = getattr(req, "remote_addr", None)
+    else:
+        raise TypeError(
+            "Unsupported request type for Arcjet client_ip_details(). "
+            "Pass a RequestContext, an ASGI scope dict, a Django HttpRequest, or a plain mapping."
+        )
+
+    if _is_global_public_ip(remote, proxy_nets):
+        return ClientIpDetails(
+            _normalize_ip_string(remote), ClientIpProvenance.DIRECT, True
+        )
+
+    header_details = extract_ip_details_from_headers(
+        headers, proxies=proxies, environment=environment
+    )
+    if header_details.ip is not None:
+        if (
+            header_details.provenance is ClientIpProvenance.UNVERIFIED_HEADER
+            and _is_trusted_proxy(remote, proxy_nets)
+        ):
+            return ClientIpDetails(
+                header_details.ip,
+                ClientIpProvenance.TRUSTED_PROXY,
+                True,
+                header_details.header,
+            )
+        return header_details
+
+    if _is_development(environment=environment):
+        return ClientIpDetails("127.0.0.1", ClientIpProvenance.DEVELOPMENT, False)
+    return ClientIpDetails(None, ClientIpProvenance.NONE, False)
 
 
 def request_details_from_context(ctx: RequestContext) -> decide_pb2.RequestDetails:
@@ -387,20 +540,12 @@ def coerce_request_context(
                     headers[k.decode("latin-1")] = v.decode("latin-1")
                 except Exception:
                     continue
-            ip = None
-            client = cast_req.get("client")
-            if not ip_src:
-                if isinstance(client, (tuple, list)) and client:
-                    # Prefer the direct remote address when it's global and not a trusted proxy.
-                    if _is_global_public_ip(client[0], _parse_proxies(proxies)):
-                        ip = client[0]
-                ip = ip or extract_ip_from_headers(
-                    headers, proxies=proxies, environment=environment
-                )
-                if not ip and _is_development(environment=environment):
-                    ip = "127.0.0.1"
-            else:
-                ip = ip_src
+            ip = client_ip_details(
+                req,
+                proxies=proxies,
+                ip_src=ip_src,
+                environment=environment,
+            ).ip
 
             return RequestContext(
                 ip=ip,
@@ -437,18 +582,12 @@ def coerce_request_context(
             headers = dict(getattr(req, "headers", {}) or {})
         except Exception:
             headers = {}
-        ip = None
-        remote = getattr(req, "remote_addr", None)
-        if not ip_src:
-            if _is_global_public_ip(remote, _parse_proxies(proxies)):
-                ip = remote
-            ip = ip or extract_ip_from_headers(
-                headers, proxies=proxies, environment=environment
-            )
-            if not ip and _is_development(environment=environment):
-                ip = "127.0.0.1"
-        else:
-            ip = ip_src
+        ip = client_ip_details(
+            req,
+            proxies=proxies,
+            ip_src=ip_src,
+            environment=environment,
+        ).ip
         try:
             query_raw = getattr(req, "query_string", None)
             query = (
@@ -481,18 +620,12 @@ def coerce_request_context(
         # Django 2.2+ has request.headers (case-insensitive)
         hdrs_obj = getattr(req, "headers", None)
         headers = dict(hdrs_obj) if hdrs_obj is not None else {}
-        ip = None
-        remote = meta.get("REMOTE_ADDR")
-        if not ip_src:
-            if _is_global_public_ip(remote, _parse_proxies(proxies)):
-                ip = remote
-            ip = ip or extract_ip_from_headers(
-                headers, proxies=proxies, environment=environment
-            )
-            if not ip and _is_development(environment=environment):
-                ip = "127.0.0.1"
-        else:
-            ip = ip_src
+        ip = client_ip_details(
+            req,
+            proxies=proxies,
+            ip_src=ip_src,
+            environment=environment,
+        ).ip
         scheme = (
             "https"
             if meta.get("wsgi.url_scheme") == "https"

--- a/src/arcjet/_context.py
+++ b/src/arcjet/_context.py
@@ -29,17 +29,26 @@ from __future__ import annotations
 
 import ipaddress
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Any, Iterable, Mapping, Protocol, Sequence, cast
 
 from arcjet.proto.decide.v1alpha1 import decide_pb2
 
 HeaderValue = str | Sequence[str]
+ProxyNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 
 class ClientIpProvenance(str, Enum):
-    """Where Arcjet obtained a client IP address."""
+    """Where Arcjet obtained a client IP address.
+
+    ``DIRECT`` and ``PLATFORM`` identify framework or hosting-platform data.
+    ``TRUSTED_PROXY`` means the direct peer matched configured ``proxies``.
+    ``UNVERIFIED_HEADER`` means Arcjet used a forwarding header without that
+    trust signal. ``MANUAL`` is an explicit ``ip_src`` value, ``REQUEST`` is an
+    application-supplied request context, ``DEVELOPMENT`` is a development
+    override or loopback fallback, and ``NONE`` means no usable address exists.
+    """
 
     DIRECT = "direct"
     TRUSTED_PROXY = "trusted-proxy"
@@ -52,7 +61,22 @@ class ClientIpProvenance(str, Enum):
 
 @dataclass(frozen=True, slots=True)
 class ClientIpDetails:
-    """Debug information about Arcjet's client IP selection."""
+    """Explain the client IP Arcjet selected for a request.
+
+    Attributes:
+        ip: Normalized IPv4 or IPv6 address, or ``None`` when no usable address
+            was found.
+        provenance: Where Arcjet obtained the address.
+        verified: Whether the SDK tied the source to a direct request or a
+            configured platform/proxy. This does not certify the surrounding
+            network configuration.
+        header: Lowercase header name when a header supplied the address.
+
+    Example::
+
+        details = aj.client_ip_details(request)
+        print(details.ip, details.provenance, details.verified, details.header)
+    """
 
     ip: str | None
     provenance: ClientIpProvenance
@@ -208,8 +232,8 @@ def _normalize_ip_string(value: str | None) -> str | None:
 
 def _parse_proxies(
     proxies: Iterable[str] | None,
-) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
-    out: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+) -> list[ProxyNetwork]:
+    out: list[ProxyNetwork] = []
     if not proxies:
         return out
     for p in proxies:
@@ -237,20 +261,30 @@ def validate_ip(value: str, *, name: str = "IP address") -> str:
         ) from exc
 
 
+def _validate_proxy_config(
+    proxies: Sequence[str],
+) -> tuple[tuple[str, ...], tuple[ProxyNetwork, ...]]:
+    """Normalize proxy strings and parse them once for configuration checks."""
+    normalized: list[str] = []
+    for proxy in proxies:
+        if not isinstance(proxy, str) or not proxy.strip():
+            raise ValueError(f"invalid proxy IP or CIDR: {proxy!r}")
+        normalized.append(proxy.strip())
+    values = tuple(normalized)
+    return values, tuple(_parse_proxies(values))
+
+
 def validate_proxies(proxies: Sequence[str]) -> tuple[str, ...]:
     """Validate proxy IP/CIDR configuration and return stripped values."""
-    _parse_proxies(proxies)
-    return tuple(proxy.strip() for proxy in proxies)
+    return _validate_proxy_config(proxies)[0]
 
 
 def has_trust_all_proxy(proxies: Sequence[str]) -> bool:
     """Return whether configuration trusts an entire IP address family."""
-    return any(network.prefixlen == 0 for network in _parse_proxies(proxies))
+    return any(network.prefixlen == 0 for network in _validate_proxy_config(proxies)[1])
 
 
-def _is_trusted_proxy(
-    ip_str: str | None, proxies: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
-) -> bool:
+def _is_trusted_proxy(ip_str: str | None, proxies: Sequence[ProxyNetwork]) -> bool:
     ip_norm = _normalize_ip_string(ip_str or "")
     if not ip_norm:
         return False
@@ -268,7 +302,7 @@ def _is_trusted_proxy(
 
 def _is_global_public_ip(
     ip_str: str | None,
-    proxies: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+    proxies: Sequence[ProxyNetwork],
 ) -> bool:
     """True if `ip_str` is a valid, globally routable IP and not a trusted proxy."""
     ip_norm = _normalize_ip_string(ip_str or "")
@@ -303,22 +337,12 @@ def _parse_x_forwarded_for_values(values: Sequence[str]) -> list[str]:
     return out
 
 
-def extract_ip_details_from_headers(
+def _extract_ip_details_from_headers(
     headers: Mapping[str, HeaderValue],
     *,
-    proxies: Sequence[str] | None = None,
+    proxy_nets: Sequence[ProxyNetwork],
     environment: str | None = None,
 ) -> ClientIpDetails:
-    """
-    Extract a likely client IP from headers with validation and trusted proxies.
-
-    When ``environment`` is supplied, it overrides ``ARCJET_ENV`` for the
-    development-mode gating of the ``X-Arcjet-Ip`` override. Pass this when
-    using a config library that does not propagate ``.env`` values into
-    ``os.environ`` (e.g. ``pydantic-settings``).
-    """
-    proxy_nets = _parse_proxies(proxies)
-
     # In development only, allow override for testing.
     if _is_development(environment=environment):
         xaj = _first_header(headers, "x-arcjet-ip")
@@ -345,6 +369,25 @@ def extract_ip_details_from_headers(
     return ClientIpDetails(None, ClientIpProvenance.NONE, False)
 
 
+def extract_ip_details_from_headers(
+    headers: Mapping[str, HeaderValue],
+    *,
+    proxies: Sequence[str] | None = None,
+    environment: str | None = None,
+) -> ClientIpDetails:
+    """Extract a client IP and provenance from forwarding headers.
+
+    Without a trusted direct peer this is an ``UNVERIFIED_HEADER`` result. Pass
+    every trusted proxy IP/CIDR in ``proxies`` and restrict direct access to the
+    application before treating the header as authoritative.
+    """
+    return _extract_ip_details_from_headers(
+        headers,
+        proxy_nets=_parse_proxies(proxies),
+        environment=environment,
+    )
+
+
 def extract_ip_from_headers(
     headers: Mapping[str, HeaderValue],
     *,
@@ -364,7 +407,12 @@ def client_ip_details(
     ip_src: str | None = None,
     environment: str | None = None,
 ) -> ClientIpDetails:
-    """Explain how Arcjet would select the client IP for ``req``."""
+    """Explain how Arcjet would select the client IP for ``req``.
+
+    This low-level helper performs no logging or network request. Prefer
+    ``Arcjet.client_ip_details()`` or ``ArcjetSync.client_ip_details()`` so the
+    client's proxy, environment, and manual-IP configuration is applied.
+    """
     proxy_nets = _parse_proxies(proxies)
 
     if ip_src is not None:
@@ -374,7 +422,14 @@ def client_ip_details(
 
     if isinstance(req, RequestContext):
         if req.ip:
-            return ClientIpDetails(req.ip, ClientIpProvenance.REQUEST, True)
+            try:
+                ip = validate_ip(req.ip, name="request IP")
+            except ValueError:
+                ip = None
+            if ip is not None:
+                return ClientIpDetails(ip, ClientIpProvenance.REQUEST, True)
+        if _is_development(environment=environment):
+            return ClientIpDetails("127.0.0.1", ClientIpProvenance.DEVELOPMENT, False)
         return ClientIpDetails(None, ClientIpProvenance.NONE, False)
 
     headers: dict[str, HeaderValue] = {}
@@ -394,7 +449,16 @@ def client_ip_details(
         else:
             value = cast_req.get("ip")
             if isinstance(value, str) and value:
-                return ClientIpDetails(value, ClientIpProvenance.REQUEST, True)
+                try:
+                    ip = validate_ip(value, name="request IP")
+                except ValueError:
+                    ip = None
+                if ip is not None:
+                    return ClientIpDetails(ip, ClientIpProvenance.REQUEST, True)
+            if _is_development(environment=environment):
+                return ClientIpDetails(
+                    "127.0.0.1", ClientIpProvenance.DEVELOPMENT, False
+                )
             return ClientIpDetails(None, ClientIpProvenance.NONE, False)
     elif hasattr(req, "META") and hasattr(req, "method"):
         meta = getattr(req, "META", {}) or {}
@@ -418,8 +482,8 @@ def client_ip_details(
             _normalize_ip_string(remote), ClientIpProvenance.DIRECT, True
         )
 
-    header_details = extract_ip_details_from_headers(
-        headers, proxies=proxies, environment=environment
+    header_details = _extract_ip_details_from_headers(
+        headers, proxy_nets=proxy_nets, environment=environment
     )
     if header_details.ip is not None:
         if (
@@ -502,6 +566,7 @@ def coerce_request_context(
     proxies: Sequence[str] | None = None,
     ip_src: str | None = None,
     environment: str | None = None,
+    resolved_ip_details: ClientIpDetails | None = None,
 ) -> RequestContext:
     """Best-effort coercion from common request objects.
 
@@ -519,10 +584,25 @@ def coerce_request_context(
     When ``environment`` is supplied, it overrides ``ARCJET_ENV`` for the
     development-mode check; pass this when using a config library that does
     not propagate ``.env`` values into ``os.environ`` (e.g. ``pydantic-settings``).
-    Raises `TypeError` for unsupported shapes.
+    ``resolved_ip_details`` lets callers reuse a previously resolved address so
+    proxy headers are not parsed twice. Raises `TypeError` for unsupported
+    shapes.
     """
+
+    def resolved_ip() -> str | None:
+        if resolved_ip_details is not None:
+            return resolved_ip_details.ip
+        return client_ip_details(
+            req,
+            proxies=proxies,
+            ip_src=ip_src,
+            environment=environment,
+        ).ip
+
     if isinstance(req, RequestContext):
-        return req
+        if resolved_ip_details is None and ip_src is None:
+            return req
+        return replace(req, ip=resolved_ip())
 
     if isinstance(req, Mapping):
         # Here we cast to Mapping[str, Any] to help type checkers understand
@@ -540,12 +620,7 @@ def coerce_request_context(
                     headers[k.decode("latin-1")] = v.decode("latin-1")
                 except Exception:
                     continue
-            ip = client_ip_details(
-                req,
-                proxies=proxies,
-                ip_src=ip_src,
-                environment=environment,
-            ).ip
+            ip = resolved_ip()
 
             return RequestContext(
                 ip=ip,
@@ -563,13 +638,16 @@ def coerce_request_context(
             )
 
         # Plain mapping: treat as already-normalized
-        return RequestContext(
+        context = RequestContext(
             **{
                 k: cast_req.get(k)
                 for k in RequestContext.__dataclass_fields__.keys()
                 if k in cast_req
             }
         )
+        if resolved_ip_details is not None or ip_src is not None:
+            return replace(context, ip=resolved_ip())
+        return context
 
     # Flask/Werkzeug Request (duck typing)
     if (
@@ -582,12 +660,7 @@ def coerce_request_context(
             headers = dict(getattr(req, "headers", {}) or {})
         except Exception:
             headers = {}
-        ip = client_ip_details(
-            req,
-            proxies=proxies,
-            ip_src=ip_src,
-            environment=environment,
-        ).ip
+        ip = resolved_ip()
         try:
             query_raw = getattr(req, "query_string", None)
             query = (
@@ -620,12 +693,7 @@ def coerce_request_context(
         # Django 2.2+ has request.headers (case-insensitive)
         hdrs_obj = getattr(req, "headers", None)
         headers = dict(hdrs_obj) if hdrs_obj is not None else {}
-        ip = client_ip_details(
-            req,
-            proxies=proxies,
-            ip_src=ip_src,
-            environment=environment,
-        ).ip
+        ip = resolved_ip()
         scheme = (
             "https"
             if meta.get("wsgi.url_scheme") == "https"

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -236,10 +236,10 @@ def test_proxy_configuration_warnings_are_precise(
 ):
     import logging
 
-    import arcjet as arcjet_module
+    from arcjet import arcjet, arcjet_sync
     from arcjet._rules import Mode, token_bucket
 
-    factory = getattr(arcjet_module, factory_name)
+    factory = {"arcjet": arcjet, "arcjet_sync": arcjet_sync}[factory_name]
     rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
     with caplog.at_level(logging.WARNING, logger="arcjet"):
         factory(key="ajkey_x", rules=rules, proxies=["10.0.0.0/8"])

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -196,6 +196,67 @@ def test_client_ip_details_and_unverified_header_warning_once(
     assert len(warning_records) == 1
 
 
+def test_manual_ip_reaches_decide_for_all_supported_context_shapes(
+    mock_protobuf_modules,
+    make_allow_decision,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import asyncio
+
+    from arcjet import arcjet
+    from arcjet._context import RequestContext
+    from arcjet._rules import Mode, token_bucket
+    from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
+
+    captured: list[str] = []
+
+    def allow(req):
+        captured.append(req.details.ip)
+        return mock_protobuf_modules["DecideResponse"](make_allow_decision())
+
+    monkeypatch.setattr(DecideServiceClient, "decide_behavior", allow, raising=False)
+    aj = arcjet(
+        key="ajkey_x",
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
+        disable_automatic_ip_detection=True,
+    )
+
+    asyncio.run(aj.protect(RequestContext(ip="1.1.1.1"), ip_src="8.8.8.8"))
+    asyncio.run(aj.protect({"ip": "1.1.1.1"}, ip_src="8.8.8.8"))
+    assert captured == ["8.8.8.8", "8.8.8.8"]
+
+
+@pytest.mark.parametrize("factory_name", ["arcjet", "arcjet_sync"])
+@pytest.mark.parametrize("trust_all", ["0.0.0.0/0", "::/0"])
+def test_proxy_configuration_warnings_are_precise(
+    mock_protobuf_modules,
+    caplog: pytest.LogCaptureFixture,
+    factory_name: str,
+    trust_all: str,
+):
+    import logging
+
+    import arcjet as arcjet_module
+    from arcjet._rules import Mode, token_bucket
+
+    factory = getattr(arcjet_module, factory_name)
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
+    with caplog.at_level(logging.WARNING, logger="arcjet"):
+        factory(key="ajkey_x", rules=rules, proxies=["10.0.0.0/8"])
+        assert not any(
+            "entire IP address family" in record.getMessage()
+            for record in caplog.records
+        )
+        factory(key="ajkey_x", rules=rules, proxies=[trust_all])
+    assert (
+        sum(
+            "entire IP address family" in record.getMessage()
+            for record in caplog.records
+        )
+        == 1
+    )
+
+
 def test_invalid_proxy_and_manual_ip_are_rejected(mock_protobuf_modules):
     import asyncio
 
@@ -266,16 +327,13 @@ def test_disable_automatic_ip_detection_with_proxies(mock_protobuf_modules):
     from arcjet._rules import Mode, token_bucket
 
     rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
-    aj = arcjet(
-        key="ajkey_x",
-        rules=rules,
-        disable_automatic_ip_detection=True,
-        proxies=["3.3.3.3"],
-    )
-    import asyncio
-
     with pytest.raises(ArcjetMisconfiguration, match="proxies cannot be used"):
-        asyncio.run(aj.protect({"headers": [], "type": "http"}, ip_src="8.8.8.8"))
+        arcjet(
+            key="ajkey_x",
+            rules=rules,
+            disable_automatic_ip_detection=True,
+            proxies=["3.3.3.3"],
+        )
 
 
 def test_ip_src_disallowed_when_automatic_ip_detection_enabled(mock_protobuf_modules):

--- a/tests/unit/test_client_async.py
+++ b/tests/unit/test_client_async.py
@@ -152,6 +152,66 @@ def test_ip_override_with_ip_src(
     assert d.is_allowed()
 
 
+def test_client_ip_details_and_unverified_header_warning_once(
+    mock_protobuf_modules,
+    make_allow_decision,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    import asyncio
+    import logging
+
+    from arcjet import ClientIpProvenance, arcjet
+    from arcjet._rules import Mode, token_bucket
+    from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClient
+
+    def allow(_req):
+        return mock_protobuf_modules["DecideResponse"](make_allow_decision())
+
+    monkeypatch.setattr(DecideServiceClient, "decide_behavior", allow, raising=False)
+    aj = arcjet(
+        key="ajkey_x",
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
+    )
+    request = {
+        "type": "http",
+        "headers": [(b"x-forwarded-for", b"8.8.8.8")],
+        "client": ("10.0.0.1", 1234),
+    }
+
+    details = aj.client_ip_details(request)
+    assert details.provenance is ClientIpProvenance.UNVERIFIED_HEADER
+    with caplog.at_level(logging.DEBUG, logger="arcjet"):
+        asyncio.run(aj.protect(request))
+        asyncio.run(aj.protect(request))
+
+    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    assert any(
+        getattr(r, "client_ip_provenance", None) == "unverified-header"
+        for r in debug_records
+    )
+    warning_records = [
+        r for r in caplog.records if "unverified forwarding header" in r.getMessage()
+    ]
+    assert len(warning_records) == 1
+
+
+def test_invalid_proxy_and_manual_ip_are_rejected(mock_protobuf_modules):
+    import asyncio
+
+    from arcjet import arcjet
+    from arcjet._errors import ArcjetMisconfiguration
+    from arcjet._rules import Mode, token_bucket
+
+    rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
+    with pytest.raises(ArcjetMisconfiguration, match="invalid proxy IP or CIDR"):
+        arcjet(key="ajkey_x", rules=rules, proxies=["not-an-ip"])
+
+    aj = arcjet(key="ajkey_x", rules=rules, disable_automatic_ip_detection=True)
+    with pytest.raises(ArcjetMisconfiguration, match="ip_src must be a valid"):
+        asyncio.run(aj.protect({"headers": [], "type": "http"}, ip_src="not-an-ip"))
+
+
 def test_correlation_id_sent_in_decide_request(
     mock_protobuf_modules,
     make_allow_decision,

--- a/tests/unit/test_client_sync.py
+++ b/tests/unit/test_client_sync.py
@@ -185,6 +185,57 @@ def test_ip_override_with_ip_src(
     assert d.is_allowed()
 
 
+def test_unverified_header_warning_is_once_per_sync_client(
+    mock_protobuf_modules,
+    make_allow_decision,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    import logging
+
+    from arcjet import arcjet_sync
+    from arcjet._rules import Mode, token_bucket
+    from arcjet.proto.decide.v1alpha1.decide_connect import DecideServiceClientSync
+
+    def allow(_req):
+        return mock_protobuf_modules["DecideResponse"](make_allow_decision())
+
+    monkeypatch.setattr(
+        DecideServiceClientSync, "decide_behavior", allow, raising=False
+    )
+    aj = arcjet_sync(
+        key="ajkey_x",
+        rules=[token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)],
+    )
+    request = {
+        "type": "http",
+        "headers": [(b"x-forwarded-for", b"8.8.8.8")],
+        "client": ("10.0.0.1", 1234),
+    }
+
+    # Inspection is silent and does not consume the lifetime warning budget.
+    aj.client_ip_details(request)
+    with caplog.at_level(logging.DEBUG, logger="arcjet"):
+        aj.protect(request)
+        aj.protect(request)
+
+    assert (
+        sum(
+            "unverified forwarding header" in record.getMessage()
+            for record in caplog.records
+        )
+        == 1
+    )
+    assert (
+        sum(
+            getattr(record, "client_ip_provenance", None) == "unverified-header"
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+        )
+        == 2
+    )
+
+
 def test_disable_automatic_ip_detection_requires_ip_src(mock_protobuf_modules):
     """Test that ip_src is required when automatic IP detection is disabled."""
     from arcjet import arcjet_sync
@@ -205,15 +256,13 @@ def test_disable_automatic_ip_detection_with_proxies(mock_protobuf_modules):
     from arcjet._rules import Mode, token_bucket
 
     rules = [token_bucket(mode=Mode.LIVE, refill_rate=1, interval=1, capacity=1)]
-    aj = arcjet_sync(
-        key="ajkey_x",
-        rules=rules,
-        disable_automatic_ip_detection=True,
-        proxies=["3.3.3.3"],
-    )
-
     with pytest.raises(ArcjetMisconfiguration, match="proxies cannot be used"):
-        aj.protect({"headers": [], "type": "http"}, ip_src="8.8.8.8")
+        arcjet_sync(
+            key="ajkey_x",
+            rules=rules,
+            disable_automatic_ip_detection=True,
+            proxies=["3.3.3.3"],
+        )
 
 
 def test_ip_src_disallowed_when_automatic_ip_detection_enabled(mock_protobuf_modules):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -9,13 +9,16 @@ from __future__ import annotations
 import pytest
 
 from arcjet._context import (
+    ClientIpDetails,
     ClientIpProvenance,
     RequestContext,
     _is_development,
     client_ip_details,
     coerce_request_context,
     extract_ip_from_headers,
+    has_trust_all_proxy,
     request_details_from_context,
+    validate_proxies,
 )
 
 
@@ -71,6 +74,90 @@ def test_client_ip_details_marks_configured_direct_proxy():
 def test_client_ip_details_validates_manual_ip():
     with pytest.raises(ValueError, match="ip_src must be a valid"):
         client_ip_details({}, ip_src="not-an-ip")
+
+
+def test_client_ip_details_covers_every_resolution_source():
+    direct = client_ip_details(
+        {"type": "http", "headers": [], "client": ("8.8.8.8", 443)}
+    )
+    assert direct == ClientIpDetails("8.8.8.8", ClientIpProvenance.DIRECT, True)
+
+    manual = client_ip_details({}, ip_src="2001:4860:4860::8888")
+    assert manual == ClientIpDetails(
+        "2001:4860:4860::8888", ClientIpProvenance.MANUAL, True
+    )
+
+    request = client_ip_details(RequestContext(ip="2001:4860:4860:0::8888"))
+    assert request == ClientIpDetails(
+        "2001:4860:4860::8888", ClientIpProvenance.REQUEST, True
+    )
+
+    development_header = client_ip_details(
+        {
+            "type": "http",
+            "headers": [(b"x-arcjet-ip", b"10.0.0.1")],
+            "client": None,
+        },
+        environment="development",
+    )
+    assert development_header == ClientIpDetails(
+        "10.0.0.1",
+        ClientIpProvenance.DEVELOPMENT,
+        False,
+        "x-arcjet-ip",
+    )
+
+    development_fallback = client_ip_details({}, environment="development")
+    assert development_fallback == ClientIpDetails(
+        "127.0.0.1", ClientIpProvenance.DEVELOPMENT, False
+    )
+
+    assert client_ip_details({}, environment="production") == ClientIpDetails(
+        None, ClientIpProvenance.NONE, False
+    )
+    assert client_ip_details(
+        RequestContext(ip="not-an-ip"), environment="production"
+    ) == ClientIpDetails(None, ClientIpProvenance.NONE, False)
+
+
+@pytest.mark.parametrize(
+    "proxies",
+    [
+        [""],
+        ["   "],
+        ["not-an-ip"],
+        ["10.0.0.0/33"],
+        ["2001:db8::/129"],
+        [1234],
+    ],
+)
+def test_validate_proxies_rejects_every_malformed_shape(proxies):
+    with pytest.raises(ValueError, match="invalid proxy IP or CIDR"):
+        validate_proxies(proxies)
+
+
+def test_validate_proxies_normalizes_and_detects_only_trust_all_cidrs():
+    assert validate_proxies([" 10.0.0.0/8 ", "2001:db8::1"]) == (
+        "10.0.0.0/8",
+        "2001:db8::1",
+    )
+    assert has_trust_all_proxy(["0.0.0.0/0"])
+    assert has_trust_all_proxy(["::/0"])
+    assert not has_trust_all_proxy(["0.0.0.0"])
+    assert not has_trust_all_proxy(["::"])
+
+
+def test_coerce_request_context_reuses_resolved_ip_for_manual_mode():
+    resolved = ClientIpDetails("8.8.8.8", ClientIpProvenance.MANUAL, True)
+    mapping = coerce_request_context(
+        {"ip": "1.1.1.1", "method": "GET"}, resolved_ip_details=resolved
+    )
+    context = coerce_request_context(
+        RequestContext(ip="1.1.1.1", method="GET"),
+        resolved_ip_details=resolved,
+    )
+    assert mapping.ip == "8.8.8.8"
+    assert context.ip == "8.8.8.8"
 
 
 def test_extract_ip_dev_override_wins(dev_environment):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -15,6 +15,7 @@ from arcjet._context import (
     _is_development,
     client_ip_details,
     coerce_request_context,
+    extract_ip_details_from_headers,
     extract_ip_from_headers,
     has_trust_all_proxy,
     request_details_from_context,
@@ -69,6 +70,28 @@ def test_client_ip_details_marks_configured_direct_proxy():
     assert details.ip == "8.8.8.8"
     assert details.provenance is ClientIpProvenance.TRUSTED_PROXY
     assert details.verified is True
+
+
+@pytest.mark.parametrize(
+    ("headers", "proxies", "environment"),
+    [
+        ({"x-forwarded-for": "1.1.1.1, 8.8.8.8"}, None, "production"),
+        ({"x-forwarded-for": "1.1.1.1, 10.0.0.1"}, ["10.0.0.0/8"], "production"),
+        ({"x-real-ip": "2001:4860:4860::8888"}, None, "production"),
+        ({"x-arcjet-ip": "10.0.0.1"}, None, "development"),
+        ({}, None, "production"),
+    ],
+)
+def test_legacy_header_ip_api_remains_details_ip_projection(
+    headers, proxies, environment
+):
+    """The diagnostics API must not change the legacy string result."""
+    assert (
+        extract_ip_from_headers(headers, proxies=proxies, environment=environment)
+        == extract_ip_details_from_headers(
+            headers, proxies=proxies, environment=environment
+        ).ip
+    )
 
 
 def test_client_ip_details_validates_manual_ip():
@@ -158,6 +181,26 @@ def test_coerce_request_context_reuses_resolved_ip_for_manual_mode():
     )
     assert mapping.ip == "8.8.8.8"
     assert context.ip == "8.8.8.8"
+
+
+def test_legacy_context_coercion_preserves_identity_and_fields():
+    """New optional diagnostics inputs leave existing coercion calls unchanged."""
+    original = RequestContext(ip="8.8.8.8", method="POST", path="/legacy")
+    assert coerce_request_context(original) is original
+
+    assert coerce_request_context(
+        {
+            "ip": "1.1.1.1",
+            "method": "GET",
+            "path": "/legacy",
+            "extra": {"existing": "value"},
+        }
+    ) == RequestContext(
+        ip="1.1.1.1",
+        method="GET",
+        path="/legacy",
+        extra={"existing": "value"},
+    )
 
 
 def test_extract_ip_dev_override_wins(dev_environment):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import pytest
 
 from arcjet._context import (
+    ClientIpProvenance,
     RequestContext,
     _is_development,
+    client_ip_details,
     coerce_request_context,
     extract_ip_from_headers,
     request_details_from_context,
@@ -32,9 +34,43 @@ def test_extract_ip_xff_skips_multiple_trusted_proxies():
     assert extract_ip_from_headers(headers, proxies=["3.3.3.3", "2.2.2.2"]) == "1.1.1.1"
 
 
-def test_extract_ip_xff_ignores_invalid_proxy_entries():
+def test_extract_ip_xff_rejects_invalid_proxy_entries():
     headers = {"x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3"}
-    assert extract_ip_from_headers(headers, proxies=[1234]) == "3.3.3.3"  # type: ignore
+    with pytest.raises(ValueError, match="invalid proxy IP or CIDR"):
+        extract_ip_from_headers(headers, proxies=[1234])  # type: ignore
+
+
+def test_client_ip_details_marks_unverified_header():
+    details = client_ip_details(
+        {
+            "type": "http",
+            "headers": [(b"x-forwarded-for", b"8.8.8.8")],
+            "client": ("10.0.0.1", 1234),
+        }
+    )
+    assert details.ip == "8.8.8.8"
+    assert details.provenance is ClientIpProvenance.UNVERIFIED_HEADER
+    assert details.verified is False
+    assert details.header == "x-forwarded-for"
+
+
+def test_client_ip_details_marks_configured_direct_proxy():
+    details = client_ip_details(
+        {
+            "type": "http",
+            "headers": [(b"x-forwarded-for", b"8.8.8.8")],
+            "client": ("10.0.0.1", 1234),
+        },
+        proxies=["10.0.0.0/8"],
+    )
+    assert details.ip == "8.8.8.8"
+    assert details.provenance is ClientIpProvenance.TRUSTED_PROXY
+    assert details.verified is True
+
+
+def test_client_ip_details_validates_manual_ip():
+    with pytest.raises(ValueError, match="ip_src must be a valid"):
+        client_ip_details({}, ip_src="not-an-ip")
 
 
 def test_extract_ip_dev_override_wins(dev_environment):


### PR DESCRIPTION
## Summary

- expose client IP provenance through `client_ip_details()` and structured debug log facets
- warn once per client when a generic forwarding header is used without a verifiable trust path
- reject malformed proxy and manual IP configuration, and warn on trust-all proxy ranges
- document safe proxy configuration in the README

## Validation

- Ruff formatting and lint
- ty (one pre-existing diagnostic)
- Pyright
- Griffe API compatibility check against `origin/main`
- full pytest suite: 1,544 passed, 8 skipped (91.40% coverage)
