### PR TITLE
feat(guard): add Claude Agent SDK support as arcjet.guard.claude_agent_sdk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,14 +174,19 @@ keeping the existing API surface intact with internal changes.
   `.handler`; on DENY it returns
   `{content: [{type: text, text: json.dumps(ArcjetDenialResult)}], is_error: True}`
   and does not throw (the SDK swallows into `str(e)`) and does not set
-  `structuredContent` (`create_sdk_mcp_server` drops it). `guard_hooks`
+  `structuredContent` (`create_sdk_mcp_server` drops it).   `guard_hooks`
   denies unwrapped built-ins / MCP on `PreToolUse`
-  (`permissionDecision: "deny"`) and screens inbound on `UserPromptSubmit`
-  (`{decision: "block"}` via `inbound=` — there is no `guard_inbound`).
-  Wrapped tools are excluded from PreToolUse by the `mcp__{server}__{name}`
-  name. `claude_agent_context` reads a caller-owned UUID `session_id` and
-  never mints, never reads `trace_id`. `can_use_tool` is HITL and is not
-  wrapped. Already-branded tools are skipped.
+  (`permissionDecision: "deny"`), captures on `PostToolUse`
+  (`claude.phase: after`; `exclude` does not skip it), and screens inbound
+  on `UserPromptSubmit` (`{decision: "block"}` via `inbound=` — there is
+  no `guard_inbound`). Tool-hook `rules` / `actor` / `inputs` / `metadata`
+  receive `tool_input` plus `tool_name`. `actor=` / `inputs=` do not
+  register a tool hook by themselves; pass `tools=True` for the default
+  `{tool_name}.invoked` gate. Wrap-time `session_id=` / `correlation_id=`
+  must be a UUID. Wrapped tools are excluded from PreToolUse by the
+  `mcp__{server}__{name}` name. `claude_agent_context` reads a caller-owned
+  UUID `session_id` and never mints, never reads `trace_id`. `can_use_tool`
+  is HITL and is not wrapped. Already-branded tools are skipped.
 - `src/arcjet/_analyze/` — WASM component integration with typed Python bindings.
   See `docs/WITGEN.md` for binding generation and
   `docs/WASMTIME.md` for wasmtime-py details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,21 @@ keeping the existing API surface intact with internal changes.
   string). `openai_agents_context` reads a caller-owned id and never mints,
   never reads `trace_id`, and never constructs a session. `needs_approval`
   is HITL and is not wrapped. Already-branded tools are skipped.
+- `src/arcjet/guard/claude_agent_sdk/` — Optional Claude Agent SDK
+  integration (`arcjet[claude-agent-sdk]`, peer `claude-agent-sdk>=0.2.127,<1`).
+  Independent of LangChain, CrewAI, and OpenAI Agents: it must not import
+  any of them. `guard_tool` wraps an authored `@tool` / `SdkMcpTool`
+  `.handler`; on DENY it returns
+  `{content: [{type: text, text: json.dumps(ArcjetDenialResult)}], is_error: True}`
+  and does not throw (the SDK swallows into `str(e)`) and does not set
+  `structuredContent` (`create_sdk_mcp_server` drops it). `guard_hooks`
+  denies unwrapped built-ins / MCP on `PreToolUse`
+  (`permissionDecision: "deny"`) and screens inbound on `UserPromptSubmit`
+  (`{decision: "block"}` via `inbound=` — there is no `guard_inbound`).
+  Wrapped tools are excluded from PreToolUse by the `mcp__{server}__{name}`
+  name. `claude_agent_context` reads a caller-owned UUID `session_id` and
+  never mints, never reads `trace_id`. `can_use_tool` is HITL and is not
+  wrapped. Already-branded tools are skipped.
 - `src/arcjet/_analyze/` — WASM component integration with typed Python bindings.
   See `docs/WITGEN.md` for binding generation and
   `docs/WASMTIME.md` for wasmtime-py details.
@@ -193,6 +208,11 @@ deliberately kept apart and **must not be merged**:
   `arcjet.guard.openai_agents`. No chromadb. Like CrewAI, it is in no
   dependency group so `uv.lock` does not pull its transitive tree into every
   `uv sync`; install it ad hoc for integration tests — see CONTRIBUTING.
+- `claude-agent-sdk` → `claude-agent-sdk>=0.2.127,<1`. Enough for
+  `arcjet.guard.claude_agent_sdk`. No chromadb. Same lockfile policy as
+  openai-agents. The floor is 0.2.127 (0.2.83 was mcp CVE + timeout
+  fail-close; 0.2.127 includes that and the background-task PreToolUse
+  stdin fix). Verified on 0.2.148.
 There is deliberately **no `crewai` extra and no CrewAI dependency group**.
 `crewai` hard-depends on `chromadb~=1.1.0`, and chromadb 1.0.0–1.5.9 all carry
 an unpatched critical RCE (CVE-2026-45829). No fixed version exists and
@@ -211,7 +231,8 @@ Nothing outside `src/arcjet/guard/langchain/` may import LangChain. Using
 Arcjet Guard must never require LangChain to be installed. Nothing outside
 `src/arcjet/guard/crewai/` may import CrewAI. Nothing outside
 `src/arcjet/guard/openai_agents/` may import the OpenAI Agents SDK
-(`agents`).
+(`agents`). Nothing outside `src/arcjet/guard/claude_agent_sdk/` may
+import the Claude Agent SDK (`claude_agent_sdk`).
 
 ## Coding conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,24 @@ uv run --no-sync pytest tests/integration/guard/test_openai_agents.py tests/inte
 including when the extra is absent. `just test` on a plain `uv sync` skips the
 integration files, which is what CI does.
 
+### Claude Agent SDK tests
+
+`arcjet[claude-agent-sdk]` is a real extra (`claude-agent-sdk>=0.2.127,<1`) but
+is in no dependency group, so the lockfile does not pull its transitive tree
+into every `uv sync`. Install it alongside the locked environment when you want
+integration coverage:
+
+```sh
+uv sync
+uv pip install "claude-agent-sdk>=0.2.127,<1"
+# `--no-sync`, or uv restores the lock and removes claude-agent-sdk again
+uv run --no-sync pytest tests/integration/guard/test_claude_agent_sdk.py --no-cov
+```
+
+`tests/unit/guard/test_claude_agent_sdk.py` imports no `claude_agent_sdk` and
+always runs, including when the extra is absent. `just test` on a plain
+`uv sync` skips the integration file, which is what CI does.
+
 ## Benchmarks
 
 WASM performance benchmarks live in `tests/benchmarks/` and measure the per-call

--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,8 @@ effect happens.
 | A CrewAI crew / LiteAgent / MCP or crew-injected tool | `register_arcjet_hooks` | your own `crewai` | Yes — via `HookAborted` |
 | A CrewAI `BaseTool` you call yourself | `guard_tool` (`arcjet.guard.crewai`) | your own `crewai` | Yes |
 | An OpenAI Agents authored `FunctionTool` | `guard_tool` (`arcjet.guard.openai_agents`) | `arcjet[openai-agents]` | Yes — via `reject_content` |
+| A Claude Agent SDK authored `@tool` / `SdkMcpTool` | `guard_tool` (`arcjet.guard.claude_agent_sdk`) | `arcjet[claude-agent-sdk]` | Yes — via `is_error` tool result |
+| Unwrapped Claude built-ins / MCP, or inbound user text | `guard_hooks` (`arcjet.guard.claude_agent_sdk`) | `arcjet[claude-agent-sdk]` | Yes — `PreToolUse` deny / `UserPromptSubmit` block |
 
 Two rules of thumb. If you can name the tool at wiring time, `guard_tool` is the
 smaller change — it returns something that *is* the tool, so nothing downstream
@@ -1025,6 +1027,12 @@ right home for capture and the wrong home for policy.
   Independent of LangChain and CrewAI. Docs:
   [`/guards/openai-agents-py/`](https://docs.arcjet.com/guards/openai-agents-py/)
   — not the JS page [`/guards/openai-agents/`](https://docs.arcjet.com/guards/openai-agents/).
+- **`arcjet[claude-agent-sdk]`** — `guard_tool`, `guard_hooks`, and
+  `claude_agent_context` for the Claude Agent SDK
+  (`claude-agent-sdk>=0.2.127,<1`). Independent of LangChain, CrewAI, and
+  OpenAI Agents. Docs:
+  [`/guards/claude-agent-sdk-py/`](https://docs.arcjet.com/guards/claude-agent-sdk-py/)
+  — not the JS page [`/guards/claude-agent-sdk/`](https://docs.arcjet.com/guards/claude-agent-sdk/).
 There is deliberately **no `arcjet[crewai]` extra**. `arcjet.guard.crewai`
 works against the `crewai` you install yourself (`>=1.15.3,<2`, where `@on`
 and `HookAborted` landed; CrewAI requires Python `>=3.10,<3.14`). Arcjet does
@@ -1051,7 +1059,7 @@ from arcjet.guard.langchain import (
 )
 ```
 
-**Fail-closed default** — The *checkpoint surfaces* (`guard_action`, `guard_action_sync`, `guard_tool`, `ArcjetMiddleware`, `register_arcjet_hooks`) default to denying when evaluation is unavailable. This is Arcjet's one documented divergence from the platform-wide fail-open convention. Note the scope: the core `guard()` call still fails **open**, returning an ALLOW for which `has_failed_open()` is `True`, as does the request protection API (`arcjet` / `arcjet_sync`). It is the surfaces that wrap a consequential effect which fail closed:
+**Fail-closed default** — The *checkpoint surfaces* (`guard_action`, `guard_action_sync`, `guard_tool`, `guard_hooks`, `ArcjetMiddleware`, `register_arcjet_hooks`) default to denying when evaluation is unavailable. This is Arcjet's one documented divergence from the platform-wide fail-open convention. Note the scope: the core `guard()` call still fails **open**, returning an ALLOW for which `has_failed_open()` is `True`, as does the request protection API (`arcjet` / `arcjet_sync`). It is the surfaces that wrap a consequential effect which fail closed:
 
 - **`on_guard_error="deny"`** (default) — If Guard is unavailable or evaluation fails, the guarded action blocks with `ArcjetUnavailableError`.
 - **`on_guard_error="allow"`** — Opt out: if Guard is unavailable, the action runs anyway. Use this only where availability matters more than enforcement.
@@ -1538,6 +1546,88 @@ Hosted tools, MCP, Computer / Shell / ApplyPatch, handoffs, and
 `conversation_id` / `group_id`, then the enclosing `arcjet_sequence()`. It
 never mints. It never reads `trace_id`. It never constructs
 `OpenAIConversationsSession()` just to get an id.
+
+### Claude Agent SDK tools and hooks
+
+`arcjet.guard.claude_agent_sdk` needs `pip install "arcjet[claude-agent-sdk]"`
+(`claude-agent-sdk>=0.2.127,<1`). Nothing here imports
+`arcjet.guard.langchain`, `arcjet.guard.crewai`, or
+`arcjet.guard.openai_agents`, and importing `arcjet.guard` never imports the
+Claude Agent SDK. The Python page is
+[`/guards/claude-agent-sdk-py/`](https://docs.arcjet.com/guards/claude-agent-sdk-py/);
+it does not replace the JS page
+[`/guards/claude-agent-sdk/`](https://docs.arcjet.com/guards/claude-agent-sdk/).
+
+```py
+from arcjet.guard import DetectPromptInjection, launch_arcjet
+from arcjet.guard.claude_agent_sdk import (
+    claude_agent_context,
+    guard_hooks,
+    guard_tool,
+)
+from claude_agent_sdk import tool
+
+aj = launch_arcjet(key=arcjet_key)
+session_id = conversation_id  # a UUID the app already minted
+
+
+@tool("send_email", "Send an email", {"to": str, "body": str})
+async def send_email(args):
+    return {"content": [{"type": "text", "text": "sent"}]}
+
+
+guarded_send = guard_tool(
+    guard=aj,
+    tool=send_email,
+    action="email.sent",
+    session_id=session_id,  # authored handler has no extra.session_id
+    on_guard_error="deny",  # default
+)
+
+hooks = guard_hooks(
+    guard=aj,
+    session_id=session_id,
+    action=lambda hook: f"{hook['tool_name']}.invoked",
+    exclude=[{"server": "mail", "name": "send_email"}],
+    inbound={
+        "action": "message.received",
+        "rules": lambda arguments: [DetectPromptInjection()(arguments["prompt"])],
+    },
+)
+```
+
+On DENY the authored handler returns exactly
+`{"content": [{"type": "text", "text": <json.dumps(ArcjetDenialResult)>}], "is_error": True}`.
+It does not throw (the SDK swallows into `str(e)`) and it does not set
+`structuredContent` (`create_sdk_mcp_server` drops it). Already-branded
+tools are skipped.
+
+#### Screen inbound on `UserPromptSubmit`
+
+There is no `guard_inbound` helper. Put prompt-injection and other inbound
+rules on `guard_hooks(..., inbound=...)`. A deny is `{"decision": "block"}`.
+`protect()` and the request path are fail-open — the caller must check
+`has_failed_open()`. These helpers default to `on_guard_error="deny"`.
+
+#### `can_use_tool` is not a policy gate
+
+`can_use_tool` is ask-only HITL. `allowed_tools`, allow rules, and
+`bypassPermissions` / `acceptEdits` skip it. There is no
+`guard_can_use_tool`. `permissionDecision: "ask"` is HITL, not deny. Use
+`guard_tool` for authored tools or `PreToolUse` for unwrapped ones.
+
+#### Deny unwrapped tools on `PreToolUse`
+
+Built-ins (Bash, Write, …) and MCP tools not passed through `guard_tool`
+are gated here. `PreToolUse` returns `permissionDecision: "deny"`. List
+every `guard_tool` wrapper in `exclude` as `{"server": ..., "name": ...}`
+so the reported `mcp__{server}__{name}` name is not double-gated. A bare
+authored name does not match every server's tool of that name.
+
+`claude_agent_context` reads hook `session_id` first, then the
+caller-owned `session_id=` fallback, then `arcjet_sequence()`. It never
+mints. It never reads `trace_id`. The value must be a UUID the app already
+minted if you also pass it to `query()`.
 
 ### Sync usage
 

--- a/README.md
+++ b/README.md
@@ -1559,7 +1559,7 @@ it does not replace the JS page
 [`/guards/claude-agent-sdk/`](https://docs.arcjet.com/guards/claude-agent-sdk/).
 
 ```py
-from arcjet.guard import DetectPromptInjection, launch_arcjet
+from arcjet.guard import DetectPromptInjection, TokenBucket, launch_arcjet
 from arcjet.guard.claude_agent_sdk import (
     claude_agent_context,
     guard_hooks,
@@ -1569,6 +1569,7 @@ from claude_agent_sdk import tool
 
 aj = launch_arcjet(key=arcjet_key)
 session_id = conversation_id  # a UUID the app already minted
+mcp_limit = TokenBucket(refill_rate=20, interval_seconds=60, max_tokens=20)
 
 
 @tool("send_email", "Send an email", {"to": str, "body": str})
@@ -1588,6 +1589,7 @@ hooks = guard_hooks(
     guard=aj,
     session_id=session_id,
     action=lambda hook: f"{hook['tool_name']}.invoked",
+    rules=lambda call: [mcp_limit(key=call["tool_name"], requested=1)],
     exclude=[{"server": "mail", "name": "send_email"}],
     inbound={
         "action": "message.received",
@@ -1619,15 +1621,21 @@ rules on `guard_hooks(..., inbound=...)`. A deny is `{"decision": "block"}`.
 #### Deny unwrapped tools on `PreToolUse`
 
 Built-ins (Bash, Write, …) and MCP tools not passed through `guard_tool`
-are gated here. `PreToolUse` returns `permissionDecision: "deny"`. List
-every `guard_tool` wrapper in `exclude` as `{"server": ..., "name": ...}`
-so the reported `mcp__{server}__{name}` name is not double-gated. A bare
-authored name does not match every server's tool of that name.
+are gated here. `PreToolUse` returns `permissionDecision: "deny"`.
+`rules` / `actor` / `inputs` / `metadata` callables receive `tool_input`
+plus `tool_name` so a local rate limit can key on the name. List every
+`guard_tool` wrapper in `exclude` as `{"server": ..., "name": ...}` so the
+reported `mcp__{server}__{name}` name is not double-gated. A bare authored
+name does not match every server's tool of that name. `PostToolUse` is
+capture-only (`claude.phase: after`) and is not skipped by `exclude`.
+`actor=` / `inputs=` next to `inbound=` do not install a tool gate; pass
+`tools=True` for the default `{tool_name}.invoked` gate with empty rules.
 
 `claude_agent_context` reads hook `session_id` first, then the
 caller-owned `session_id=` fallback, then `arcjet_sequence()`. It never
-mints. It never reads `trace_id`. The value must be a UUID the app already
-minted if you also pass it to `query()`.
+mints. It never reads `trace_id`. Wrap-time `session_id=` /
+`correlation_id=` (including `inbound["session_id"]`) must be a UUID the
+app already minted — the same value you pass to `query()`.
 
 ### Sync usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,16 @@ langchain-agents = [
 # on_invoke_tool. Verified on 0.22.0. No chromadb — unlike CrewAI this extra
 # is safe to declare.
 openai-agents = ["openai-agents>=0.19.0,<1"]
+# Authored @tool / SdkMcpTool wrap plus PreToolUse / UserPromptSubmit hooks.
+# Separate extra so installing `arcjet` never pulls the Claude Agent SDK;
+# `arcjet.guard.claude_agent_sdk` imports `claude_agent_sdk` lazily. The
+# floor is 0.2.127 (0.2.83 was the mcp CVE + timeout fail-close line;
+# 0.2.127 includes that and the background-task PreToolUse stdin fix, so
+# this adapter does not have to caveat that path). Verified on 0.2.148.
+# No chromadb — unlike CrewAI this extra is safe to declare. Like
+# openai-agents it is in no dependency group so the lockfile does not
+# pull its transitive tree into every `uv sync`.
+claude-agent-sdk = ["claude-agent-sdk>=0.2.127,<1"]
 # There is deliberately no `crewai` extra, and CrewAI is in no dependency
 # group. `crewai` hard-depends on `chromadb~=1.1.0`, and every chromadb from
 # 1.0.0 to 1.5.9 carries an unpatched critical RCE (CVE-2026-45829 /
@@ -186,6 +196,8 @@ exclude = [
   # Optional extra; openai-agents is not in the default install.
   "tests/integration/guard/test_openai_agents.py",
   "tests/integration/guard/test_openai_agents_runner.py",
+  # Optional extra; claude-agent-sdk is not in the default install.
+  "tests/integration/guard/test_claude_agent_sdk.py",
 ]
 include = ["src", "tests"]
 pythonVersion = "3.10"
@@ -212,4 +224,6 @@ exclude = [
   # Optional extra; openai-agents is not in the default install.
   "tests/integration/guard/test_openai_agents.py",
   "tests/integration/guard/test_openai_agents_runner.py",
+  # Optional extra; claude-agent-sdk is not in the default install.
+  "tests/integration/guard/test_claude_agent_sdk.py",
 ]

--- a/src/arcjet/guard/claude_agent_sdk/__init__.py
+++ b/src/arcjet/guard/claude_agent_sdk/__init__.py
@@ -1,0 +1,46 @@
+"""Optional Claude Agent SDK tool-call and inbound integration.
+
+Install ``arcjet[claude-agent-sdk]`` to use this module. Core Guard clients
+do not import the Claude Agent SDK, and this package does not import
+:mod:`arcjet.guard.langchain`, :mod:`arcjet.guard.crewai`, or
+:mod:`arcjet.guard.openai_agents`.
+
+Three names:
+
+* :func:`guard_tool` — wrap an authored ``@tool`` / ``SdkMcpTool`` so the
+  handler never runs on DENY. The deny is an MCP tool result
+  ``{"content": [{"type": "text", "text": <json>}], "is_error": True}``.
+  Do not throw (the SDK swallows into ``str(e)``). Do not set
+  ``structuredContent`` (``create_sdk_mcp_server`` drops it).
+* :func:`guard_hooks` — ``PreToolUse`` ``permissionDecision: "deny"`` for
+  unwrapped built-ins / MCP, and ``UserPromptSubmit`` ``{"decision":
+  "block"}`` when ``inbound=`` is set. List ``guard_tool`` wrappers in
+  ``exclude`` as ``{"server": ..., "name": ...}`` so they are not
+  double-gated under the ``mcp__{server}__{name}`` name.
+* :func:`claude_agent_context` — read a caller-owned ``session_id`` from
+  hook input or a policy fallback. Never mints. Never reads ``trace_id``.
+  An authored handler has no ``extra.session_id`` — use
+  ``session_id=`` on the wrap.
+
+There is no ``guard_inbound`` helper and no ``guard_can_use_tool``.
+``can_use_tool`` is ask-only HITL, not a policy gate.
+``permissionDecision: "ask"`` is HITL, not deny.
+
+``protect()`` / the request path is fail-open — check
+:meth:`~arcjet.guard.Decision.has_failed_open`. These helpers are
+fail-closed (default ``on_guard_error="deny"``).
+
+See https://docs.arcjet.com/guards/claude-agent-sdk-py/
+"""
+
+from __future__ import annotations
+
+from ._context import claude_agent_context
+from ._hooks import guard_hooks
+from ._tool import guard_tool
+
+__all__ = [
+    "guard_tool",
+    "guard_hooks",
+    "claude_agent_context",
+]

--- a/src/arcjet/guard/claude_agent_sdk/__init__.py
+++ b/src/arcjet/guard/claude_agent_sdk/__init__.py
@@ -13,10 +13,14 @@ Three names:
   Do not throw (the SDK swallows into ``str(e)``). Do not set
   ``structuredContent`` (``create_sdk_mcp_server`` drops it).
 * :func:`guard_hooks` — ``PreToolUse`` ``permissionDecision: "deny"`` for
-  unwrapped built-ins / MCP, and ``UserPromptSubmit`` ``{"decision":
+  unwrapped built-ins / MCP, ``PostToolUse`` capture-only
+  (``claude.phase: after``), and ``UserPromptSubmit`` ``{"decision":
   "block"}`` when ``inbound=`` is set. List ``guard_tool`` wrappers in
   ``exclude`` as ``{"server": ..., "name": ...}`` so they are not
-  double-gated under the ``mcp__{server}__{name}`` name.
+  double-gated under the ``mcp__{server}__{name}`` name. ``exclude``
+  does not skip PostToolUse. ``actor=`` / ``inputs=`` do not register
+  a tool hook by themselves; pass ``tools=True`` for the default
+  ``"{tool_name}.invoked"`` gate.
 * :func:`claude_agent_context` — read a caller-owned ``session_id`` from
   hook input or a policy fallback. Never mints. Never reads ``trace_id``.
   An authored handler has no ``extra.session_id`` — use

--- a/src/arcjet/guard/claude_agent_sdk/_context.py
+++ b/src/arcjet/guard/claude_agent_sdk/_context.py
@@ -1,0 +1,163 @@
+"""Caller-owned correlation for a Claude Agent SDK run.
+
+Hook input carries ``session_id``. ``ClaudeAgentOptions.session_id`` must be
+a UUID the application already minted — the CLI exits on anything else, and
+reusing a session id on a second ``query()`` exits with "already in use".
+This helper reads that id. It never mints. It never reads ``trace_id``.
+It never constructs a session just to ask it for an id.
+
+An authored ``SdkMcpTool.handler`` has no ``extra.session_id``. Pass the
+same caller-owned UUID as ``session_id=`` on :func:`guard_tool` /
+:func:`guard_hooks`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from arcjet._logging import logger
+from arcjet._metadata import Metadata
+
+from .._context import _validated, current_correlation_id
+
+#: Never read as correlation. The SDK / CLI can mint a session when one is
+#: omitted; joining a Sequence on a generated id is one nobody can look up.
+_NEVER_READ = frozenset({"trace_id", "traceId"})
+
+
+@dataclass(frozen=True, slots=True)
+class ClaudeAgentContext:
+    """What :func:`claude_agent_context` derived.
+
+    ``correlation_id`` is ``None`` when nothing valid was present — this
+    helper never mints one.
+    """
+
+    correlation_id: Optional[str] = None
+    metadata: Optional[Metadata] = None
+
+
+def _readable(value: Any) -> Any:
+    """*value* if named fields can be read off it, else ``None``."""
+    if value is None or isinstance(
+        value, (str, bytes, bytearray, list, tuple, set, frozenset)
+    ):
+        return None
+    return value
+
+
+def _read(source: Any, name: str) -> Any:
+    """*name* off a mapping or an object, whichever *source* is."""
+    if source is None or name in _NEVER_READ:
+        return None
+    if isinstance(source, Mapping):
+        return source.get(name)
+    return getattr(source, name, None)
+
+
+def _valid_session_id(value: Any) -> Optional[str]:
+    """A caller-owned UUID the CLI will accept as ``session_id``.
+
+    Anything else is skipped, not minted. A non-UUID that happens to be
+    printable ASCII would still fail ``query({options.session_id})``, so it
+    is not used as a Sequence id either.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        _validated(value)
+    except (TypeError, ValueError):
+        return None
+    try:
+        uuid.UUID(value)
+    except ValueError:
+        return None
+    return value
+
+
+def claude_agent_context(
+    source: Any = None,
+    *,
+    session_id: Optional[str] = None,
+    metadata: Optional[Metadata] = None,
+) -> ClaudeAgentContext:
+    """Read a caller-owned session UUID from a Claude Agent SDK hook.
+
+    Preference order:
+
+    1. ``session_id`` on hook input (or a mapping / object that looks like
+       one)
+    2. ``session_id=`` passed here — the policy fallback an authored
+       handler needs, because it has no ``extra.session_id``
+    3. The enclosing :func:`~arcjet.guard.arcjet_sequence`, if any
+
+    ``trace_id`` is never read. A non-UUID or otherwise invalid candidate
+    is skipped. If nothing valid remains, ``correlation_id`` is ``None``
+    and the decision is uncorrelated rather than joined to a generated id
+    nobody has.
+
+    Subagent ``agent_id`` is recorded as ``claude.agent`` metadata only.
+
+    Args:
+        source: A hook input mapping (``session_id``, optional
+            ``agent_id`` / ``tool_name``), or ``None``.
+        session_id: Caller-owned UUID fallback, used only if *source*
+            carries nothing valid.
+        metadata: Merged over the session / tool / agent metadata derived
+            from *source*.
+
+    Returns:
+        The correlation id and metadata to pass to ``guard()``.
+    """
+    envelope = _readable(source)
+
+    candidates: list[tuple[Any, str]] = []
+    hook_session = _read(envelope, "session_id")
+    if hook_session is None:
+        hook_session = _read(envelope, "sessionId")
+    if hook_session is not None:
+        candidates.append((hook_session, "session_id"))
+    if session_id is not None:
+        candidates.append((session_id, "session_id"))
+
+    resolved: Optional[str] = None
+    rejected: Optional[str] = None
+    for value, label in candidates:
+        valid = _valid_session_id(value)
+        if valid is not None:
+            resolved = valid
+            break
+        if isinstance(value, str):
+            rejected = label
+
+    if resolved is None:
+        resolved = current_correlation_id()
+
+    if rejected is not None and resolved is None:
+        logger.warning(
+            "arcjet: Claude Agent SDK %s rejected; no valid caller-owned "
+            "UUID session_id, leaving the call uncorrelated",
+            rejected,
+        )
+
+    derived: dict[str, Any] = {}
+    session = _valid_session_id(hook_session) or _valid_session_id(session_id)
+    if session is not None:
+        derived["claude.session"] = session
+    tool_name = _read(envelope, "tool_name")
+    if isinstance(tool_name, str) and tool_name:
+        derived["claude.tool"] = tool_name
+    agent_id = _read(envelope, "agent_id")
+    if agent_id is None:
+        agent_id = _read(envelope, "agentId")
+    if isinstance(agent_id, str) and agent_id:
+        derived["claude.agent"] = agent_id
+
+    merged: dict[str, Any] = {**derived}
+    if metadata:
+        merged.update(metadata)
+
+    return ClaudeAgentContext(correlation_id=resolved, metadata=merged or None)

--- a/src/arcjet/guard/claude_agent_sdk/_context.py
+++ b/src/arcjet/guard/claude_agent_sdk/_context.py
@@ -61,21 +61,38 @@ def _read(source: Any, name: str) -> Any:
 def _valid_session_id(value: Any) -> Optional[str]:
     """A caller-owned UUID the CLI will accept as ``session_id``.
 
-    Anything else is skipped, not minted. A non-UUID that happens to be
-    printable ASCII would still fail ``query({options.session_id})``, so it
-    is not used as a Sequence id either.
+    Anything else is skipped, not minted. Used when reading hook input,
+    which may carry garbage; wrap-time arguments use
+    :func:`_require_session_id` so a non-UUID is refused instead of
+    accepted and then dropped here.
     """
     if not isinstance(value, str):
         return None
     try:
-        _validated(value)
+        return _require_session_id(value)
     except (TypeError, ValueError):
         return None
+
+
+def _require_session_id(value: str) -> str:
+    """Raise unless *value* is a caller-owned UUID the CLI will accept.
+
+    Wrap-time counterpart of :func:`_valid_session_id`. ``_validated``
+    accepts any printable-ASCII Sequence id; the Claude CLI additionally
+    requires a UUID for ``ClaudeAgentOptions.session_id``. Refusing here
+    keeps ``guard_tool(..., correlation_id="run-abc")`` from succeeding
+    and then leaving the call uncorrelated.
+    """
+    validated = _validated(value)
     try:
-        uuid.UUID(value)
-    except ValueError:
-        return None
-    return value
+        uuid.UUID(validated)
+    except ValueError as exc:
+        raise ValueError(
+            "session_id must be a UUID the Claude Agent SDK will accept "
+            "(the same value you pass to ClaudeAgentOptions.session_id); "
+            f"got {value!r}"
+        ) from exc
+    return validated
 
 
 def claude_agent_context(

--- a/src/arcjet/guard/claude_agent_sdk/_denial.py
+++ b/src/arcjet/guard/claude_agent_sdk/_denial.py
@@ -115,14 +115,14 @@ def dumps_denial(payload: ArcjetDenialResult) -> str:
     return json.dumps(payload, separators=(",", ":"))
 
 
-def payload_from_block(
-    _action: str, decision: Optional[Decision]
-) -> ArcjetDenialResult:
-    """DENY uses the decision; everything else is an unavailability envelope."""
+def payload_from_block(decision: Optional[Decision]) -> ArcjetDenialResult:
+    """DENY uses the decision; everything else is an unavailability envelope.
+
+    Action is kept on the capture, not in this envelope: the model-facing
+    shape is shared with JS and has no action field.
+    """
     if decision is not None and getattr(decision, "conclusion", None) == "DENY":
         return denial_result(decision)
-    # *_action* is kept on the capture, not in this envelope: the model-facing
-    # shape is shared with JS and has no action field.
     return unavailable_result()
 
 

--- a/src/arcjet/guard/claude_agent_sdk/_denial.py
+++ b/src/arcjet/guard/claude_agent_sdk/_denial.py
@@ -1,0 +1,138 @@
+"""Model-visible denial payload for a Claude Agent SDK tool result.
+
+LangChain and CrewAI raise typed errors from their checkpoints. The Claude
+Agent SDK cannot: an exception from an authored ``SdkMcpTool.handler`` is
+swallowed into ``str(e)``. The honest deny is a returned MCP tool result
+with ``is_error: True``. ``create_sdk_mcp_server`` copies only ``content``
+and ``is_error`` — it drops ``structuredContent`` — so the JSON envelope
+lives in a text content block.
+
+The envelope is the one every JS adapter already uses. Python has no second
+shape for a model-facing tool result — do not invent one.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from typing import Any, Optional, TypedDict
+
+from .._types import Decision
+
+UNAVAILABLE_RETRY_AFTER_SECONDS: int = 5
+
+
+class _ArcjetDenialRequired(TypedDict):
+    """Required fields of the model-visible denial envelope."""
+
+    arcjetDenied: bool
+    reason: str
+    message: str
+    retryable: bool
+
+
+class ArcjetDenialResult(_ArcjetDenialRequired, total=False):
+    """JSON object the model reads from the tool-result text block.
+
+    Keys stay camelCase so a model (and a shared Sequence reader) sees the
+    same envelope the JS adapters already emit.
+    """
+
+    retryAfterSeconds: int
+
+
+def retry_after_seconds(decision: Decision) -> Optional[int]:
+    """Seconds until a rate-limited call may be retried.
+
+    Only meaningful for a ``RATE_LIMIT`` denial. A co-occurring rule that
+    allowed can still leave a ``reset_at_unix_seconds`` in ``decision.results``;
+    ignore it when the denying reason is not a rate limit — same rule as JS
+    ``denial.ts``.
+    """
+    if decision.reason != "RATE_LIMIT":
+        return None
+    now = time.time()
+    found: Optional[int] = None
+    for result in decision.results:
+        if getattr(result, "conclusion", None) != "DENY":
+            continue
+        if getattr(result, "reason", None) != "RATE_LIMIT":
+            continue
+        reset = getattr(result, "reset_at_unix_seconds", None)
+        if isinstance(reset, int) and reset > 0:
+            seconds = max(0, math.ceil(reset - now))
+            if found is None or seconds < found:
+                found = seconds
+    return found
+
+
+def denied_message(decision: Decision) -> str:
+    """Human- and model-readable explanation of a real DENY."""
+    if decision.reason == "RATE_LIMIT":
+        retry_after = retry_after_seconds(decision)
+        suffix = " later." if retry_after is None else f" after {retry_after} seconds."
+        return f"Arcjet denied this call ({decision.reason}). It may be retried{suffix}"
+    return (
+        f"Arcjet denied this call ({decision.reason}). Do not retry; explain "
+        f"the denial to the user or try a different approach."
+    )
+
+
+def unavailable_message() -> str:
+    return "Arcjet security check could not be completed; please retry later."
+
+
+def denial_result(decision: Decision) -> ArcjetDenialResult:
+    """Structured payload for an evaluated DENY."""
+    is_rate_limit = decision.reason == "RATE_LIMIT"
+    payload: ArcjetDenialResult = {
+        "arcjetDenied": True,
+        "reason": decision.reason,
+        "message": denied_message(decision),
+        "retryable": is_rate_limit,
+    }
+    if is_rate_limit:
+        retry_after = retry_after_seconds(decision)
+        if retry_after is not None:
+            payload["retryAfterSeconds"] = retry_after
+    return payload
+
+
+def unavailable_result() -> ArcjetDenialResult:
+    """Structured payload when policy could not be evaluated and we fail closed."""
+    return {
+        "arcjetDenied": True,
+        "reason": "ERROR",
+        "message": unavailable_message(),
+        "retryable": True,
+        "retryAfterSeconds": UNAVAILABLE_RETRY_AFTER_SECONDS,
+    }
+
+
+def dumps_denial(payload: ArcjetDenialResult) -> str:
+    """JSON the model receives in a tool-result text block."""
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def payload_from_block(
+    _action: str, decision: Optional[Decision]
+) -> ArcjetDenialResult:
+    """DENY uses the decision; everything else is an unavailability envelope."""
+    if decision is not None and getattr(decision, "conclusion", None) == "DENY":
+        return denial_result(decision)
+    # *_action* is kept on the capture, not in this envelope: the model-facing
+    # shape is shared with JS and has no action field.
+    return unavailable_result()
+
+
+def denial_tool_result(payload: ArcjetDenialResult) -> dict[str, Any]:
+    """MCP tool result ``create_sdk_mcp_server`` actually forwards.
+
+    ``content`` + ``is_error`` only. ``structuredContent`` is omitted on
+    purpose: the helper copies those two keys and drops the rest.
+    """
+    return {
+        "content": [{"type": "text", "text": dumps_denial(payload)}],
+        "is_error": True,
+    }

--- a/src/arcjet/guard/claude_agent_sdk/_hooks.py
+++ b/src/arcjet/guard/claude_agent_sdk/_hooks.py
@@ -1,0 +1,627 @@
+"""Claude Agent SDK ``PreToolUse`` / ``UserPromptSubmit`` hooks.
+
+Unwrapped built-ins and MCP tools have no authored handler to wrap.
+``PreToolUse`` with ``permissionDecision: "deny"`` is the only deny that
+still runs under ``allowed_tools`` / ``bypassPermissions``.
+``permissionDecision: "ask"`` is HITL, not deny, and is never returned.
+
+Inbound text is screened on ``UserPromptSubmit`` via ``inbound=``. There
+is no ``guard_inbound`` helper. A deny is ``{"decision": "block"}``.
+
+``can_use_tool`` is not a policy gate and is not wrapped.
+
+``PreToolUse`` fires for every tool and the input carries only a name,
+never the brand :func:`guard_tool` applies. List wrapped tools in
+``exclude`` as ``{"server": ..., "name": ...}`` so they match
+``mcp__{server}__{name}`` exactly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Optional, Union, cast
+
+from arcjet._errors import ArcjetMisconfiguration
+from arcjet._logging import logger
+from arcjet._metadata import Metadata
+
+from .._checkpoint import (
+    ResolvedInputs,
+    _classify_decision,
+    _emit_capture,
+    _guard_async,
+    _guard_sync,
+    _outcome_for_completed_action,
+    _resolve_correlation_id,
+)
+from .._context import _validated
+from .._errors import ArcjetDeniedError, ArcjetUnavailableError, OnGuardError
+from .._policy_input import PolicyInputMap
+from .._registry import _awaitable
+from .._rules import RuleWithInput
+from ._context import claude_agent_context
+from ._denial import payload_from_block, unavailable_message
+from ._import import load_hook_matcher
+from ._names import ExcludeEntry, as_exclude_entry, excluded_names, is_excluded
+
+ActionResolver = Union[str, Callable[[Mapping[str, Any]], str], None]
+ActorResolver = Union[str, Callable[[Mapping[str, Any]], Optional[str]], None]
+InputResolver = Union[
+    PolicyInputMap,
+    Callable[[Mapping[str, Any]], Optional[PolicyInputMap]],
+    None,
+]
+RulesResolver = Union[
+    Sequence[RuleWithInput],
+    Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+]
+MetadataResolver = Union[
+    Metadata, Callable[[Mapping[str, Any]], Optional[Metadata]], None
+]
+
+
+@dataclass(frozen=True, slots=True)
+class _HookConfig:
+    guard: Any
+    action: ActionResolver
+    actor: ActorResolver
+    inputs: InputResolver
+    rules: RulesResolver
+    metadata: MetadataResolver
+    session_id: Optional[str]
+    on_guard_error: OnGuardError
+    exclude: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class _InboundConfig:
+    guard: Any
+    action: str
+    actor: ActorResolver
+    inputs: InputResolver
+    rules: RulesResolver
+    metadata: MetadataResolver
+    session_id: Optional[str]
+    on_guard_error: OnGuardError
+
+
+@dataclass(frozen=True, slots=True)
+class PreToolUseVerdict:
+    """What PreToolUse should tell the SDK. Unit tests call this without
+    constructing a real ``HookMatcher``.
+    """
+
+    deny: bool
+    reason: Optional[str] = None
+
+
+@dataclass(frozen=True, slots=True)
+class UserPromptSubmitVerdict:
+    """What UserPromptSubmit should tell the SDK."""
+
+    block: bool
+    reason: Optional[str] = None
+
+
+def _hook_mapping(source: Any) -> Mapping[str, Any]:
+    if isinstance(source, Mapping):
+        return source
+    return {}
+
+
+def _tool_name(source: Mapping[str, Any]) -> str:
+    name = source.get("tool_name")
+    return name if isinstance(name, str) else ""
+
+
+def _tool_arguments(source: Mapping[str, Any]) -> Mapping[str, Any]:
+    raw = source.get("tool_input")
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _prompt(source: Mapping[str, Any]) -> str:
+    raw = source.get("prompt")
+    return raw if isinstance(raw, str) else ""
+
+
+def _resolve(source: Any, arguments: Mapping[str, Any]) -> Any:
+    if source is None or not callable(source):
+        return source
+    return source(arguments)
+
+
+def _prepared(
+    actor: ActorResolver,
+    inputs: InputResolver,
+    arguments: Mapping[str, Any],
+) -> ResolvedInputs:
+    degraded: Optional[BaseException] = None
+    resolved_actor: Optional[str] = None
+    resolved_inputs: Optional[PolicyInputMap] = None
+    try:
+        resolved_actor = _resolve(actor, arguments)
+    except Exception as exc:
+        degraded = exc
+    try:
+        resolved_inputs = _resolve(inputs, arguments)
+    except Exception as exc:
+        degraded = degraded or exc
+    return ResolvedInputs(
+        actor=resolved_actor, inputs=resolved_inputs, degraded=degraded
+    )
+
+
+def _resolved_rules(
+    rules: RulesResolver, arguments: Mapping[str, Any]
+) -> Sequence[RuleWithInput]:
+    if not callable(rules):
+        return rules
+    return cast(
+        Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+        rules,
+    )(arguments)
+
+
+def _resolved_metadata(
+    metadata: MetadataResolver, arguments: Mapping[str, Any]
+) -> Optional[Metadata]:
+    if callable(metadata):
+        return cast(
+            Callable[[Mapping[str, Any]], Optional[Metadata]],
+            metadata,
+        )(arguments)
+    return metadata
+
+
+def _correlation(session_id: Optional[str], source: Mapping[str, Any]) -> Optional[str]:
+    derived = claude_agent_context(source, session_id=session_id)
+    return _resolve_correlation_id(derived.correlation_id)
+
+
+def _merged_metadata(
+    session_id: Optional[str],
+    source: Mapping[str, Any],
+    extra: Optional[Metadata],
+) -> Optional[Metadata]:
+    derived = claude_agent_context(source, session_id=session_id)
+    merged: dict[str, Any] = {}
+    if derived.metadata:
+        merged.update(derived.metadata)
+    if extra:
+        merged.update(extra)
+    return merged or None
+
+
+def _unavailable(action: str, cause: Optional[BaseException]) -> BaseException:
+    return ArcjetUnavailableError(action, cause=cause)
+
+
+async def _decide(
+    guard: Any,
+    *,
+    action: str,
+    correlation_id: Optional[str],
+    metadata: Optional[Metadata],
+    prepared: ResolvedInputs,
+    rules: Sequence[RuleWithInput],
+) -> Any:
+    kwargs = {
+        "rules": rules,
+        "label": action,
+        "metadata": metadata,
+        "correlation_id": correlation_id,
+        "actor": prepared.actor,
+        "inputs": prepared.inputs,
+    }
+    if _awaitable(guard, "guard") is not None or guard is None:
+        return await _guard_async(guard, **kwargs)
+    return await asyncio.to_thread(partial(_guard_sync, guard, **kwargs))
+
+
+def _resolve_tool_action(config: _HookConfig, source: Mapping[str, Any]) -> str:
+    action = config.action
+    if action is None:
+        name = _tool_name(source) or "tool"
+        return f"{name}.invoked"
+    if callable(action):
+        return cast(Callable[[Mapping[str, Any]], str], action)(source)
+    return action
+
+
+async def evaluate_pre_tool_use(source: Any, config: _HookConfig) -> PreToolUseVerdict:
+    """Evaluate PreToolUse policy. Never raises an Arcjet error.
+
+    A raise would leave the hook; depending on the SDK version that can
+    fail-open or stringify. ``permissionDecision: "deny"`` is the only
+    deny. ``"ask"`` is never returned.
+    """
+    hook = _hook_mapping(source)
+    name = _tool_name(hook)
+    if is_excluded(name, config.exclude):
+        return PreToolUseVerdict(deny=False)
+
+    action = f"{name or 'tool'}.invoked"
+    correlation_id = _resolve_correlation_id(None)
+    metadata: Optional[Metadata] = None
+
+    try:
+        action = _resolve_tool_action(config, hook)
+        arguments = _tool_arguments(hook)
+        correlation_id = _correlation(config.session_id, hook)
+        extra = _resolved_metadata(config.metadata, arguments)
+        metadata = _merged_metadata(config.session_id, hook, extra)
+        prepared = _prepared(config.actor, config.inputs, arguments)
+        rules = _resolved_rules(config.rules, arguments)
+        decision = await _decide(
+            config.guard,
+            action=action,
+            correlation_id=correlation_id,
+            metadata=metadata,
+            prepared=prepared,
+            rules=rules,
+        )
+        failure = _classify_decision(
+            decision,
+            action=action,
+            on_guard_error=config.on_guard_error,
+            denied_error=ArcjetDeniedError,
+            unavailable_error=_unavailable,
+            degraded=prepared.degraded,
+        )
+    except Exception:
+        if config.on_guard_error == "allow":
+            logger.warning(
+                "arcjet: policy for action %r could not be evaluated; proceeding "
+                "because on_guard_error is 'allow'",
+                action,
+            )
+            return PreToolUseVerdict(deny=False)
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="unavailable",
+            correlation_id=correlation_id,
+            decision=None,
+            metadata=metadata,
+        )
+        return PreToolUseVerdict(deny=True, reason=unavailable_message())
+
+    if failure is not None:
+        denied = getattr(decision, "conclusion", None) == "DENY"
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="denied" if denied else "unavailable",
+            correlation_id=correlation_id,
+            decision=decision,
+            metadata=metadata,
+        )
+        payload = payload_from_block(action, decision)
+        return PreToolUseVerdict(deny=True, reason=payload["message"])
+
+    _emit_capture(
+        client=config.guard,
+        action=action,
+        outcome=_outcome_for_completed_action(decision, degraded=prepared.degraded),
+        correlation_id=correlation_id,
+        decision=decision,
+        metadata=metadata,
+    )
+    return PreToolUseVerdict(deny=False)
+
+
+async def evaluate_user_prompt_submit(
+    source: Any, config: _InboundConfig
+) -> UserPromptSubmitVerdict:
+    """Evaluate UserPromptSubmit policy. Never raises an Arcjet error.
+
+    A deny is ``{"decision": "block"}``. There is no ``guard_inbound``
+    helper — this is the inbound path.
+    """
+    hook = _hook_mapping(source)
+    action = config.action
+    correlation_id = _resolve_correlation_id(None)
+    metadata: Optional[Metadata] = None
+    arguments: Mapping[str, Any] = {"prompt": _prompt(hook)}
+
+    try:
+        correlation_id = _correlation(config.session_id, hook)
+        extra = _resolved_metadata(config.metadata, arguments)
+        metadata = _merged_metadata(config.session_id, hook, extra)
+        prepared = _prepared(config.actor, config.inputs, arguments)
+        rules = _resolved_rules(config.rules, arguments)
+        decision = await _decide(
+            config.guard,
+            action=action,
+            correlation_id=correlation_id,
+            metadata=metadata,
+            prepared=prepared,
+            rules=rules,
+        )
+        failure = _classify_decision(
+            decision,
+            action=action,
+            on_guard_error=config.on_guard_error,
+            denied_error=ArcjetDeniedError,
+            unavailable_error=_unavailable,
+            degraded=prepared.degraded,
+        )
+    except Exception:
+        if config.on_guard_error == "allow":
+            logger.warning(
+                "arcjet: policy for action %r could not be evaluated; proceeding "
+                "because on_guard_error is 'allow'",
+                action,
+            )
+            return UserPromptSubmitVerdict(block=False)
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="unavailable",
+            correlation_id=correlation_id,
+            decision=None,
+            metadata=metadata,
+        )
+        return UserPromptSubmitVerdict(block=True, reason=unavailable_message())
+
+    if failure is not None:
+        denied = getattr(decision, "conclusion", None) == "DENY"
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="denied" if denied else "unavailable",
+            correlation_id=correlation_id,
+            decision=decision,
+            metadata=metadata,
+        )
+        payload = payload_from_block(action, decision)
+        return UserPromptSubmitVerdict(block=True, reason=payload["message"])
+
+    _emit_capture(
+        client=config.guard,
+        action=action,
+        outcome=_outcome_for_completed_action(decision, degraded=prepared.degraded),
+        correlation_id=correlation_id,
+        decision=decision,
+        metadata=metadata,
+    )
+    return UserPromptSubmitVerdict(block=False)
+
+
+def pre_tool_use_output(verdict: PreToolUseVerdict) -> dict[str, Any]:
+    """SDK ``HookJSONOutput`` for a PreToolUse deny or allow."""
+    if not verdict.deny:
+        return {}
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": verdict.reason or unavailable_message(),
+        }
+    }
+
+
+def user_prompt_submit_output(verdict: UserPromptSubmitVerdict) -> dict[str, Any]:
+    """SDK ``HookJSONOutput`` for a UserPromptSubmit block or allow."""
+    if not verdict.block:
+        return {}
+    return {
+        "decision": "block",
+        "reason": verdict.reason or unavailable_message(),
+    }
+
+
+def _inbound_config(
+    *,
+    guard: Any,
+    session_id: Optional[str],
+    on_guard_error: OnGuardError,
+    inbound: Mapping[str, Any],
+) -> _InboundConfig:
+    action = inbound.get("action")
+    if not isinstance(action, str) or not action:
+        raise ArcjetMisconfiguration(
+            "guard_hooks(inbound=...) needs a non-empty action string "
+            "(there is no guard_inbound helper; UserPromptSubmit is this path)"
+        )
+    inbound_error = inbound.get("on_guard_error", on_guard_error)
+    if inbound_error not in ("allow", "deny"):
+        raise ArcjetMisconfiguration(
+            f"on_guard_error must be 'allow' or 'deny', got {inbound_error!r}. "
+            f"It decides whether a call runs when policy could not be "
+            f"evaluated, so there is no safe value to guess."
+        )
+    return _InboundConfig(
+        guard=inbound.get("guard", guard),
+        action=action,
+        actor=inbound.get("actor"),
+        inputs=inbound.get("inputs"),
+        rules=inbound.get("rules", ()),
+        metadata=inbound.get("metadata"),
+        session_id=inbound.get("session_id", session_id),
+        on_guard_error=inbound_error,
+    )
+
+
+def _tool_hooks_requested(
+    *,
+    action: ActionResolver,
+    rules: RulesResolver,
+    actor: ActorResolver,
+    inputs: InputResolver,
+    exclude: Sequence[ExcludeEntry] | None,
+) -> bool:
+    if action is not None:
+        return True
+    if callable(rules) or (isinstance(rules, Sequence) and len(rules) > 0):
+        return True
+    if actor is not None or inputs is not None:
+        return True
+    return bool(exclude)
+
+
+def guard_hooks(
+    *,
+    guard: Any,
+    action: ActionResolver = None,
+    actor: ActorResolver = None,
+    inputs: InputResolver = None,
+    rules: RulesResolver = (),
+    metadata: MetadataResolver = None,
+    session_id: Optional[str] = None,
+    correlation_id: Optional[str] = None,
+    on_guard_error: OnGuardError = "deny",
+    exclude: Sequence[ExcludeEntry] | None = None,
+    inbound: Optional[Mapping[str, Any]] = None,
+) -> dict[str, list[Any]]:
+    """Build Claude Agent SDK hooks that fail closed.
+
+    Returns a ``dict[HookEvent, list[HookMatcher]]`` for
+    ``ClaudeAgentOptions.hooks``.
+
+    * ``PreToolUse`` — deny unwrapped built-ins / MCP with
+      ``permissionDecision: "deny"``. Tools already wrapped by
+      :func:`~arcjet.guard.claude_agent_sdk.guard_tool` must be listed in
+      *exclude* as ``{"server": ..., "name": ...}`` (qualified to
+      ``mcp__{server}__{name}``) or as the exact reported name. A bare
+      authored name does not match every server.
+    * ``UserPromptSubmit`` — when *inbound* is set, ``{"decision":
+      "block"}`` is the inbound path. There is no ``guard_inbound``.
+
+    ``can_use_tool`` is not wrapped. ``permissionDecision: "ask"`` is
+    never returned.
+
+    Args:
+        guard: The Arcjet client. An async client is preferred; a blocking
+            client is accepted.
+        action: Checkpoint label, or a callable of the hook input. Defaults
+            to ``"{tool_name}.invoked"`` when a tool hook is registered.
+        actor: Who is acting, or a callable of the tool arguments (or
+            ``{"prompt": ...}`` on inbound).
+        inputs: Policy inputs, or a callable of those arguments.
+        rules: Local rules, or a callable of those arguments. Empty still
+            contacts Guard.
+        metadata: Capture metadata, or a callable of those arguments.
+        session_id: Caller-owned UUID fallback. Hook ``session_id`` is
+            preferred. Never minted.
+        correlation_id: Alias of *session_id*. Ignored when *session_id*
+            is set.
+        on_guard_error: ``"deny"`` (default) or ``"allow"``.
+        exclude: Tools already wrapped by ``guard_tool``.
+        inbound: UserPromptSubmit policy. Requires ``action``. Optional
+            ``rules``, ``actor``, ``inputs``, ``metadata``,
+            ``on_guard_error``, ``session_id``.
+
+    Raises:
+        ArcjetMisconfiguration: *on_guard_error* is not ``"allow"`` or
+            ``"deny"``, *inbound* is missing ``action``, or neither a
+            tool hook nor inbound was requested.
+        ValueError: *session_id* / *correlation_id* is not printable
+            ASCII, or an exclude entry cannot be qualified.
+        ImportError: the ``claude-agent-sdk`` extra is not installed.
+    """
+    if on_guard_error not in ("allow", "deny"):
+        raise ArcjetMisconfiguration(
+            f"on_guard_error must be 'allow' or 'deny', got {on_guard_error!r}. "
+            f"It decides whether a call runs when policy could not be "
+            f"evaluated, so there is no safe value to guess."
+        )
+    owned = session_id if session_id is not None else correlation_id
+    if owned is not None:
+        _validated(owned)
+    if inbound is not None and not isinstance(inbound, Mapping):
+        raise TypeError(
+            "guard_hooks(inbound=...) is a mapping with at least action=; "
+            "there is no guard_inbound helper"
+        )
+
+    want_tools = _tool_hooks_requested(
+        action=action,
+        rules=rules,
+        actor=actor,
+        inputs=inputs,
+        exclude=exclude,
+    )
+    if not want_tools and inbound is None:
+        raise ArcjetMisconfiguration(
+            "guard_hooks() needs a tool policy (action= / rules=) and/or "
+            "inbound= for UserPromptSubmit. There is no guard_inbound "
+            "helper and no guard_can_use_tool."
+        )
+
+    inbound_config = (
+        _inbound_config(
+            guard=guard,
+            session_id=owned,
+            on_guard_error=on_guard_error,
+            inbound=inbound,
+        )
+        if inbound is not None
+        else None
+    )
+
+    hook_matcher = load_hook_matcher()
+    hooks: dict[str, list[Any]] = {}
+
+    if want_tools:
+        config = _HookConfig(
+            guard=guard,
+            action=action,
+            actor=actor,
+            inputs=inputs,
+            rules=rules,
+            metadata=metadata,
+            session_id=owned,
+            on_guard_error=on_guard_error,
+            exclude=excluded_names(
+                [as_exclude_entry(entry) for entry in (exclude or ())]
+            ),
+        )
+
+        async def pre_tool_use(
+            input_data: Any, _tool_use_id: Optional[str], _context: Any
+        ) -> dict[str, Any]:
+            try:
+                verdict = await evaluate_pre_tool_use(input_data, config)
+            except Exception:
+                if config.on_guard_error == "allow":
+                    logger.warning(
+                        "arcjet: the Claude Agent SDK PreToolUse hook failed; "
+                        "the tool proceeds because on_guard_error is 'allow'"
+                    )
+                    return {}
+                return pre_tool_use_output(
+                    PreToolUseVerdict(deny=True, reason=unavailable_message())
+                )
+            return pre_tool_use_output(verdict)
+
+        hooks["PreToolUse"] = [hook_matcher(matcher=None, hooks=[pre_tool_use])]
+
+    if inbound_config is not None:
+
+        async def user_prompt_submit(
+            input_data: Any, _tool_use_id: Optional[str], _context: Any
+        ) -> dict[str, Any]:
+            try:
+                verdict = await evaluate_user_prompt_submit(input_data, inbound_config)
+            except Exception:
+                if inbound_config.on_guard_error == "allow":
+                    logger.warning(
+                        "arcjet: the Claude Agent SDK UserPromptSubmit hook "
+                        "failed; the prompt proceeds because on_guard_error "
+                        "is 'allow'"
+                    )
+                    return {}
+                return user_prompt_submit_output(
+                    UserPromptSubmitVerdict(block=True, reason=unavailable_message())
+                )
+            return user_prompt_submit_output(verdict)
+
+        hooks["UserPromptSubmit"] = [
+            hook_matcher(matcher=None, hooks=[user_prompt_submit])
+        ]
+
+    return hooks

--- a/src/arcjet/guard/claude_agent_sdk/_hooks.py
+++ b/src/arcjet/guard/claude_agent_sdk/_hooks.py
@@ -465,7 +465,7 @@ def _tool_hooks_requested(
 
 def guard_hooks(
     *,
-    guard: Any,
+    guard: Any = None,
     action: ActionResolver = None,
     actor: ActorResolver = None,
     inputs: InputResolver = None,

--- a/src/arcjet/guard/claude_agent_sdk/_hooks.py
+++ b/src/arcjet/guard/claude_agent_sdk/_hooks.py
@@ -318,7 +318,7 @@ async def evaluate_pre_tool_use(source: Any, config: _HookConfig) -> PreToolUseV
             decision=decision,
             metadata=metadata,
         )
-        payload = payload_from_block(action, decision)
+        payload = payload_from_block(decision)
         return PreToolUseVerdict(deny=True, reason=payload["message"])
 
     _emit_capture(
@@ -396,7 +396,7 @@ async def evaluate_user_prompt_submit(
             decision=decision,
             metadata=metadata,
         )
-        payload = payload_from_block(action, decision)
+        payload = payload_from_block(decision)
         return UserPromptSubmitVerdict(block=True, reason=payload["message"])
 
     _emit_capture(
@@ -442,7 +442,6 @@ def capture_post_tool_use(source: Any, config: _HookConfig) -> dict[str, Any]:
     from a result the model is meant to read.
     """
     hook = _hook_mapping(source)
-    action = f"{_tool_name(hook) or 'tool'}.invoked"
     try:
         action = _resolve_tool_action(config, hook)
         arguments = _tool_call(hook)
@@ -467,6 +466,12 @@ def capture_post_tool_use(source: Any, config: _HookConfig) -> dict[str, Any]:
 def _inbound_session_id(
     inbound: Mapping[str, Any], session_id: Optional[str]
 ) -> Optional[str]:
+    """Inbound ``session_id`` overrides the top-level fallback when the key is present.
+
+    ``{"session_id": None}`` is an explicit clear: inbound stays
+    uncorrelated rather than inheriting *session_id*. Omit the key to
+    inherit.
+    """
     if "session_id" not in inbound:
         return session_id
     raw = inbound["session_id"]
@@ -596,7 +601,10 @@ def guard_hooks(
             *action* / *rules* / *exclude*.
         inbound: UserPromptSubmit policy. Requires ``action``. Optional
             ``rules``, ``actor``, ``inputs``, ``metadata``,
-            ``on_guard_error``, ``session_id``.
+            ``on_guard_error``, ``session_id``. An explicit
+            ``session_id`` key, including ``None``, overrides the
+            top-level fallback (``None`` leaves inbound uncorrelated
+            rather than inheriting).
 
     Raises:
         ArcjetMisconfiguration: *on_guard_error* is not ``"allow"`` or

--- a/src/arcjet/guard/claude_agent_sdk/_hooks.py
+++ b/src/arcjet/guard/claude_agent_sdk/_hooks.py
@@ -13,7 +13,9 @@ is no ``guard_inbound`` helper. A deny is ``{"decision": "block"}``.
 ``PreToolUse`` fires for every tool and the input carries only a name,
 never the brand :func:`guard_tool` applies. List wrapped tools in
 ``exclude`` as ``{"server": ..., "name": ...}`` so they match
-``mcp__{server}__{name}`` exactly.
+``mcp__{server}__{name}`` exactly. ``PostToolUse`` is capture only and
+is not skipped by *exclude*. ``rules`` / ``actor`` / ``inputs`` /
+``metadata`` see ``tool_input`` plus ``tool_name``.
 """
 
 from __future__ import annotations
@@ -37,12 +39,11 @@ from .._checkpoint import (
     _outcome_for_completed_action,
     _resolve_correlation_id,
 )
-from .._context import _validated
 from .._errors import ArcjetDeniedError, ArcjetUnavailableError, OnGuardError
 from .._policy_input import PolicyInputMap
 from .._registry import _awaitable
 from .._rules import RuleWithInput
-from ._context import claude_agent_context
+from ._context import _require_session_id, claude_agent_context
 from ._denial import payload_from_block, unavailable_message
 from ._import import load_hook_matcher
 from ._names import ExcludeEntry, as_exclude_entry, excluded_names, is_excluded
@@ -122,6 +123,21 @@ def _tool_arguments(source: Mapping[str, Any]) -> Mapping[str, Any]:
     return dict(raw) if isinstance(raw, Mapping) else {}
 
 
+def _tool_call(source: Mapping[str, Any]) -> dict[str, Any]:
+    """What ``rules`` / ``actor`` / ``inputs`` / ``metadata`` see for a tool hook.
+
+    The model-produced ``tool_input`` fields plus ``tool_name``, so a
+    per-tool rate limit can key on the name the JS adapter exposes as
+    ``{ toolName, input }``. ``tool_name`` is applied last so a tool
+    argument of the same name cannot hide the hook's name.
+    """
+    call = dict(_tool_arguments(source))
+    name = _tool_name(source)
+    if name:
+        call["tool_name"] = name
+    return call
+
+
 def _prompt(source: Mapping[str, Any]) -> str:
     raw = source.get("prompt")
     return raw if isinstance(raw, str) else ""
@@ -185,11 +201,14 @@ def _merged_metadata(
     session_id: Optional[str],
     source: Mapping[str, Any],
     extra: Optional[Metadata],
+    *,
+    phase: str,
 ) -> Optional[Metadata]:
     derived = claude_agent_context(source, session_id=session_id)
     merged: dict[str, Any] = {}
     if derived.metadata:
         merged.update(derived.metadata)
+    merged["claude.phase"] = phase
     if extra:
         merged.update(extra)
     return merged or None
@@ -249,10 +268,10 @@ async def evaluate_pre_tool_use(source: Any, config: _HookConfig) -> PreToolUseV
 
     try:
         action = _resolve_tool_action(config, hook)
-        arguments = _tool_arguments(hook)
+        arguments = _tool_call(hook)
         correlation_id = _correlation(config.session_id, hook)
         extra = _resolved_metadata(config.metadata, arguments)
-        metadata = _merged_metadata(config.session_id, hook, extra)
+        metadata = _merged_metadata(config.session_id, hook, extra, phase="before")
         prepared = _prepared(config.actor, config.inputs, arguments)
         rules = _resolved_rules(config.rules, arguments)
         decision = await _decide(
@@ -330,7 +349,7 @@ async def evaluate_user_prompt_submit(
     try:
         correlation_id = _correlation(config.session_id, hook)
         extra = _resolved_metadata(config.metadata, arguments)
-        metadata = _merged_metadata(config.session_id, hook, extra)
+        metadata = _merged_metadata(config.session_id, hook, extra, phase="inbound")
         prepared = _prepared(config.actor, config.inputs, arguments)
         rules = _resolved_rules(config.rules, arguments)
         decision = await _decide(
@@ -414,6 +433,53 @@ def user_prompt_submit_output(verdict: UserPromptSubmitVerdict) -> dict[str, Any
     }
 
 
+def capture_post_tool_use(source: Any, config: _HookConfig) -> dict[str, Any]:
+    """Observe-only PostToolUse. Never blocks. *exclude* does not skip this.
+
+    ``guard_tool`` already captured the gate; this is the JS adapter's
+    after-call audit trail (``claude.phase: after``). Outcome is
+    ``success`` because PostToolUse cannot distinguish a tool error
+    from a result the model is meant to read.
+    """
+    hook = _hook_mapping(source)
+    action = f"{_tool_name(hook) or 'tool'}.invoked"
+    try:
+        action = _resolve_tool_action(config, hook)
+        arguments = _tool_call(hook)
+        extra = _resolved_metadata(config.metadata, arguments)
+        metadata = _merged_metadata(config.session_id, hook, extra, phase="after")
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="success",
+            correlation_id=_correlation(config.session_id, hook),
+            decision=None,
+            metadata=metadata,
+        )
+    except Exception:
+        logger.warning(
+            "arcjet: the Claude Agent SDK PostToolUse hook failed; "
+            "the tool result is unchanged"
+        )
+    return {}
+
+
+def _inbound_session_id(
+    inbound: Mapping[str, Any], session_id: Optional[str]
+) -> Optional[str]:
+    if "session_id" not in inbound:
+        return session_id
+    raw = inbound["session_id"]
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise TypeError(
+            "guard_hooks(inbound=...) session_id must be a str UUID, "
+            f"got {type(raw).__name__}"
+        )
+    return _require_session_id(raw)
+
+
 def _inbound_config(
     *,
     guard: Any,
@@ -441,7 +507,7 @@ def _inbound_config(
         inputs=inbound.get("inputs"),
         rules=inbound.get("rules", ()),
         metadata=inbound.get("metadata"),
-        session_id=inbound.get("session_id", session_id),
+        session_id=_inbound_session_id(inbound, session_id),
         on_guard_error=inbound_error,
     )
 
@@ -450,15 +516,20 @@ def _tool_hooks_requested(
     *,
     action: ActionResolver,
     rules: RulesResolver,
-    actor: ActorResolver,
-    inputs: InputResolver,
     exclude: Sequence[ExcludeEntry] | None,
+    tools: bool,
 ) -> bool:
+    """Whether to register PreToolUse / PostToolUse.
+
+    ``actor=`` / ``inputs=`` / ``metadata=`` are policy for a tool hook
+    that was requested some other way — they must not install a global
+    gate next to inbound-only ``guard_hooks(inbound=...)``.
+    """
+    if tools:
+        return True
     if action is not None:
         return True
     if callable(rules) or (isinstance(rules, Sequence) and len(rules) > 0):
-        return True
-    if actor is not None or inputs is not None:
         return True
     return bool(exclude)
 
@@ -475,6 +546,7 @@ def guard_hooks(
     correlation_id: Optional[str] = None,
     on_guard_error: OnGuardError = "deny",
     exclude: Sequence[ExcludeEntry] | None = None,
+    tools: bool = False,
     inbound: Optional[Mapping[str, Any]] = None,
 ) -> dict[str, list[Any]]:
     """Build Claude Agent SDK hooks that fail closed.
@@ -488,29 +560,40 @@ def guard_hooks(
       *exclude* as ``{"server": ..., "name": ...}`` (qualified to
       ``mcp__{server}__{name}``) or as the exact reported name. A bare
       authored name does not match every server.
+    * ``PostToolUse`` — capture only (``claude.phase: after``). Never
+      blocks. *exclude* does not skip this.
     * ``UserPromptSubmit`` — when *inbound* is set, ``{"decision":
       "block"}`` is the inbound path. There is no ``guard_inbound``.
 
     ``can_use_tool`` is not wrapped. ``permissionDecision: "ask"`` is
     never returned.
 
+    Tool-hook ``rules`` / ``actor`` / ``inputs`` / ``metadata`` callables
+    receive ``tool_input`` plus ``tool_name``. ``action`` still receives
+    the full hook input.
+
     Args:
         guard: The Arcjet client. An async client is preferred; a blocking
             client is accepted.
         action: Checkpoint label, or a callable of the hook input. Defaults
             to ``"{tool_name}.invoked"`` when a tool hook is registered.
-        actor: Who is acting, or a callable of the tool arguments (or
-            ``{"prompt": ...}`` on inbound).
-        inputs: Policy inputs, or a callable of those arguments.
-        rules: Local rules, or a callable of those arguments. Empty still
+        actor: Who is acting, or a callable of the tool-call envelope (or
+            ``{"prompt": ...}`` on inbound). Does not register a tool hook
+            by itself — put it on *inbound* for inbound-only setups.
+        inputs: Policy inputs, or a callable of that envelope.
+        rules: Local rules, or a callable of that envelope. Empty still
             contacts Guard.
-        metadata: Capture metadata, or a callable of those arguments.
+        metadata: Capture metadata, or a callable of that envelope.
         session_id: Caller-owned UUID fallback. Hook ``session_id`` is
             preferred. Never minted.
         correlation_id: Alias of *session_id*. Ignored when *session_id*
             is set.
         on_guard_error: ``"deny"`` (default) or ``"allow"``.
         exclude: Tools already wrapped by ``guard_tool``.
+        tools: Register PreToolUse / PostToolUse with the default
+            ``"{tool_name}.invoked"`` action and empty rules. Use this
+            when you want every unwrapped tool gated and have no local
+            *action* / *rules* / *exclude*.
         inbound: UserPromptSubmit policy. Requires ``action``. Optional
             ``rules``, ``actor``, ``inputs``, ``metadata``,
             ``on_guard_error``, ``session_id``.
@@ -519,8 +602,9 @@ def guard_hooks(
         ArcjetMisconfiguration: *on_guard_error* is not ``"allow"`` or
             ``"deny"``, *inbound* is missing ``action``, or neither a
             tool hook nor inbound was requested.
-        ValueError: *session_id* / *correlation_id* is not printable
-            ASCII, or an exclude entry cannot be qualified.
+        TypeError: *tools* is not a bool, or *inbound* is not a mapping.
+        ValueError: *session_id* / *correlation_id* is not a UUID, or an
+            exclude entry cannot be qualified.
         ImportError: the ``claude-agent-sdk`` extra is not installed.
     """
     if on_guard_error not in ("allow", "deny"):
@@ -529,9 +613,15 @@ def guard_hooks(
             f"It decides whether a call runs when policy could not be "
             f"evaluated, so there is no safe value to guess."
         )
+    if not isinstance(tools, bool):
+        raise TypeError(
+            "guard_hooks(tools=) is True to register PreToolUse / PostToolUse "
+            "with the default {tool_name}.invoked action; it is not a tool "
+            f"list. got {type(tools).__name__}"
+        )
     owned = session_id if session_id is not None else correlation_id
     if owned is not None:
-        _validated(owned)
+        _require_session_id(owned)
     if inbound is not None and not isinstance(inbound, Mapping):
         raise TypeError(
             "guard_hooks(inbound=...) is a mapping with at least action=; "
@@ -541,15 +631,14 @@ def guard_hooks(
     want_tools = _tool_hooks_requested(
         action=action,
         rules=rules,
-        actor=actor,
-        inputs=inputs,
         exclude=exclude,
+        tools=tools,
     )
     if not want_tools and inbound is None:
         raise ArcjetMisconfiguration(
-            "guard_hooks() needs a tool policy (action= / rules=) and/or "
-            "inbound= for UserPromptSubmit. There is no guard_inbound "
-            "helper and no guard_can_use_tool."
+            "guard_hooks() needs a tool policy (action= / rules= / "
+            "tools=True / exclude=) and/or inbound= for UserPromptSubmit. "
+            "There is no guard_inbound helper and no guard_can_use_tool."
         )
 
     inbound_config = (
@@ -598,7 +687,13 @@ def guard_hooks(
                 )
             return pre_tool_use_output(verdict)
 
+        async def post_tool_use(
+            input_data: Any, _tool_use_id: Optional[str], _context: Any
+        ) -> dict[str, Any]:
+            return capture_post_tool_use(input_data, config)
+
         hooks["PreToolUse"] = [hook_matcher(matcher=None, hooks=[pre_tool_use])]
+        hooks["PostToolUse"] = [hook_matcher(matcher=None, hooks=[post_tool_use])]
 
     if inbound_config is not None:
 

--- a/src/arcjet/guard/claude_agent_sdk/_import.py
+++ b/src/arcjet/guard/claude_agent_sdk/_import.py
@@ -39,6 +39,10 @@ def _release(raw: str) -> tuple[int, ...]:
     dependency, and a three-part release is all this comparison needs. Pre-
     release suffixes (``rc1``) are stripped; post-releases (``0.2.148.post1``)
     also compare as ``(0, 2, 148)`` because only the leading digit run is kept.
+    A short or non-numeric release such as ``"0.2"`` or ``"0.2.post1"``
+    collapses to ``(0, 2)``, which compares less than the three-part floor
+    and is refused — not treated as unknown and skipped. An empty parse
+    (``"weird"``) is the skip path.
     """
     parts: list[int] = []
     for chunk in raw.split(".")[:3]:

--- a/src/arcjet/guard/claude_agent_sdk/_import.py
+++ b/src/arcjet/guard/claude_agent_sdk/_import.py
@@ -1,0 +1,113 @@
+"""Lazy Claude Agent SDK imports, so this package works without the extra.
+
+The public module is importable without ``claude-agent-sdk``: unit tests and
+``import arcjet.guard`` must keep working. The first call that wraps a tool
+or builds hooks loads the peer, and says what to install if it is missing or
+too old.
+
+The floor is 0.2.127. 0.2.83 was the mcp CVE + timeout fail-close line;
+0.2.127 includes that and the background-task PreToolUse stdin fix, so this
+adapter does not have to caveat that path. Verified on 0.2.148.
+
+``importlib`` is used rather than static imports so type checkers do not need
+the extra installed either.
+"""
+
+from __future__ import annotations
+
+import importlib
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Final, Optional
+
+from arcjet._errors import ArcjetMisconfiguration
+
+#: Floor that includes the mcp CVE + timeout fail-close fix (0.2.83) and the
+#: background-task PreToolUse stdin fix, so we do not have to caveat that
+#: path. Verified on 0.2.148.
+MINIMUM_CLAUDE_AGENT_SDK: Final[tuple[int, int, int]] = (0, 2, 127)
+
+_INSTALL_HINT: Final[str] = (
+    'Install it with: pip install "arcjet[claude-agent-sdk]" '
+    "(claude-agent-sdk>=0.2.127,<1)"
+)
+
+
+def _release(raw: str) -> tuple[int, ...]:
+    """The numeric release segment of *raw*, e.g. ``"0.2.148rc1"`` → ``(0, 2, 148)``.
+
+    Local parsing rather than ``packaging.version``: that is not an Arcjet
+    dependency, and a three-part release is all this comparison needs. Pre-
+    release suffixes (``rc1``) are stripped; post-releases (``0.2.148.post1``)
+    also compare as ``(0, 2, 148)`` because only the leading digit run is kept.
+    """
+    parts: list[int] = []
+    for chunk in raw.split(".")[:3]:
+        digits = ""
+        for char in chunk:
+            if not char.isdigit():
+                break
+            digits += char
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def _installed_version() -> Optional[str]:
+    try:
+        return version("claude-agent-sdk")
+    except PackageNotFoundError:  # pragma: no cover - depends on the install
+        return None
+
+
+def _require_claude_agent_sdk() -> None:
+    """Refuse a peer too old to deny honestly, before anything is wired.
+
+    Below the floor this adapter would have to caveat the PreToolUse stdin
+    fix (and would sit under the 0.2.83 mcp CVE line). Reported at wrap /
+    hook-build time rather than as an ``AttributeError`` from inside a
+    handler the SDK would swallow into ``str(e)``.
+    """
+    installed = _installed_version()
+    if installed is None:
+        return
+    release = _release(installed)
+    if release and release < MINIMUM_CLAUDE_AGENT_SDK:
+        floor = ".".join(str(part) for part in MINIMUM_CLAUDE_AGENT_SDK)
+        raise ArcjetMisconfiguration(
+            f"arcjet.guard.claude_agent_sdk needs claude-agent-sdk >= {floor}, "
+            f"but {installed} is installed. Below {floor} the PreToolUse "
+            f"background-task stdin path is incomplete and the 0.2.83 mcp "
+            f"CVE / timeout fail-close line is not guaranteed. Upgrade with: "
+            f'pip install "claude-agent-sdk>={floor},<1"'
+        )
+
+
+def load_claude_agent_sdk() -> Any:
+    """The ``claude_agent_sdk`` package, or an error naming what to install."""
+    _require_claude_agent_sdk()
+    try:
+        return importlib.import_module("claude_agent_sdk")
+    except ImportError as exc:  # pragma: no cover - depends on the install
+        raise ImportError(
+            f"arcjet.guard.claude_agent_sdk needs the Claude Agent SDK. {_INSTALL_HINT}"
+        ) from exc
+
+
+def load_sdk_mcp_tool() -> type[Any]:
+    """The SDK's ``SdkMcpTool``, or an error naming what to install."""
+    return load_claude_agent_sdk().SdkMcpTool
+
+
+def load_hook_matcher() -> type[Any]:
+    """The SDK's ``HookMatcher``, or an error naming what to install."""
+    return load_claude_agent_sdk().HookMatcher
+
+
+def claude_agent_sdk_present() -> bool:
+    """Whether ``claude_agent_sdk`` is importable in this process."""
+    try:
+        importlib.import_module("claude_agent_sdk")
+    except ImportError:
+        return False
+    return True

--- a/src/arcjet/guard/claude_agent_sdk/_names.py
+++ b/src/arcjet/guard/claude_agent_sdk/_names.py
@@ -27,28 +27,29 @@ def exclude_name(entry: ExcludeEntry) -> str:
     is used as-is (a built-in such as ``"Bash"``, or an already-qualified
     ``mcp__support__lookup_order``).
     """
-    if isinstance(entry, Mapping):
-        server = entry.get("server")
-        name = entry.get("name")
-        if not isinstance(server, str) or not server:
+    if isinstance(entry, str):
+        if not entry:
             raise ValueError(
-                "exclude mapping needs a non-empty 'server' string "
-                "(the mcp_servers key), so the PreToolUse name can be "
-                f"qualified as mcp__{{server}}__{{name}}; got {entry!r}"
+                "exclude entry must be a non-empty tool name or "
+                "{'server': ..., 'name': ...}; got an empty string"
             )
-        if not isinstance(name, str) or not name:
-            raise ValueError(
-                "exclude mapping needs a non-empty 'name' string "
-                "(the @tool name), so the PreToolUse name can be "
-                f"qualified as mcp__{{server}}__{{name}}; got {entry!r}"
-            )
-        return mcp_tool_name(server, name)
-    if not isinstance(entry, str) or not entry:
+        return entry
+    fields = dict(entry)
+    server = fields.get("server")
+    name = fields.get("name")
+    if not isinstance(server, str) or not server:
         raise ValueError(
-            "exclude entry must be a non-empty tool name or "
-            f"{{'server': ..., 'name': ...}}; got {entry!r}"
+            "exclude mapping needs a non-empty 'server' string "
+            "(the mcp_servers key), so the PreToolUse name can be "
+            f"qualified as mcp__{{server}}__{{name}}; got {entry!r}"
         )
-    return entry
+    if not isinstance(name, str) or not name:
+        raise ValueError(
+            "exclude mapping needs a non-empty 'name' string "
+            "(the @tool name), so the PreToolUse name can be "
+            f"qualified as mcp__{{server}}__{{name}}; got {entry!r}"
+        )
+    return mcp_tool_name(server, name)
 
 
 def excluded_names(entries: Sequence[ExcludeEntry] | None) -> frozenset[str]:

--- a/src/arcjet/guard/claude_agent_sdk/_names.py
+++ b/src/arcjet/guard/claude_agent_sdk/_names.py
@@ -1,0 +1,75 @@
+"""Qualify and match Claude Agent SDK tool names for ``exclude``.
+
+Authored ``@tool`` / ``SdkMcpTool`` handlers are reached from
+``create_sdk_mcp_server`` as ``mcp__{server}__{name}`` on ``PreToolUse``.
+A bare authored name must not match every server's tool of that name: two
+servers can expose the same name with only one of them wrapped, and a
+loose match would drop the gate on the unprotected one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Union
+
+ExcludeEntry = Union[str, Mapping[str, str]]
+
+
+def mcp_tool_name(server: str, name: str) -> str:
+    """The ``PreToolUse`` name for an authored SDK MCP tool."""
+    return f"mcp__{server}__{name}"
+
+
+def exclude_name(entry: ExcludeEntry) -> str:
+    """Exact ``PreToolUse`` name this exclude entry matches.
+
+    A mapping ``{"server": ..., "name": ...}`` is qualified. A bare string
+    is used as-is (a built-in such as ``"Bash"``, or an already-qualified
+    ``mcp__support__lookup_order``).
+    """
+    if isinstance(entry, Mapping):
+        server = entry.get("server")
+        name = entry.get("name")
+        if not isinstance(server, str) or not server:
+            raise ValueError(
+                "exclude mapping needs a non-empty 'server' string "
+                "(the mcp_servers key), so the PreToolUse name can be "
+                f"qualified as mcp__{{server}}__{{name}}; got {entry!r}"
+            )
+        if not isinstance(name, str) or not name:
+            raise ValueError(
+                "exclude mapping needs a non-empty 'name' string "
+                "(the @tool name), so the PreToolUse name can be "
+                f"qualified as mcp__{{server}}__{{name}}; got {entry!r}"
+            )
+        return mcp_tool_name(server, name)
+    if not isinstance(entry, str) or not entry:
+        raise ValueError(
+            "exclude entry must be a non-empty tool name or "
+            f"{{'server': ..., 'name': ...}}; got {entry!r}"
+        )
+    return entry
+
+
+def excluded_names(entries: Sequence[ExcludeEntry] | None) -> frozenset[str]:
+    """Exact names :func:`guard_hooks` PreToolUse should skip."""
+    if not entries:
+        return frozenset()
+    return frozenset(exclude_name(entry) for entry in entries)
+
+
+def is_excluded(tool_name: str, excluded: frozenset[str]) -> bool:
+    """Whether *tool_name* is an exact exclude match."""
+    return bool(tool_name) and tool_name in excluded
+
+
+def as_exclude_entry(value: Any) -> ExcludeEntry:
+    """Narrow a caller value to :data:`ExcludeEntry`, or raise."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        return value
+    raise TypeError(
+        "exclude entries must be a tool name string or "
+        f"{{'server': ..., 'name': ...}}, got {type(value).__name__}"
+    )

--- a/src/arcjet/guard/claude_agent_sdk/_tool.py
+++ b/src/arcjet/guard/claude_agent_sdk/_tool.py
@@ -251,7 +251,7 @@ async def evaluate_handler(arguments: Any, config: _ToolConfig) -> HandlerVerdic
             decision=None,
             metadata=metadata,
         )
-        return HandlerVerdict(deny=True, payload=payload_from_block(action, None))
+        return HandlerVerdict(deny=True, payload=payload_from_block(None))
 
     if failure is not None:
         denied = getattr(decision, "conclusion", None) == "DENY"
@@ -263,7 +263,7 @@ async def evaluate_handler(arguments: Any, config: _ToolConfig) -> HandlerVerdic
             decision=decision,
             metadata=metadata,
         )
-        return HandlerVerdict(deny=True, payload=payload_from_block(action, decision))
+        return HandlerVerdict(deny=True, payload=payload_from_block(decision))
 
     _emit_capture(
         client=config.guard,
@@ -279,13 +279,34 @@ async def evaluate_handler(arguments: Any, config: _ToolConfig) -> HandlerVerdic
 def handler_denial_result(verdict: HandlerVerdict) -> dict[str, Any]:
     """The exact MCP tool result a DENY handler must return."""
     payload = (
-        verdict.payload if verdict.payload is not None else payload_from_block("", None)
+        verdict.payload if verdict.payload is not None else payload_from_block(None)
     )
     return denial_tool_result(payload)
 
 
 def _is_already_guarded(tool: Any) -> bool:
     return bool(getattr(tool, _GUARD_BRAND, False))
+
+
+def _brand(tool: Any) -> None:
+    """Mark the wrapped *copy* so a second wrap does not double-call Guard.
+
+    An attribute rather than a WeakSet of ``id()`` values: CPython reuses
+    the id of a collected object, so an id-keyed registry starts skipping
+    unrelated tools — a silent fail-open. ``object.__setattr__`` works on
+    a frozen dataclass. If ``SdkMcpTool`` grows ``__slots__`` without room
+    for this name, fail loudly at wrap time rather than shipping an
+    unbranded copy.
+    """
+    try:
+        object.__setattr__(tool, _GUARD_BRAND, True)
+    except AttributeError as exc:
+        raise TypeError(
+            "guard_tool() could not brand the SdkMcpTool copy with "
+            f"{_GUARD_BRAND!r}; the SDK type likely uses __slots__ "
+            "without space for this attribute. The wrap cannot proceed "
+            "without the brand — a second wrap would double-call Guard."
+        ) from exc
 
 
 def _copy_tool(tool: Any) -> Any:
@@ -305,7 +326,7 @@ def _wrap_handler(config: _ToolConfig, original: Any) -> Any:
                     config.action,
                 )
                 return await original(arguments)
-            return denial_tool_result(payload_from_block(config.action, None))
+            return denial_tool_result(payload_from_block(None))
         if verdict.deny:
             return handler_denial_result(verdict)
         return await original(arguments)
@@ -411,7 +432,5 @@ def guard_tool(
             f"{type(original).__name__}"
         )
     guarded.handler = _wrap_handler(config, original)
-    # Only the copy is branded. Branding the original as well would make a
-    # later wrap of the unwrapped tool skip it, which is a fail-open.
-    object.__setattr__(guarded, _GUARD_BRAND, True)
+    _brand(guarded)
     return guarded

--- a/src/arcjet/guard/claude_agent_sdk/_tool.py
+++ b/src/arcjet/guard/claude_agent_sdk/_tool.py
@@ -1,0 +1,418 @@
+"""Authored ``@tool`` / ``SdkMcpTool`` wrap via a replaced ``.handler``.
+
+The SDK invokes ``SdkMcpTool.handler`` from ``create_sdk_mcp_server``. On
+DENY the original handler must not run. The deny is a returned MCP tool
+result — ``create_sdk_mcp_server`` copies ``content`` and ``is_error`` and
+drops ``structuredContent``, and an exception is swallowed into ``str(e)``.
+
+This module therefore does **not** wrap ``can_use_tool`` as a policy gate.
+An authored handler has no ``extra.session_id`` — pass ``session_id=``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Optional, Union, cast
+
+from arcjet._errors import ArcjetMisconfiguration
+from arcjet._logging import logger
+from arcjet._metadata import Metadata
+
+from .._checkpoint import (
+    ResolvedInputs,
+    _classify_decision,
+    _emit_capture,
+    _guard_async,
+    _guard_sync,
+    _outcome_for_completed_action,
+    _resolve_correlation_id,
+)
+from .._context import _validated
+from .._errors import ArcjetDeniedError, ArcjetUnavailableError, OnGuardError
+from .._policy_input import PolicyInputMap
+from .._registry import _awaitable
+from .._rules import RuleWithInput
+from ._context import claude_agent_context
+from ._denial import (
+    ArcjetDenialResult,
+    denial_tool_result,
+    payload_from_block,
+)
+from ._import import load_sdk_mcp_tool
+
+ActorResolver = Union[str, Callable[[Mapping[str, Any]], Optional[str]], None]
+InputResolver = Union[
+    PolicyInputMap,
+    Callable[[Mapping[str, Any]], Optional[PolicyInputMap]],
+    None,
+]
+RulesResolver = Union[
+    Sequence[RuleWithInput],
+    Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+]
+MetadataResolver = Union[
+    Metadata, Callable[[Mapping[str, Any]], Optional[Metadata]], None
+]
+
+#: Attribute :func:`guard_tool` puts on the copy it returns, so a second wrap
+#: of the same object does not evaluate the same call twice. An attribute
+#: rather than a registry of ``id()`` values: CPython reuses the id of a
+#: collected object, so an id-keyed registry starts skipping unrelated tools
+#: once the wrapped tool is garbage collected.
+_GUARD_BRAND = "_arcjet_guarded"
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolConfig:
+    guard: Any
+    action: str
+    actor: ActorResolver
+    inputs: InputResolver
+    rules: RulesResolver
+    metadata: MetadataResolver
+    session_id: Optional[str]
+    on_guard_error: OnGuardError
+    tool_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class HandlerVerdict:
+    """What the wrapped handler should return. Unit tests call this without
+    constructing a real ``SdkMcpTool``.
+    """
+
+    deny: bool
+    payload: Optional[ArcjetDenialResult] = None
+
+
+def _arguments_from_handler(arguments: Any) -> Mapping[str, Any]:
+    """The model-produced arguments, as the SDK handed the handler.
+
+    The SDK validates against the tool schema and passes a dict. A
+    non-mapping is an empty mapping — the same shape a policy with no
+    resolver sees for a call with no args — rather than an exception that
+    would skip Guard.
+    """
+    if isinstance(arguments, Mapping):
+        return dict(arguments)
+    return {}
+
+
+def _resolve(source: Any, arguments: Mapping[str, Any]) -> Any:
+    if source is None or not callable(source):
+        return source
+    return source(arguments)
+
+
+def _prepared(config: _ToolConfig, arguments: Mapping[str, Any]) -> ResolvedInputs:
+    """What the decision is made from; a failed resolver is reported."""
+    degraded: Optional[BaseException] = None
+    resolved_actor: Optional[str] = None
+    resolved_inputs: Optional[PolicyInputMap] = None
+    try:
+        resolved_actor = _resolve(config.actor, arguments)
+    except Exception as exc:
+        degraded = exc
+    try:
+        resolved_inputs = _resolve(config.inputs, arguments)
+    except Exception as exc:
+        degraded = degraded or exc
+    return ResolvedInputs(
+        actor=resolved_actor, inputs=resolved_inputs, degraded=degraded
+    )
+
+
+def _resolved_rules(
+    config: _ToolConfig, arguments: Mapping[str, Any]
+) -> Sequence[RuleWithInput]:
+    rules = config.rules
+    if not callable(rules):
+        return rules
+    return cast(
+        Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+        rules,
+    )(arguments)
+
+
+def _resolved_metadata(
+    config: _ToolConfig, arguments: Mapping[str, Any]
+) -> Optional[Metadata]:
+    metadata = config.metadata
+    if callable(metadata):
+        return cast(
+            Callable[[Mapping[str, Any]], Optional[Metadata]],
+            metadata,
+        )(arguments)
+    return metadata
+
+
+def _correlation(config: _ToolConfig) -> Optional[str]:
+    """Caller-owned UUID from the wrap, then the enclosing sequence."""
+    derived = claude_agent_context(session_id=config.session_id)
+    return _resolve_correlation_id(derived.correlation_id)
+
+
+def _merged_metadata(
+    config: _ToolConfig, extra: Optional[Metadata]
+) -> Optional[Metadata]:
+    derived = claude_agent_context(session_id=config.session_id)
+    merged: dict[str, Any] = {}
+    if derived.metadata:
+        merged.update(derived.metadata)
+    if config.tool_name and "claude.tool" not in merged:
+        merged["claude.tool"] = config.tool_name
+    if extra:
+        merged.update(extra)
+    return merged or None
+
+
+def _unavailable(action: str, cause: Optional[BaseException]) -> BaseException:
+    return ArcjetUnavailableError(action, cause=cause)
+
+
+async def _decide(
+    config: _ToolConfig,
+    *,
+    action: str,
+    correlation_id: Optional[str],
+    metadata: Optional[Metadata],
+    prepared: ResolvedInputs,
+    rules: Sequence[RuleWithInput],
+) -> Any:
+    """Evaluate through the async client when there is one, else the sync one.
+
+    Authored handlers are async. A blocking ``guard_sync()`` client is
+    offloaded with ``asyncio.to_thread`` so the event loop is not wedged
+    for the Guard round trip.
+    """
+    kwargs = {
+        "rules": rules,
+        "label": action,
+        "metadata": metadata,
+        "correlation_id": correlation_id,
+        "actor": prepared.actor,
+        "inputs": prepared.inputs,
+    }
+    if _awaitable(config.guard, "guard") is not None or config.guard is None:
+        return await _guard_async(config.guard, **kwargs)
+    return await asyncio.to_thread(partial(_guard_sync, config.guard, **kwargs))
+
+
+async def evaluate_handler(arguments: Any, config: _ToolConfig) -> HandlerVerdict:
+    """Evaluate policy for one authored tool call. Never raises an Arcjet error.
+
+    A raise from this function would leave the handler, and the SDK would
+    swallow it into ``str(e)``. The deny envelope is the only shape the
+    model can read as a structured ``ArcjetDenialResult``.
+    """
+    action = config.action
+    correlation_id = _resolve_correlation_id(None)
+    metadata: Optional[Metadata] = None
+
+    try:
+        parsed = _arguments_from_handler(arguments)
+        correlation_id = _correlation(config)
+        extra = _resolved_metadata(config, parsed)
+        metadata = _merged_metadata(config, extra)
+        prepared = _prepared(config, parsed)
+        rules = _resolved_rules(config, parsed)
+        decision = await _decide(
+            config,
+            action=action,
+            correlation_id=correlation_id,
+            metadata=metadata,
+            prepared=prepared,
+            rules=rules,
+        )
+        failure = _classify_decision(
+            decision,
+            action=action,
+            on_guard_error=config.on_guard_error,
+            denied_error=ArcjetDeniedError,
+            unavailable_error=_unavailable,
+            degraded=prepared.degraded,
+        )
+    except Exception:
+        if config.on_guard_error == "allow":
+            logger.warning(
+                "arcjet: policy for action %r could not be evaluated; proceeding "
+                "because on_guard_error is 'allow'",
+                action,
+            )
+            return HandlerVerdict(deny=False)
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="unavailable",
+            correlation_id=correlation_id,
+            decision=None,
+            metadata=metadata,
+        )
+        return HandlerVerdict(deny=True, payload=payload_from_block(action, None))
+
+    if failure is not None:
+        denied = getattr(decision, "conclusion", None) == "DENY"
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="denied" if denied else "unavailable",
+            correlation_id=correlation_id,
+            decision=decision,
+            metadata=metadata,
+        )
+        return HandlerVerdict(deny=True, payload=payload_from_block(action, decision))
+
+    _emit_capture(
+        client=config.guard,
+        action=action,
+        outcome=_outcome_for_completed_action(decision, degraded=prepared.degraded),
+        correlation_id=correlation_id,
+        decision=decision,
+        metadata=metadata,
+    )
+    return HandlerVerdict(deny=False)
+
+
+def handler_denial_result(verdict: HandlerVerdict) -> dict[str, Any]:
+    """The exact MCP tool result a DENY handler must return."""
+    payload = (
+        verdict.payload if verdict.payload is not None else payload_from_block("", None)
+    )
+    return denial_tool_result(payload)
+
+
+def _is_already_guarded(tool: Any) -> bool:
+    return bool(getattr(tool, _GUARD_BRAND, False))
+
+
+def _copy_tool(tool: Any) -> Any:
+    return copy.copy(tool)
+
+
+def _wrap_handler(config: _ToolConfig, original: Any) -> Any:
+    async def guarded_handler(arguments: Any) -> dict[str, Any]:
+        # Never throw: the SDK reports ``str(e)`` and drops the envelope.
+        try:
+            verdict = await evaluate_handler(arguments, config)
+        except Exception:
+            if config.on_guard_error == "allow":
+                logger.warning(
+                    "arcjet: policy for action %r could not be evaluated; "
+                    "proceeding because on_guard_error is 'allow'",
+                    config.action,
+                )
+                return await original(arguments)
+            return denial_tool_result(payload_from_block(config.action, None))
+        if verdict.deny:
+            return handler_denial_result(verdict)
+        return await original(arguments)
+
+    return guarded_handler
+
+
+def guard_tool(
+    *,
+    guard: Any,
+    tool: Any,
+    action: str,
+    actor: ActorResolver = None,
+    inputs: InputResolver = None,
+    rules: RulesResolver = (),
+    metadata: MetadataResolver = None,
+    session_id: Optional[str] = None,
+    correlation_id: Optional[str] = None,
+    on_guard_error: OnGuardError = "deny",
+) -> Any:
+    """Wrap an authored ``SdkMcpTool`` so the handler never runs on DENY.
+
+    Returns a copy of *tool* whose ``handler`` evaluates policy first. A
+    ``DENY`` (or an unevaluated policy under the default
+    ``on_guard_error="deny"``) returns exactly::
+
+        {
+            "content": [{"type": "text", "text": <json.dumps(ArcjetDenialResult)>}],
+            "is_error": True,
+        }
+
+    The tool body does not run. Already-branded tools are returned unchanged
+    so a second wrap cannot double-call Guard. ``structuredContent`` is not
+    set: ``create_sdk_mcp_server`` drops it.
+
+    ``can_use_tool`` is not a policy gate and is not wrapped.
+    ``permissionDecision: "ask"`` is HITL, not deny.
+
+    The authored handler has no ``extra.session_id``. Pass the same
+    caller-owned UUID you give ``ClaudeAgentOptions.session_id`` as
+    *session_id* (or *correlation_id*). Never minted.
+
+    Args:
+        guard: The Arcjet client. An async client is preferred; a blocking
+            client is accepted.
+        tool: A Claude Agent SDK ``SdkMcpTool`` from ``@tool``.
+        action: Checkpoint label, e.g. ``"email.sent"``.
+        actor: Who is acting, or a callable of the call's arguments.
+        inputs: Policy inputs, or a callable of the call's arguments.
+        rules: Local rules, or a callable of the call's arguments. Empty
+            still contacts Guard.
+        metadata: Capture metadata, or a callable of the call's arguments.
+        session_id: Caller-owned UUID Sequence id. Preferred over
+            *correlation_id*. Falls back to
+            :func:`~arcjet.guard.arcjet_sequence`. Never minted.
+        correlation_id: Alias of *session_id* for the same caller-owned
+            id. Ignored when *session_id* is set.
+        on_guard_error: ``"deny"`` (default) or ``"allow"``.
+
+    Raises:
+        ArcjetMisconfiguration: *on_guard_error* is not ``"allow"`` or
+            ``"deny"``, or the installed ``claude-agent-sdk`` is below
+            0.2.127.
+        TypeError: *tool* is not an ``SdkMcpTool``.
+        ValueError: *session_id* / *correlation_id* is not printable ASCII
+            within 256 bytes.
+        ImportError: the ``claude-agent-sdk`` extra is not installed.
+    """
+    if on_guard_error not in ("allow", "deny"):
+        raise ArcjetMisconfiguration(
+            f"on_guard_error must be 'allow' or 'deny', got {on_guard_error!r}. "
+            f"It decides whether a call runs when policy could not be "
+            f"evaluated, so there is no safe value to guess."
+        )
+    owned = session_id if session_id is not None else correlation_id
+    if owned is not None:
+        _validated(owned)
+    sdk_mcp_tool = load_sdk_mcp_tool()
+    if not isinstance(tool, sdk_mcp_tool):
+        raise TypeError(
+            f"guard_tool() wraps a Claude Agent SDK SdkMcpTool, got "
+            f"{type(tool).__name__}"
+        )
+    if _is_already_guarded(tool):
+        return tool
+
+    guarded = _copy_tool(tool)
+    config = _ToolConfig(
+        guard=guard,
+        action=action,
+        actor=actor,
+        inputs=inputs,
+        rules=rules,
+        metadata=metadata,
+        session_id=owned,
+        on_guard_error=on_guard_error,
+        tool_name=getattr(tool, "name", "") or "",
+    )
+    original = getattr(tool, "handler", None)
+    if not callable(original):
+        raise TypeError(
+            "guard_tool() wraps an SdkMcpTool with a callable handler, got "
+            f"{type(original).__name__}"
+        )
+    guarded.handler = _wrap_handler(config, original)
+    # Only the copy is branded. Branding the original as well would make a
+    # later wrap of the unwrapped tool skip it, which is a fail-open.
+    object.__setattr__(guarded, _GUARD_BRAND, True)
+    return guarded

--- a/src/arcjet/guard/claude_agent_sdk/_tool.py
+++ b/src/arcjet/guard/claude_agent_sdk/_tool.py
@@ -31,12 +31,11 @@ from .._checkpoint import (
     _outcome_for_completed_action,
     _resolve_correlation_id,
 )
-from .._context import _validated
 from .._errors import ArcjetDeniedError, ArcjetUnavailableError, OnGuardError
 from .._policy_input import PolicyInputMap
 from .._registry import _awaitable
 from .._rules import RuleWithInput
-from ._context import claude_agent_context
+from ._context import _require_session_id, claude_agent_context
 from ._denial import (
     ArcjetDenialResult,
     denial_tool_result,
@@ -371,8 +370,8 @@ def guard_tool(
             ``"deny"``, or the installed ``claude-agent-sdk`` is below
             0.2.127.
         TypeError: *tool* is not an ``SdkMcpTool``.
-        ValueError: *session_id* / *correlation_id* is not printable ASCII
-            within 256 bytes.
+        ValueError: *session_id* / *correlation_id* is not a UUID (or is
+            not printable ASCII within 256 bytes).
         ImportError: the ``claude-agent-sdk`` extra is not installed.
     """
     if on_guard_error not in ("allow", "deny"):
@@ -383,7 +382,7 @@ def guard_tool(
         )
     owned = session_id if session_id is not None else correlation_id
     if owned is not None:
-        _validated(owned)
+        _require_session_id(owned)
     sdk_mcp_tool = load_sdk_mcp_tool()
     if not isinstance(tool, sdk_mcp_tool):
         raise TypeError(

--- a/tests/integration/guard/test_claude_agent_sdk.py
+++ b/tests/integration/guard/test_claude_agent_sdk.py
@@ -94,8 +94,9 @@ def test_guard_hooks_builds_real_matchers() -> None:
         inbound={"action": "message.received"},
         session_id=SESSION_ID,
     )
-    assert set(hooks) == {"PreToolUse", "UserPromptSubmit"}
+    assert set(hooks) == {"PreToolUse", "PostToolUse", "UserPromptSubmit"}
     assert isinstance(hooks["PreToolUse"][0], HookMatcher)
+    assert isinstance(hooks["PostToolUse"][0], HookMatcher)
     assert isinstance(hooks["UserPromptSubmit"][0], HookMatcher)
 
     pre = hooks["PreToolUse"][0].hooks[0]
@@ -148,6 +149,43 @@ def test_guard_hooks_builds_real_matchers() -> None:
         )
     )
     assert blocked["decision"] == "block"
+
+    post = hooks["PostToolUse"][0].hooks[0]
+    observed = asyncio.run(
+        post(
+            {
+                "hook_event_name": "PostToolUse",
+                "session_id": SESSION_ID,
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"},
+                "tool_response": {"content": [{"type": "text", "text": "ok"}]},
+                "tool_use_id": "tu_1",
+                "transcript_path": "/tmp/t",
+                "cwd": "/tmp",
+            },
+            None,
+            {"signal": None},
+        )
+    )
+    assert observed == {}
+    assert client.captures[-1]["metadata"]["claude.phase"] == "after"
+
+
+def test_inbound_plus_actor_does_not_register_tool_hooks() -> None:
+    client = StubGuardClient(decision=make_allow_decision())
+    hooks = guard_hooks(
+        guard=client,
+        actor="user-1",
+        inbound={"action": "message.received"},
+        session_id=SESSION_ID,
+    )
+    assert set(hooks) == {"UserPromptSubmit"}
+
+
+def test_tools_true_registers_default_tool_hooks() -> None:
+    client = StubGuardClient(decision=make_allow_decision())
+    hooks = guard_hooks(guard=client, tools=True, session_id=SESSION_ID)
+    assert set(hooks) == {"PreToolUse", "PostToolUse"}
 
 
 def test_claude_agent_context_reads_hook_session_id() -> None:

--- a/tests/integration/guard/test_claude_agent_sdk.py
+++ b/tests/integration/guard/test_claude_agent_sdk.py
@@ -72,7 +72,7 @@ def test_allow_runs_handler() -> None:
     guarded = guard_tool(guard=client, tool=echo, action="echo.invoked")
     result = asyncio.run(guarded.handler({"value": "hello"}))
     assert _ECHO_CALLS == ["hello"]
-    assert result["is_error"] is not True
+    assert result.get("is_error") is not True
     assert result["content"][0]["text"] == "hello"
 
 

--- a/tests/integration/guard/test_claude_agent_sdk.py
+++ b/tests/integration/guard/test_claude_agent_sdk.py
@@ -1,0 +1,157 @@
+"""Claude Agent SDK wrap + hooks. Skips when the extra is absent."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+from guard_doubles import StubGuardClient, make_allow_decision, make_deny_decision
+
+pytest.importorskip(
+    "claude_agent_sdk", reason="arcjet[claude-agent-sdk] extra is not installed"
+)
+
+from claude_agent_sdk import HookMatcher, SdkMcpTool, tool  # noqa: E402
+
+from arcjet.guard.claude_agent_sdk import (  # noqa: E402
+    claude_agent_context,
+    guard_hooks,
+    guard_tool,
+)
+from arcjet.guard.claude_agent_sdk._tool import _GUARD_BRAND  # noqa: E402
+
+_ECHO_CALLS: list[str] = []
+SESSION_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+@tool("echo", "Echo a value", {"value": str})
+async def echo(args: dict[str, Any]) -> dict[str, Any]:
+    _ECHO_CALLS.append(str(args["value"]))
+    return {"content": [{"type": "text", "text": str(args["value"])}]}
+
+
+@pytest.fixture(autouse=True)
+def _clean_calls() -> Any:
+    _ECHO_CALLS.clear()
+    yield
+    _ECHO_CALLS.clear()
+
+
+def test_guard_tool_wraps_handler_and_returns_a_branded_copy() -> None:
+    client = StubGuardClient(decision=make_allow_decision())
+    guarded = guard_tool(guard=client, tool=echo, action="echo.invoked")
+    assert isinstance(guarded, SdkMcpTool)
+    assert guarded is not echo
+    assert getattr(guarded, _GUARD_BRAND, False) is True
+    assert getattr(echo, _GUARD_BRAND, False) is False
+    assert guarded.handler is not echo.handler
+
+
+def test_second_wrap_is_skipped() -> None:
+    client = StubGuardClient(decision=make_allow_decision())
+    first = guard_tool(guard=client, tool=echo, action="echo.invoked")
+    second = guard_tool(guard=client, tool=first, action="echo.invoked")
+    assert second is first
+
+
+def test_deny_skips_handler_and_returns_envelope() -> None:
+    client = StubGuardClient(decision=make_deny_decision())
+    guarded = guard_tool(guard=client, tool=echo, action="echo.invoked")
+    result = asyncio.run(guarded.handler({"value": "hello"}))
+    assert _ECHO_CALLS == []
+    assert result["is_error"] is True
+    assert "structuredContent" not in result
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["arcjetDenied"] is True
+
+
+def test_allow_runs_handler() -> None:
+    client = StubGuardClient(decision=make_allow_decision())
+    guarded = guard_tool(guard=client, tool=echo, action="echo.invoked")
+    result = asyncio.run(guarded.handler({"value": "hello"}))
+    assert _ECHO_CALLS == ["hello"]
+    assert result["is_error"] is not True
+    assert result["content"][0]["text"] == "hello"
+
+
+def test_handler_never_throws_on_unavailable() -> None:
+    client = StubGuardClient(exception=RuntimeError("down"))
+    guarded = guard_tool(guard=client, tool=echo, action="echo.invoked")
+    result = asyncio.run(guarded.handler({"value": "hello"}))
+    assert _ECHO_CALLS == []
+    assert result["is_error"] is True
+    assert json.loads(result["content"][0]["text"])["reason"] == "ERROR"
+
+
+def test_guard_hooks_builds_real_matchers() -> None:
+    client = StubGuardClient(decision=make_deny_decision())
+    hooks = guard_hooks(
+        guard=client,
+        action=lambda hook: f"{hook['tool_name']}.invoked",
+        exclude=[{"server": "support", "name": "echo"}],
+        inbound={"action": "message.received"},
+        session_id=SESSION_ID,
+    )
+    assert set(hooks) == {"PreToolUse", "UserPromptSubmit"}
+    assert isinstance(hooks["PreToolUse"][0], HookMatcher)
+    assert isinstance(hooks["UserPromptSubmit"][0], HookMatcher)
+
+    pre = hooks["PreToolUse"][0].hooks[0]
+    denied = asyncio.run(
+        pre(
+            {
+                "hook_event_name": "PreToolUse",
+                "session_id": SESSION_ID,
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"},
+                "tool_use_id": "tu_1",
+                "transcript_path": "/tmp/t",
+                "cwd": "/tmp",
+            },
+            None,
+            {"signal": None},
+        )
+    )
+    assert denied["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    skipped = asyncio.run(
+        pre(
+            {
+                "hook_event_name": "PreToolUse",
+                "session_id": SESSION_ID,
+                "tool_name": "mcp__support__echo",
+                "tool_input": {"value": "x"},
+                "tool_use_id": "tu_2",
+                "transcript_path": "/tmp/t",
+                "cwd": "/tmp",
+            },
+            None,
+            {"signal": None},
+        )
+    )
+    assert skipped == {}
+
+    inbound = hooks["UserPromptSubmit"][0].hooks[0]
+    blocked = asyncio.run(
+        inbound(
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "session_id": SESSION_ID,
+                "prompt": "hello",
+                "transcript_path": "/tmp/t",
+                "cwd": "/tmp",
+            },
+            None,
+            {"signal": None},
+        )
+    )
+    assert blocked["decision"] == "block"
+
+
+def test_claude_agent_context_reads_hook_session_id() -> None:
+    ctx = claude_agent_context({"session_id": SESSION_ID, "agent_id": "sub-1"})
+    assert ctx.correlation_id == SESSION_ID
+    assert ctx.metadata is not None
+    assert ctx.metadata["claude.agent"] == "sub-1"

--- a/tests/unit/guard/test_claude_agent_sdk.py
+++ b/tests/unit/guard/test_claude_agent_sdk.py
@@ -1,0 +1,762 @@
+"""Claude Agent SDK adapter unit tests that must run with the extra absent.
+
+The extra is optional. These tests import ``arcjet.guard.claude_agent_sdk``
+helpers that do not load the peer.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from guard_doubles import (
+    StubGuardClient,
+    make_allow_decision,
+    make_deny_decision,
+)
+
+from arcjet._errors import ArcjetMisconfiguration
+from arcjet.guard import arcjet_sequence
+from arcjet.guard._policy_input import PolicyInputMap
+from arcjet.guard._types import RuleResultError, RuleResultTokenBucket
+from arcjet.guard.claude_agent_sdk import _import as import_module
+from arcjet.guard.claude_agent_sdk import (
+    claude_agent_context,
+    guard_hooks,
+    guard_tool,
+)
+from arcjet.guard.claude_agent_sdk._context import ClaudeAgentContext
+from arcjet.guard.claude_agent_sdk._denial import (
+    UNAVAILABLE_RETRY_AFTER_SECONDS,
+    denial_result,
+    denial_tool_result,
+    dumps_denial,
+    retry_after_seconds,
+    unavailable_result,
+)
+from arcjet.guard.claude_agent_sdk._hooks import (
+    PreToolUseVerdict,
+    UserPromptSubmitVerdict,
+    _HookConfig,
+    _InboundConfig,
+    evaluate_pre_tool_use,
+    evaluate_user_prompt_submit,
+    pre_tool_use_output,
+    user_prompt_submit_output,
+)
+from arcjet.guard.claude_agent_sdk._import import (
+    _release,
+    claude_agent_sdk_present,
+    load_sdk_mcp_tool,
+)
+from arcjet.guard.claude_agent_sdk._names import (
+    exclude_name,
+    excluded_names,
+    mcp_tool_name,
+)
+from arcjet.guard.claude_agent_sdk._tool import (
+    _GUARD_BRAND,
+    _arguments_from_handler,
+    _ToolConfig,
+    evaluate_handler,
+    handler_denial_result,
+)
+
+CLAUDE_AGENT_SDK_SRC = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "arcjet"
+    / "guard"
+    / "claude_agent_sdk"
+)
+
+SESSION_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _tool_config(**kwargs: Any) -> _ToolConfig:
+    defaults: dict[str, Any] = {
+        "guard": StubGuardClient(decision=make_allow_decision()),
+        "action": "echo.invoked",
+        "actor": None,
+        "inputs": None,
+        "rules": (),
+        "metadata": None,
+        "session_id": None,
+        "on_guard_error": "deny",
+        "tool_name": "echo",
+    }
+    defaults.update(kwargs)
+    return _ToolConfig(**defaults)
+
+
+def _hook_config(**kwargs: Any) -> _HookConfig:
+    defaults: dict[str, Any] = {
+        "guard": StubGuardClient(decision=make_allow_decision()),
+        "action": None,
+        "actor": None,
+        "inputs": None,
+        "rules": (),
+        "metadata": None,
+        "session_id": None,
+        "on_guard_error": "deny",
+        "exclude": frozenset(),
+    }
+    defaults.update(kwargs)
+    return _HookConfig(**defaults)
+
+
+def _inbound_config(**kwargs: Any) -> _InboundConfig:
+    defaults: dict[str, Any] = {
+        "guard": StubGuardClient(decision=make_allow_decision()),
+        "action": "message.received",
+        "actor": None,
+        "inputs": None,
+        "rules": (),
+        "metadata": None,
+        "session_id": None,
+        "on_guard_error": "deny",
+    }
+    defaults.update(kwargs)
+    return _InboundConfig(**defaults)
+
+
+def _pre_input(**kwargs: object) -> dict[str, object]:
+    defaults: dict[str, object] = {
+        "hook_event_name": "PreToolUse",
+        "session_id": SESSION_ID,
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls"},
+        "tool_use_id": "tu_1",
+        "transcript_path": "/tmp/t",
+        "cwd": "/tmp",
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _prompt_input(**kwargs: object) -> dict[str, object]:
+    defaults: dict[str, object] = {
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": SESSION_ID,
+        "prompt": "hello",
+        "transcript_path": "/tmp/t",
+        "cwd": "/tmp",
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+class TestSourceIsolation:
+    def test_package_does_not_import_sibling_adapters(self) -> None:
+        for path in CLAUDE_AGENT_SDK_SRC.glob("*.py"):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module:
+                    assert "langchain" not in node.module
+                    assert "crewai" not in node.module
+                    assert "openai_agents" not in node.module
+                    assert node.module != "arcjet.guard.langchain"
+                    assert node.module != "arcjet.guard.crewai"
+                    assert node.module != "arcjet.guard.openai_agents"
+                    assert node.module != "claude_agent_sdk"
+                    assert not node.module.startswith("claude_agent_sdk.")
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        assert "langchain" not in alias.name
+                        assert "crewai" not in alias.name
+                        assert "openai_agents" not in alias.name
+                        assert alias.name != "claude_agent_sdk"
+                        assert not alias.name.startswith("claude_agent_sdk.")
+
+    def test_core_guard_imports_with_peer_unimportable(self) -> None:
+        """The real invariant, in a process where the peer cannot import."""
+        program = """
+import sys
+
+class _Blocked:
+    def find_module(self, name, path=None):
+        return self.find_spec(name, path)
+
+    def find_spec(self, name, path=None, target=None):
+        if name == "claude_agent_sdk" or name.startswith("claude_agent_sdk."):
+            raise ImportError("claude_agent_sdk is blocked for this test")
+        return None
+
+sys.meta_path.insert(0, _Blocked())
+
+import arcjet.guard
+assert callable(arcjet.guard.guard)
+assert "claude_agent_sdk" not in sys.modules
+
+import arcjet.guard.claude_agent_sdk as adapter
+assert callable(adapter.guard_tool)
+assert callable(adapter.guard_hooks)
+assert callable(adapter.claude_agent_context)
+assert adapter.__all__ == ["guard_tool", "guard_hooks", "claude_agent_context"]
+assert not hasattr(adapter, "guard_inbound")
+assert not hasattr(adapter, "guard_can_use_tool")
+try:
+    adapter.guard_tool(guard=object(), tool=object(), action="x.done")
+except ImportError as exc:
+    assert "arcjet[claude-agent-sdk]" in str(exc), exc
+else:
+    raise AssertionError("expected an ImportError naming what to install")
+try:
+    adapter.guard_hooks(guard=object(), action="x.done")
+except ImportError as exc:
+    assert "arcjet[claude-agent-sdk]" in str(exc), exc
+else:
+    raise AssertionError("expected an ImportError naming what to install")
+print("ok")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", program],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "ok"
+
+
+class TestClaudeAgentContext:
+    def test_prefers_hook_session_id(self, reset_sequence_context) -> None:
+        ctx = claude_agent_context(
+            {"session_id": SESSION_ID},
+            session_id="11111111-1111-4111-8111-111111111111",
+        )
+        assert ctx.correlation_id == SESSION_ID
+
+    def test_falls_back_to_caller_owned_session_id(
+        self, reset_sequence_context
+    ) -> None:
+        ctx = claude_agent_context({}, session_id=SESSION_ID)
+        assert ctx.correlation_id == SESSION_ID
+
+    def test_never_mints_when_nothing_is_present(self, reset_sequence_context) -> None:
+        ctx = claude_agent_context({})
+        assert ctx.correlation_id is None
+        assert isinstance(ctx, ClaudeAgentContext)
+
+    def test_never_reads_trace_id(self, reset_sequence_context) -> None:
+        ctx = claude_agent_context({"trace_id": "tr_minted", "traceId": "tr2"})
+        assert ctx.correlation_id is None
+
+    def test_non_uuid_session_id_is_skipped(self, reset_sequence_context) -> None:
+        ctx = claude_agent_context({"session_id": "not-a-uuid"})
+        assert ctx.correlation_id is None
+        assert ctx.metadata is None
+
+    def test_invalid_session_id_is_skipped(self, reset_sequence_context) -> None:
+        ctx = claude_agent_context({"session_id": "not\nvalid"})
+        assert ctx.correlation_id is None
+
+    def test_falls_back_to_ambient_sequence(self, reset_sequence_context) -> None:
+        with arcjet_sequence(correlation_id="from-sequence"):
+            ctx = claude_agent_context({})
+        assert ctx.correlation_id == "from-sequence"
+
+    def test_agent_id_is_metadata_only(self, reset_sequence_context) -> None:
+        ctx = claude_agent_context(
+            {"session_id": SESSION_ID, "agent_id": "agent-9", "tool_name": "Bash"}
+        )
+        assert ctx.correlation_id == SESSION_ID
+        assert ctx.metadata is not None
+        assert ctx.metadata["claude.session"] == SESSION_ID
+        assert ctx.metadata["claude.agent"] == "agent-9"
+        assert ctx.metadata["claude.tool"] == "Bash"
+
+    def test_does_not_construct_a_session(self, reset_sequence_context) -> None:
+        session = SimpleNamespace(
+            getSessionId=lambda: (_ for _ in ()).throw(
+                AssertionError("must not call getSessionId")
+            )
+        )
+        ctx = claude_agent_context(session)
+        assert ctx.correlation_id is None
+
+
+class TestDenialPayload:
+    def test_rate_limit_is_retryable_and_may_include_retry_after(self) -> None:
+        decision = make_deny_decision(
+            reason="RATE_LIMIT",
+            results=(
+                RuleResultTokenBucket(
+                    conclusion="DENY",
+                    reset_at_unix_seconds=2_000_000_000,
+                ),
+            ),
+        )
+        payload = denial_result(decision)
+        assert payload["arcjetDenied"] is True
+        assert payload["reason"] == "RATE_LIMIT"
+        assert payload["retryable"] is True
+        assert "retryAfterSeconds" in payload
+
+    def test_non_rate_limit_is_not_retryable(self) -> None:
+        decision = make_deny_decision(reason="PROMPT_INJECTION")
+        payload = denial_result(decision)
+        assert payload["retryable"] is False
+        assert "retryAfterSeconds" not in payload
+
+    def test_unavailable_is_retryable_with_fixed_backoff(self) -> None:
+        payload = unavailable_result()
+        assert payload == {
+            "arcjetDenied": True,
+            "reason": "ERROR",
+            "message": "Arcjet security check could not be completed; please retry later.",
+            "retryable": True,
+            "retryAfterSeconds": UNAVAILABLE_RETRY_AFTER_SECONDS,
+        }
+
+    def test_dumps_is_json_the_model_can_read(self) -> None:
+        raw = dumps_denial(unavailable_result())
+        parsed = json.loads(raw)
+        assert parsed["arcjetDenied"] is True
+
+    def test_denial_tool_result_has_no_structured_content(self) -> None:
+        result = denial_tool_result(unavailable_result())
+        assert result["is_error"] is True
+        assert "structuredContent" not in result
+        assert "structured_content" not in result
+        text = result["content"][0]["text"]
+        assert json.loads(text)["arcjetDenied"] is True
+
+    def test_retry_after_ignores_allow_results_with_reset_at(self) -> None:
+        decision = make_deny_decision(
+            reason="RATE_LIMIT",
+            results=(
+                RuleResultTokenBucket(
+                    conclusion="ALLOW",
+                    reset_at_unix_seconds=9_999_999_999,
+                ),
+                RuleResultTokenBucket(
+                    conclusion="DENY",
+                    reset_at_unix_seconds=2_000_000_000,
+                ),
+            ),
+        )
+        retry_after = retry_after_seconds(decision)
+        assert retry_after is not None
+        payload = denial_result(decision)
+        assert payload.get("retryAfterSeconds") == retry_after
+
+
+class TestEvaluateHandler:
+    """arcjet-py has no pytest-asyncio; drive coroutines with ``asyncio.run``."""
+
+    def test_deny_envelope_is_content_plus_is_error_not_a_throw(
+        self, reset_sequence_context
+    ) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        verdict = asyncio.run(
+            evaluate_handler({"value": "hello"}, _tool_config(guard=client))
+        )
+        assert verdict.deny is True
+        result = handler_denial_result(verdict)
+        assert result["is_error"] is True
+        assert "structuredContent" not in result
+        payload = json.loads(result["content"][0]["text"])
+        assert payload["arcjetDenied"] is True
+        assert payload["reason"] == "RATE_LIMIT"
+        assert client.captures[0]["metadata"]["outcome"] == "denied"
+
+    def test_allow_does_not_deny(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        verdict = asyncio.run(
+            evaluate_handler({"value": "hello"}, _tool_config(guard=client))
+        )
+        assert verdict.deny is False
+        assert client.captures[0]["metadata"]["outcome"] == "success"
+
+    def test_unavailable_fail_closed(self, reset_sequence_context) -> None:
+        client = StubGuardClient(exception=RuntimeError("down"))
+        verdict = asyncio.run(evaluate_handler({}, _tool_config(guard=client)))
+        assert verdict.deny is True
+        result = handler_denial_result(verdict)
+        payload = json.loads(result["content"][0]["text"])
+        assert payload["reason"] == "ERROR"
+        assert payload["retryable"] is True
+        assert client.captures[0]["metadata"]["outcome"] == "unavailable"
+
+    def test_unavailable_allow_proceeds(self, reset_sequence_context) -> None:
+        client = StubGuardClient(exception=RuntimeError("down"))
+        verdict = asyncio.run(
+            evaluate_handler({}, _tool_config(guard=client, on_guard_error="allow"))
+        )
+        assert verdict.deny is False
+
+    def test_failed_open_fail_closed(self, reset_sequence_context) -> None:
+        decision = make_allow_decision(
+            results=(RuleResultError(code="TIMEOUT", message="deadline"),)
+        )
+        assert decision.has_failed_open()
+        client = StubGuardClient(decision=decision)
+        verdict = asyncio.run(evaluate_handler({}, _tool_config(guard=client)))
+        assert verdict.deny is True
+        payload = json.loads(handler_denial_result(verdict)["content"][0]["text"])
+        assert payload["reason"] == "ERROR"
+
+    def test_policy_factory_throw_fail_closed(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+
+        def boom(_arguments: Mapping[str, Any]) -> PolicyInputMap:
+            raise RuntimeError("resolver exploded")
+
+        verdict = asyncio.run(
+            evaluate_handler({}, _tool_config(guard=client, inputs=boom))
+        )
+        assert verdict.deny is True
+        assert len(client.guards) == 1
+
+    def test_rules_factory_throw_fail_closed(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+
+        def boom(_arguments: Mapping[str, Any]) -> list[Any]:
+            raise RuntimeError("no rules")
+
+        verdict = asyncio.run(
+            evaluate_handler({}, _tool_config(guard=client, rules=boom))
+        )
+        assert verdict.deny is True
+        assert client.captures[0]["metadata"]["outcome"] == "unavailable"
+
+    def test_uses_policy_session_id_never_mints(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        asyncio.run(
+            evaluate_handler({}, _tool_config(guard=client, session_id=SESSION_ID))
+        )
+        assert client.guards[0]["correlation_id"] == SESSION_ID
+
+    def test_never_mints_without_a_caller_id(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        asyncio.run(evaluate_handler({}, _tool_config(guard=client)))
+        assert client.guards[0]["correlation_id"] is None
+
+    def test_resolver_sees_handler_arguments(self, reset_sequence_context) -> None:
+        seen: list[Mapping[str, Any]] = []
+
+        def actor(arguments: Mapping[str, Any]) -> str:
+            seen.append(dict(arguments))
+            return str(arguments["user_id"])
+
+        client = StubGuardClient(decision=make_allow_decision())
+        verdict = asyncio.run(
+            evaluate_handler(
+                {"user_id": "u_1", "body": "hello"},
+                _tool_config(guard=client, actor=actor),
+            )
+        )
+        assert verdict.deny is False
+        assert seen == [{"user_id": "u_1", "body": "hello"}]
+        assert client.guards[0]["actor"] == "u_1"
+
+
+class TestArgumentsFromHandler:
+    def test_accepts_a_mapping(self) -> None:
+        assert _arguments_from_handler({"value": "x"}) == {"value": "x"}
+
+    def test_non_mapping_is_empty_not_an_exception(self) -> None:
+        assert _arguments_from_handler("{not-json") == {}
+        assert _arguments_from_handler(None) == {}
+
+
+class TestEvaluatePreToolUse:
+    def test_deny_is_permission_decision_deny(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        verdict = asyncio.run(
+            evaluate_pre_tool_use(_pre_input(), _hook_config(guard=client))
+        )
+        assert verdict.deny is True
+        output = pre_tool_use_output(verdict)
+        specific = output["hookSpecificOutput"]
+        assert specific["hookEventName"] == "PreToolUse"
+        assert specific["permissionDecision"] == "deny"
+        assert specific["permissionDecision"] != "ask"
+        assert client.captures[0]["metadata"]["outcome"] == "denied"
+
+    def test_allow_is_empty_output(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        verdict = asyncio.run(
+            evaluate_pre_tool_use(_pre_input(), _hook_config(guard=client))
+        )
+        assert verdict.deny is False
+        assert pre_tool_use_output(verdict) == {}
+
+    def test_unavailable_fail_closed(self, reset_sequence_context) -> None:
+        client = StubGuardClient(exception=RuntimeError("down"))
+        verdict = asyncio.run(
+            evaluate_pre_tool_use(_pre_input(), _hook_config(guard=client))
+        )
+        assert verdict.deny is True
+        assert (
+            pre_tool_use_output(verdict)["hookSpecificOutput"]["permissionDecision"]
+            == "deny"
+        )
+
+    def test_wrapped_tool_is_excluded_from_pre_tool_use(
+        self, reset_sequence_context
+    ) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        excluded = excluded_names([{"server": "support", "name": "lookup_order"}])
+        verdict = asyncio.run(
+            evaluate_pre_tool_use(
+                _pre_input(tool_name="mcp__support__lookup_order"),
+                _hook_config(guard=client, exclude=excluded),
+            )
+        )
+        assert verdict.deny is False
+        assert client.guards == []
+
+    def test_bare_authored_name_is_not_an_exclude_match(
+        self, reset_sequence_context
+    ) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        excluded = excluded_names([{"server": "support", "name": "lookup_order"}])
+        verdict = asyncio.run(
+            evaluate_pre_tool_use(
+                _pre_input(tool_name="lookup_order"),
+                _hook_config(guard=client, exclude=excluded),
+            )
+        )
+        assert verdict.deny is True
+        assert len(client.guards) == 1
+
+    def test_other_server_same_name_is_still_gated(
+        self, reset_sequence_context
+    ) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        excluded = excluded_names([{"server": "support", "name": "lookup_order"}])
+        verdict = asyncio.run(
+            evaluate_pre_tool_use(
+                _pre_input(tool_name="mcp__other__lookup_order"),
+                _hook_config(guard=client, exclude=excluded),
+            )
+        )
+        assert verdict.deny is True
+
+    def test_correlation_from_hook_session_id(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        asyncio.run(evaluate_pre_tool_use(_pre_input(), _hook_config(guard=client)))
+        assert client.guards[0]["correlation_id"] == SESSION_ID
+
+    def test_never_mints_without_a_caller_id(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        asyncio.run(
+            evaluate_pre_tool_use(
+                _pre_input(session_id="not-a-uuid"), _hook_config(guard=client)
+            )
+        )
+        assert client.guards[0]["correlation_id"] is None
+
+
+class TestEvaluateUserPromptSubmit:
+    def test_deny_is_decision_block(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        verdict = asyncio.run(
+            evaluate_user_prompt_submit(_prompt_input(), _inbound_config(guard=client))
+        )
+        assert verdict.block is True
+        output = user_prompt_submit_output(verdict)
+        assert output["decision"] == "block"
+        assert "reason" in output
+        assert client.captures[0]["metadata"]["outcome"] == "denied"
+
+    def test_allow_is_empty_output(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        verdict = asyncio.run(
+            evaluate_user_prompt_submit(_prompt_input(), _inbound_config(guard=client))
+        )
+        assert verdict.block is False
+        assert user_prompt_submit_output(verdict) == {}
+
+    def test_unavailable_fail_closed(self, reset_sequence_context) -> None:
+        client = StubGuardClient(exception=RuntimeError("down"))
+        verdict = asyncio.run(
+            evaluate_user_prompt_submit(_prompt_input(), _inbound_config(guard=client))
+        )
+        assert verdict.block is True
+        assert user_prompt_submit_output(verdict)["decision"] == "block"
+
+    def test_unavailable_allow_proceeds(self, reset_sequence_context) -> None:
+        client = StubGuardClient(exception=RuntimeError("down"))
+        verdict = asyncio.run(
+            evaluate_user_prompt_submit(
+                _prompt_input(),
+                _inbound_config(guard=client, on_guard_error="allow"),
+            )
+        )
+        assert verdict.block is False
+
+    def test_rules_see_prompt(self, reset_sequence_context) -> None:
+        seen: list[Mapping[str, Any]] = []
+
+        def rules(arguments: Mapping[str, Any]) -> list[Any]:
+            seen.append(dict(arguments))
+            return []
+
+        client = StubGuardClient(decision=make_allow_decision())
+        asyncio.run(
+            evaluate_user_prompt_submit(
+                _prompt_input(prompt="inject me"),
+                _inbound_config(guard=client, rules=rules),
+            )
+        )
+        assert seen == [{"prompt": "inject me"}]
+
+
+class TestExcludeNames:
+    def test_qualifies_server_and_name(self) -> None:
+        assert mcp_tool_name("support", "lookup_order") == "mcp__support__lookup_order"
+        assert (
+            exclude_name({"server": "support", "name": "lookup_order"})
+            == "mcp__support__lookup_order"
+        )
+
+    def test_bare_string_is_exact(self) -> None:
+        assert exclude_name("Bash") == "Bash"
+
+    def test_mapping_requires_server_and_name(self) -> None:
+        with pytest.raises(ValueError, match="server"):
+            exclude_name({"name": "lookup_order"})
+        with pytest.raises(ValueError, match="name"):
+            exclude_name({"server": "support"})
+
+
+class TestGuardToolValidation:
+    def test_invalid_on_guard_error_is_refused(self) -> None:
+        with pytest.raises(ArcjetMisconfiguration, match="on_guard_error"):
+            guard_tool(
+                guard=StubGuardClient(),
+                tool=object(),
+                action="x.done",
+                on_guard_error="maybe",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_session_id_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="printable ASCII"):
+            guard_tool(
+                guard=StubGuardClient(),
+                tool=object(),
+                action="x.done",
+                session_id="not\nvalid",
+            )
+
+
+class TestGuardHooksValidation:
+    def test_invalid_on_guard_error_is_refused(self) -> None:
+        with pytest.raises(ArcjetMisconfiguration, match="on_guard_error"):
+            guard_hooks(on_guard_error="maybe")  # type: ignore[arg-type]
+
+    def test_neither_tool_nor_inbound_is_refused(self) -> None:
+        with pytest.raises(ArcjetMisconfiguration, match="inbound"):
+            guard_hooks()
+
+    def test_inbound_without_action_is_refused(self) -> None:
+        with pytest.raises(ArcjetMisconfiguration, match="action"):
+            guard_hooks(inbound={"rules": ()})
+
+
+class TestMissingPeer:
+    def test_guard_tool_names_what_to_install(self) -> None:
+        if claude_agent_sdk_present():
+            pytest.skip("claude-agent-sdk is installed in this environment")
+        with pytest.raises(ImportError, match=r"arcjet\[claude-agent-sdk\]"):
+            guard_tool(guard=StubGuardClient(), tool=object(), action="x.done")
+
+    def test_guard_hooks_names_what_to_install(self) -> None:
+        if claude_agent_sdk_present():
+            pytest.skip("claude-agent-sdk is installed in this environment")
+        with pytest.raises(ImportError, match=r"arcjet\[claude-agent-sdk\]"):
+            guard_hooks(action="x.done")
+
+    def test_load_sdk_mcp_tool_names_what_to_install(self) -> None:
+        if claude_agent_sdk_present():
+            pytest.skip("claude-agent-sdk is installed in this environment")
+        with pytest.raises(ImportError, match="needs the Claude Agent SDK"):
+            load_sdk_mcp_tool()
+
+
+class TestVersionFloor:
+    def test_release_parsing(self) -> None:
+        assert _release("0.2.127") == (0, 2, 127)
+        assert _release("0.2.148") == (0, 2, 148)
+        assert _release("0.2.148rc1") == (0, 2, 148)
+        assert _release("1.0.0") == (1, 0, 0)
+        assert _release("weird") == ()
+
+    def test_below_the_floor_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(import_module, "_installed_version", lambda: "0.2.83")
+        with pytest.raises(
+            ArcjetMisconfiguration, match="needs claude-agent-sdk >= 0.2.127"
+        ):
+            import_module._require_claude_agent_sdk()
+
+    def test_at_or_above_the_floor_is_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for installed in ("0.2.127", "0.2.148", "0.3.0"):
+            monkeypatch.setattr(
+                import_module, "_installed_version", lambda v=installed: v
+            )
+            import_module._require_claude_agent_sdk()
+
+    def test_absent_peer_is_left_to_the_import(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(import_module, "_installed_version", lambda: None)
+        import_module._require_claude_agent_sdk()
+
+
+class TestFailClosedHelperVsFailOpenProtect:
+    def test_helper_denies_the_same_failed_open_protect_would_allow(
+        self, reset_sequence_context
+    ) -> None:
+        """``protect()`` / core ``guard()`` fail open; these helpers do not.
+
+        A decision with an error result is the shape ``protect()`` returns
+        when evaluation did not finish: ``has_failed_open()`` is True and
+        the conclusion is still ALLOW. The helper treats that as a deny.
+        """
+        decision = make_allow_decision(
+            results=(RuleResultError(code="TIMEOUT", message="deadline"),)
+        )
+        assert decision.conclusion == "ALLOW"
+        assert decision.has_failed_open()
+        client = StubGuardClient(decision=decision)
+        verdict = asyncio.run(evaluate_handler({}, _tool_config(guard=client)))
+        assert verdict.deny is True
+        result = handler_denial_result(verdict)
+        assert result["is_error"] is True
+        assert "structuredContent" not in result
+
+
+def test_public_exports_are_only_the_locked_names() -> None:
+    from arcjet.guard import claude_agent_sdk as adapter
+
+    assert adapter.__all__ == ["guard_tool", "guard_hooks", "claude_agent_context"]
+    assert not hasattr(adapter, "guard_inbound")
+    assert not hasattr(adapter, "guard_can_use_tool")
+
+
+def test_brand_constant_is_stable() -> None:
+    assert _GUARD_BRAND == "_arcjet_guarded"
+
+
+def test_pre_tool_use_ask_is_never_emitted() -> None:
+    output = pre_tool_use_output(PreToolUseVerdict(deny=True, reason="no"))
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+    output = pre_tool_use_output(PreToolUseVerdict(deny=False))
+    assert "permissionDecision" not in output.get("hookSpecificOutput", {})
+
+
+def test_user_prompt_submit_block_shape() -> None:
+    output = user_prompt_submit_output(UserPromptSubmitVerdict(block=True, reason="no"))
+    assert output == {"decision": "block", "reason": "no"}

--- a/tests/unit/guard/test_claude_agent_sdk.py
+++ b/tests/unit/guard/test_claude_agent_sdk.py
@@ -675,7 +675,7 @@ class TestMissingPeer:
         if claude_agent_sdk_present():
             pytest.skip("claude-agent-sdk is installed in this environment")
         with pytest.raises(ImportError, match=r"arcjet\[claude-agent-sdk\]"):
-            guard_hooks(action="x.done")
+            guard_hooks(guard=StubGuardClient(), action="x.done")
 
     def test_load_sdk_mcp_tool_names_what_to_install(self) -> None:
         if claude_agent_sdk_present():

--- a/tests/unit/guard/test_claude_agent_sdk.py
+++ b/tests/unit/guard/test_claude_agent_sdk.py
@@ -47,6 +47,9 @@ from arcjet.guard.claude_agent_sdk._hooks import (
     UserPromptSubmitVerdict,
     _HookConfig,
     _InboundConfig,
+    _tool_call,
+    _tool_hooks_requested,
+    capture_post_tool_use,
     evaluate_pre_tool_use,
     evaluate_user_prompt_submit,
     pre_tool_use_output,
@@ -134,6 +137,21 @@ def _pre_input(**kwargs: object) -> dict[str, object]:
         "session_id": SESSION_ID,
         "tool_name": "Bash",
         "tool_input": {"command": "ls"},
+        "tool_use_id": "tu_1",
+        "transcript_path": "/tmp/t",
+        "cwd": "/tmp",
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _post_input(**kwargs: object) -> dict[str, object]:
+    defaults: dict[str, object] = {
+        "hook_event_name": "PostToolUse",
+        "session_id": SESSION_ID,
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls"},
+        "tool_response": {"content": [{"type": "text", "text": "ok"}]},
         "tool_use_id": "tu_1",
         "transcript_path": "/tmp/t",
         "cwd": "/tmp",
@@ -481,6 +499,21 @@ class TestEvaluatePreToolUse:
         assert specific["permissionDecision"] == "deny"
         assert specific["permissionDecision"] != "ask"
         assert client.captures[0]["metadata"]["outcome"] == "denied"
+        assert client.captures[0]["metadata"]["claude.phase"] == "before"
+
+    def test_rules_see_tool_name_and_tool_input(self, reset_sequence_context) -> None:
+        seen: list[Mapping[str, Any]] = []
+
+        def rules(arguments: Mapping[str, Any]) -> list[Any]:
+            seen.append(dict(arguments))
+            return []
+
+        client = StubGuardClient(decision=make_allow_decision())
+        asyncio.run(
+            evaluate_pre_tool_use(_pre_input(), _hook_config(guard=client, rules=rules))
+        )
+        assert seen == [{"command": "ls", "tool_name": "Bash"}]
+        assert client.guards[0]["metadata"]["claude.phase"] == "before"
 
     def test_allow_is_empty_output(self, reset_sequence_context) -> None:
         client = StubGuardClient(decision=make_allow_decision())
@@ -568,6 +601,7 @@ class TestEvaluateUserPromptSubmit:
         assert output["decision"] == "block"
         assert "reason" in output
         assert client.captures[0]["metadata"]["outcome"] == "denied"
+        assert client.captures[0]["metadata"]["claude.phase"] == "inbound"
 
     def test_allow_is_empty_output(self, reset_sequence_context) -> None:
         client = StubGuardClient(decision=make_allow_decision())
@@ -612,6 +646,47 @@ class TestEvaluateUserPromptSubmit:
         assert seen == [{"prompt": "inject me"}]
 
 
+class TestToolCallEnvelope:
+    def test_includes_tool_name_last(self) -> None:
+        assert _tool_call(
+            {"tool_name": "Bash", "tool_input": {"command": "ls", "tool_name": "nope"}}
+        ) == {"command": "ls", "tool_name": "Bash"}
+
+    def test_empty_without_a_mapping(self) -> None:
+        assert _tool_call({"tool_name": "Bash"}) == {"tool_name": "Bash"}
+
+
+class TestCapturePostToolUse:
+    def test_is_empty_output_and_does_not_re_evaluate(
+        self, reset_sequence_context
+    ) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        excluded = excluded_names([{"server": "support", "name": "lookup_order"}])
+        output = capture_post_tool_use(
+            _post_input(tool_name="mcp__support__lookup_order"),
+            _hook_config(guard=client, exclude=excluded),
+        )
+        assert output == {}
+        assert client.guards == []
+        assert len(client.captures) == 1
+        assert client.captures[0]["metadata"]["claude.phase"] == "after"
+        assert client.captures[0]["metadata"]["outcome"] == "success"
+        assert (
+            client.captures[0]["metadata"]["claude.tool"]
+            == "mcp__support__lookup_order"
+        )
+
+    def test_never_raises(self, reset_sequence_context) -> None:
+        def boom(_arguments: Mapping[str, Any]) -> dict[str, str]:
+            raise RuntimeError("metadata exploded")
+
+        output = capture_post_tool_use(
+            _post_input(),
+            _hook_config(metadata=boom),
+        )
+        assert output == {}
+
+
 class TestExcludeNames:
     def test_qualifies_server_and_name(self) -> None:
         assert mcp_tool_name("support", "lookup_order") == "mcp__support__lookup_order"
@@ -649,6 +724,15 @@ class TestGuardToolValidation:
                 session_id="not\nvalid",
             )
 
+    def test_non_uuid_session_id_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="UUID"):
+            guard_tool(
+                guard=StubGuardClient(),
+                tool=object(),
+                action="x.done",
+                session_id="run-abc",
+            )
+
 
 class TestGuardHooksValidation:
     def test_invalid_on_guard_error_is_refused(self) -> None:
@@ -659,9 +743,67 @@ class TestGuardHooksValidation:
         with pytest.raises(ArcjetMisconfiguration, match="inbound"):
             guard_hooks()
 
+    def test_actor_alone_does_not_register_tool_hooks(self) -> None:
+        with pytest.raises(ArcjetMisconfiguration, match="inbound"):
+            guard_hooks(actor="user-1")
+
     def test_inbound_without_action_is_refused(self) -> None:
         with pytest.raises(ArcjetMisconfiguration, match="action"):
             guard_hooks(inbound={"rules": ()})
+
+    def test_non_uuid_session_id_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="UUID"):
+            guard_hooks(action="x.done", session_id="run-abc")
+
+    def test_inbound_non_uuid_session_id_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="UUID"):
+            guard_hooks(inbound={"action": "message.received", "session_id": "run-abc"})
+
+    def test_inbound_invalid_session_id_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="printable ASCII"):
+            guard_hooks(
+                inbound={"action": "message.received", "session_id": "not\nvalid"}
+            )
+
+    def test_inbound_non_str_session_id_is_refused(self) -> None:
+        with pytest.raises(TypeError, match="session_id"):
+            guard_hooks(inbound={"action": "message.received", "session_id": 1})
+
+    def test_tools_must_be_bool(self) -> None:
+        with pytest.raises(TypeError, match="tools"):
+            guard_hooks(tools=["Bash"])  # type: ignore[arg-type]
+
+
+class TestToolHooksRequested:
+    def test_actor_and_inputs_are_not_a_tool_signal(self) -> None:
+        assert (
+            _tool_hooks_requested(action=None, rules=(), exclude=None, tools=False)
+            is False
+        )
+
+    def test_tools_true_is_enough(self) -> None:
+        assert (
+            _tool_hooks_requested(action=None, rules=(), exclude=None, tools=True)
+            is True
+        )
+
+    def test_action_or_rules_or_exclude_register(self) -> None:
+        assert (
+            _tool_hooks_requested(
+                action="tool.invoked", rules=(), exclude=None, tools=False
+            )
+            is True
+        )
+        assert (
+            _tool_hooks_requested(
+                action=None, rules=lambda _c: [], exclude=None, tools=False
+            )
+            is True
+        )
+        assert (
+            _tool_hooks_requested(action=None, rules=(), exclude=["Bash"], tools=False)
+            is True
+        )
 
 
 class TestMissingPeer:

--- a/tests/unit/guard/test_claude_agent_sdk.py
+++ b/tests/unit/guard/test_claude_agent_sdk.py
@@ -46,6 +46,7 @@ from arcjet.guard.claude_agent_sdk._hooks import (
     PreToolUseVerdict,
     UserPromptSubmitVerdict,
     _HookConfig,
+    _inbound_session_id,
     _InboundConfig,
     _tool_call,
     _tool_hooks_requested,
@@ -68,6 +69,7 @@ from arcjet.guard.claude_agent_sdk._names import (
 from arcjet.guard.claude_agent_sdk._tool import (
     _GUARD_BRAND,
     _arguments_from_handler,
+    _brand,
     _ToolConfig,
     evaluate_handler,
     handler_denial_result,
@@ -769,6 +771,10 @@ class TestGuardHooksValidation:
         with pytest.raises(TypeError, match="session_id"):
             guard_hooks(inbound={"action": "message.received", "session_id": 1})
 
+    def test_inbound_none_session_id_clears_the_fallback(self) -> None:
+        assert _inbound_session_id({"session_id": None}, session_id=SESSION_ID) is None
+        assert _inbound_session_id({"action": "x"}, session_id=SESSION_ID) == SESSION_ID
+
     def test_tools_must_be_bool(self) -> None:
         with pytest.raises(TypeError, match="tools"):
             guard_hooks(tools=["Bash"])  # type: ignore[arg-type]
@@ -833,6 +839,11 @@ class TestVersionFloor:
         assert _release("0.2.148rc1") == (0, 2, 148)
         assert _release("1.0.0") == (1, 0, 0)
         assert _release("weird") == ()
+        # Short / non-numeric third chunks collapse below the floor, they
+        # are not treated as unknown and skipped.
+        assert _release("0.2") == (0, 2)
+        assert _release("0.2.post1") == (0, 2)
+        assert _release("0.2") < import_module.MINIMUM_CLAUDE_AGENT_SDK
 
     def test_below_the_floor_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(import_module, "_installed_version", lambda: "0.2.83")
@@ -890,6 +901,14 @@ def test_public_exports_are_only_the_locked_names() -> None:
 
 def test_brand_constant_is_stable() -> None:
     assert _GUARD_BRAND == "_arcjet_guarded"
+
+
+def test_brand_slots_without_the_attribute_fail_loudly() -> None:
+    class Slotted:
+        __slots__ = ()
+
+    with pytest.raises(TypeError, match=_GUARD_BRAND):
+        _brand(Slotted())
 
 
 def test_pre_tool_use_ask_is_never_emitted() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+claude-agent-sdk = [
+    { name = "claude-agent-sdk" },
+]
 langchain = [
     { name = "langchain-core" },
 ]
@@ -99,6 +102,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "arcjet-sensitive-info-rampart", marker = "extra == 'sensitive-info-rampart'", editable = "sensitive-info-rampart" },
+    { name = "claude-agent-sdk", marker = "extra == 'claude-agent-sdk'", specifier = ">=0.2.127,<1" },
     { name = "connect-python", specifier = ">=0.8.1" },
     { name = "langchain", marker = "extra == 'langchain-agents'", specifier = ">=1.3,<2" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.2.5,<2" },
@@ -108,7 +112,7 @@ requires-dist = [
     { name = "pyqwest", specifier = ">=0.9.0,<0.10.0" },
     { name = "wasmtime", specifier = ">=47.0.1,<47.1.0" },
 ]
-provides-extras = ["sensitive-info-rampart", "langchain", "langchain-agents", "openai-agents"]
+provides-extras = ["sensitive-info-rampart", "langchain", "langchain-agents", "openai-agents", "claude-agent-sdk"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -375,6 +379,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
     { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
     { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "claude-agent-sdk"
+version = "0.2.144"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "jsonschema" },
+    { name = "mcp" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/e0/00d873adf589a4ba7899bc7e6ab5306fa55c8e9f4a2313a6f5fef95a473b/claude_agent_sdk-0.2.144.tar.gz", hash = "sha256:bf3df9930024bb7cf963313321af59b9ad7b6a13ec28bea6b864f457cff9afbc", size = 344707, upload-time = "2026-08-21T20:12:01.28Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/c6/3623b5e32d903a359f0daca3b9bd5e3ca4a501e104fafbdd32bf80c6d624/claude_agent_sdk-0.2.144-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a69da08f88518695630cf88155ad5888e9c2f322b05ef4e96bb4e5460b815544", size = 92931035, upload-time = "2026-08-21T20:12:06.801Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/bd/ba760bd6c7bae939105e50df983eea65ec0cba86f748c4abbedb8abbd8eb/claude_agent_sdk-0.2.144-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e685e624f598249a215a2db57c3a2fbbea5a7f7078a4cc632e099dedca303a69", size = 97959616, upload-time = "2026-08-21T20:12:11.838Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/946d37a573b52be868dbcac349fcdd2090b43ea31273d2ff7e71cfd6fd99/claude_agent_sdk-0.2.144-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:8fb664212f3eca5b0e4081f71ff8ccdf72b15e57609ff0c93e626bfea914360a", size = 102347684, upload-time = "2026-08-21T20:12:17.582Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bc/b3b859736291b73d3065a0eb69149f39fbbe61cd800087b085690f944df0/claude_agent_sdk-0.2.144-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:8aa83aa3ea4f51ca6db113a5fe27c10db25e2af99ba0eed140738141d99a0837", size = 103339972, upload-time = "2026-08-21T20:12:25.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `arcjet.guard.claude_agent_sdk` behind the `arcjet[claude-agent-sdk]` extra (`claude-agent-sdk>=0.2.127,<1`). Independent of LangChain, CrewAI, and OpenAI Agents: nothing outside this package imports `claude_agent_sdk`, and the extra is not in the `dev` group so `uv.lock` does not pull its tree into every install.

Three names only: `guard_tool`, `guard_hooks`, `claude_agent_context`. There is no `guard_inbound` and no `guard_can_use_tool` (`can_use_tool` is HITL). Helpers default to `on_guard_error="deny"`; core `guard()` / `protect()` stay fail-open.

### Wrap an authored tool

On DENY the handler never runs. The model sees an MCP tool result — `create_sdk_mcp_server` copies only `content` + `is_error`, so the JS-shaped JSON envelope lives in a text block. Do not throw (the SDK swallows into `str(e)`). Do not set `structuredContent`.

```py
from arcjet.guard import launch_arcjet
from arcjet.guard.claude_agent_sdk import guard_tool
from claude_agent_sdk import tool

aj = launch_arcjet(key=arcjet_key)

@tool("send_email", "Send an email", {"to": str, "body": str})
async def send_email(args):
    return {"content": [{"type": "text", "text": "sent"}]}

guarded = guard_tool(
    guard=aj,
    tool=send_email,
    action="email.sent",
    session_id=session_id,  # caller-owned UUID; authored handler has no extra.session_id
)
```

### Gate built-ins / inbound with hooks

`PreToolUse` denies unwrapped built-ins and MCP (`permissionDecision: "deny"`, never `"ask"`). `PostToolUse` is capture-only (`claude.phase: after`; `exclude` does not skip it). `UserPromptSubmit` blocks inbound when `inbound=` is set. List every `guard_tool` wrapper in `exclude` as `{"server": ..., "name": ...}` so `mcp__{server}__{name}` is not double-gated. `actor=` / `inputs=` do not register a tool hook by themselves; pass `tools=True` for the default `{tool_name}.invoked` gate.

Tool-hook `rules` / `actor` / `inputs` / `metadata` receive `tool_input` plus `tool_name`. Wrap-time `session_id=` / `correlation_id=` (including `inbound["session_id"]`) must be a UUID.

```py
from arcjet.guard import DetectPromptInjection, TokenBucket, launch_arcjet
from arcjet.guard.claude_agent_sdk import guard_hooks, guard_tool

mcp_limit = TokenBucket(refill_rate=20, interval_seconds=60, max_tokens=20)

hooks = guard_hooks(
    guard=aj,
    session_id=session_id,
    action=lambda hook: f"{hook['tool_name']}.invoked",
    rules=lambda call: [mcp_limit(key=call["tool_name"], requested=1)],
    exclude=[{"server": "mail", "name": "send_email"}],
    inbound={
        "action": "message.received",
        "rules": lambda arguments: [DetectPromptInjection()(arguments["prompt"])],
    },
)
```

### Correlation

`claude_agent_context` reads hook `session_id`, then the `session_id=` fallback, then `arcjet_sequence()`. Never mints. Never reads `trace_id`. Subagent `agent_id` is `claude.agent` metadata only.

### Also in this branch

- Unit tests run without the extra (lazy import). Integration tests `importorskip` when it is absent.
- README / AGENTS / CONTRIBUTING notes. Docs slug is `/guards/claude-agent-sdk-py/` — it does not overwrite the JS `/guards/claude-agent-sdk/` page.
- No `fastapi-claude-agent-sdk-guard` example in this PR (example comes after a SHA).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3428bab3-a44d-4203-972f-02fb6f62242f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3428bab3-a44d-4203-972f-02fb6f62242f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

