### PR TITLE
feat(guard): Claude Managed Agents extra (`arcjet.guard.claude_managed_agents`)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,8 +185,22 @@ keeping the existing API surface intact with internal changes.
   `{tool_name}.invoked` gate. Wrap-time `session_id=` / `correlation_id=`
   must be a UUID. Wrapped tools are excluded from PreToolUse by the
   `mcp__{server}__{name}` name. `claude_agent_context` reads a caller-owned
-  UUID `session_id` and never mints, never reads `trace_id`. `can_use_tool`
+  UUID `session_id` and never mints, never reads `trace_id`.   `can_use_tool`
   is HITL and is not wrapped. Already-branded tools are skipped.
+- `src/arcjet/guard/claude_managed_agents/` — Optional Claude Managed
+  Agents integration (`arcjet[claude-managed-agents]`, peer
+  `anthropic>=0.92.0,<2`). Hosted REST+SSE, beta
+  `managed-agents-2026-04-01`. Independent of LangChain, CrewAI, OpenAI
+  Agents, and the Claude Agent SDK: it must not import any of them.
+  There is no PreToolUse. `guard_custom_tool` runs Guard before the app
+  executes on `agent.custom_tool_use`; on DENY it does not run the tool
+  and sends `user.custom_tool_result` (`is_error` is on that schema).
+  `guard_events` gates `user.message` / `initial_events` before
+  `sessions.events.send`. `claude_managed_agents_context` reads a
+  caller-owned id and never mints, never reads Anthropic session/event
+  `id`, never reads `trace_id`. Default `always_allow` cannot be gated.
+  `web_search` / `web_fetch` always run on Anthropic. Do not export
+  `guard_tool`, `guard_hooks`, or `guard_inbound`.
 - `src/arcjet/_analyze/` — WASM component integration with typed Python bindings.
   See `docs/WITGEN.md` for binding generation and
   `docs/WASMTIME.md` for wasmtime-py details.
@@ -218,6 +232,11 @@ deliberately kept apart and **must not be merged**:
   openai-agents. The floor is 0.2.127 (0.2.83 was mcp CVE + timeout
   fail-close; 0.2.127 includes that and the background-task PreToolUse
   stdin fix). Verified on 0.2.148.
+- `claude-managed-agents` → `anthropic>=0.92.0,<2`. Enough for
+  `arcjet.guard.claude_managed_agents`. No chromadb. Same lockfile
+  policy as openai-agents. The floor is 0.92.0 (first
+  `client.beta.agents` / `sessions` / `environments`). This is not the
+  Claude Agent SDK extra.
 There is deliberately **no `crewai` extra and no CrewAI dependency group**.
 `crewai` hard-depends on `chromadb~=1.1.0`, and chromadb 1.0.0–1.5.9 all carry
 an unpatched critical RCE (CVE-2026-45829). No fixed version exists and
@@ -237,7 +256,10 @@ Arcjet Guard must never require LangChain to be installed. Nothing outside
 `src/arcjet/guard/crewai/` may import CrewAI. Nothing outside
 `src/arcjet/guard/openai_agents/` may import the OpenAI Agents SDK
 (`agents`). Nothing outside `src/arcjet/guard/claude_agent_sdk/` may
-import the Claude Agent SDK (`claude_agent_sdk`).
+import the Claude Agent SDK (`claude_agent_sdk`). Nothing outside
+`src/arcjet/guard/claude_managed_agents/` may import the Anthropic SDK
+(`anthropic`). `claude_managed_agents` must not import
+`arcjet.guard.claude_agent_sdk`.
 
 ## Coding conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,10 +195,13 @@ keeping the existing API surface intact with internal changes.
   There is no PreToolUse. `guard_custom_tool` runs Guard before the app
   executes on `agent.custom_tool_use`; on DENY it does not run the tool
   and sends `user.custom_tool_result` (`is_error` is on that schema).
-  `guard_events` gates `user.message` / `initial_events` before
-  `sessions.events.send`. `claude_managed_agents_context` reads a
-  caller-owned id and never mints, never reads Anthropic session/event
-  `id`, never reads `trace_id`. Default `always_allow` cannot be gated.
+  `tool=` wraps Python `@beta_tool` `.call` (not JS `.run`). A worker
+  deny raises `ToolError` so `SessionToolRunner` posts `is_error=True`.
+  `guard_events` is always async and gates `user.message` /
+  `initial_events` before `sessions.events.send`.
+  `claude_managed_agents_context` reads a caller-owned id and never
+  mints, never reads Anthropic session/event `id`, never reads
+  `trace_id`. Default `always_allow` cannot be gated.
   `web_search` / `web_fetch` always run on Anthropic. Do not export
   `guard_tool`, `guard_hooks`, or `guard_inbound`.
 - `src/arcjet/_analyze/` — WASM component integration with typed Python bindings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,19 @@ uv run --no-sync pytest tests/integration/guard/test_claude_agent_sdk.py --no-co
 always runs, including when the extra is absent. `just test` on a plain
 `uv sync` skips the integration file, which is what CI does.
 
+### Claude Managed Agents tests
+
+`arcjet[claude-managed-agents]` is a real extra (`anthropic>=0.92.0,<2`) but is
+in no dependency group, so the lockfile does not pull its transitive tree
+into every `uv sync`. The unit suite imports no `anthropic` and always runs,
+including when the extra is absent. This extra is not the Claude Agent SDK
+adapter — do not run those tests in place of these.
+
+```sh
+uv sync
+uv run pytest tests/unit/guard/test_claude_managed_agents.py --no-cov
+```
+
 ## Benchmarks
 
 WASM performance benchmarks live in `tests/benchmarks/` and measure the per-call

--- a/README.md
+++ b/README.md
@@ -1681,13 +1681,15 @@ handle = guard_custom_tool(
     on_guard_error="deny",  # default
 )
 
-send(
+await send(
     session.id,
     events=[{"type": "user.message", "content": [{"type": "text", "text": user_text}]}],
 )
 
 # On agent.custom_tool_use:
-await handle(event, send=client.beta.sessions.events.send, session_id=session.id)
+# wrap-time session_id= is caller-owned correlation; anthropic_session_id
+# is Anthropic's ses_... and is only used to post the result.
+await handle(event, send=send, anthropic_session_id=session.id)
 ```
 
 On DENY the custom-tool helper does not run the tool. It sends a real
@@ -1697,8 +1699,10 @@ with JSON `{ arcjetDenied, reason, message, retryable, retryAfterSeconds? }`.
 `user.message` / `initial_events` is denied.
 
 For a self-hosted `EnvironmentWorker`, wrap the custom `@beta_tool` /
-`@beta_async_tool` with the same helper (`tool=`) and put it in the
-worker's `tools` factory. The CLI worker cannot register custom tools.
+`@beta_async_tool` with the same helper (`tool=`) — that replaces
+`.call`, which is what `SessionToolRunner` invokes — and put it in the
+worker's `tools` factory. On DENY the wrapper raises `ToolError` so the
+runner posts `is_error=True`. The CLI worker cannot register custom tools.
 
 #### What this extra cannot gate
 
@@ -1714,7 +1718,10 @@ must check `has_failed_open()`. These helpers default to
 `claude_managed_agents_context` reads a caller-owned `correlation_id` /
 `session_id`, then `arcjet_sequence()`. It never mints. It never reads
 `trace_id`. It never treats Anthropic session / event ids as if we
-created them.
+created them. Wrap-time `session_id=` is that caller-owned id.
+`handle(..., anthropic_session_id=)` is Anthropic's `ses_...`, used
+only to post `user.custom_tool_result`. `guard_events` always returns
+an async callable — `await` it even when wrapping the sync client.
 
 ### Sync usage
 

--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,8 @@ effect happens.
 | An OpenAI Agents authored `FunctionTool` | `guard_tool` (`arcjet.guard.openai_agents`) | `arcjet[openai-agents]` | Yes — via `reject_content` |
 | A Claude Agent SDK authored `@tool` / `SdkMcpTool` | `guard_tool` (`arcjet.guard.claude_agent_sdk`) | `arcjet[claude-agent-sdk]` | Yes — via `is_error` tool result |
 | Unwrapped Claude built-ins / MCP, or inbound user text | `guard_hooks` (`arcjet.guard.claude_agent_sdk`) | `arcjet[claude-agent-sdk]` | Yes — `PreToolUse` deny / `UserPromptSubmit` block |
+| A Claude Managed Agents custom tool (`agent.custom_tool_use`) | `guard_custom_tool` (`arcjet.guard.claude_managed_agents`) | `arcjet[claude-managed-agents]` | Yes — `user.custom_tool_result` (does not run the tool) |
+| Claude Managed Agents inbound `user.message` / `initial_events` | `guard_events` (`arcjet.guard.claude_managed_agents`) | `arcjet[claude-managed-agents]` | Yes — does not call `sessions.events.send` |
 
 Two rules of thumb. If you can name the tool at wiring time, `guard_tool` is the
 smaller change — it returns something that *is* the tool, so nothing downstream
@@ -1033,6 +1035,11 @@ right home for capture and the wrong home for policy.
   OpenAI Agents. Docs:
   [`/guards/claude-agent-sdk-py/`](https://docs.arcjet.com/guards/claude-agent-sdk-py/)
   — not the JS page [`/guards/claude-agent-sdk/`](https://docs.arcjet.com/guards/claude-agent-sdk/).
+- **`arcjet[claude-managed-agents]`** — `guard_custom_tool`, `guard_events`,
+  and `claude_managed_agents_context` for hosted Claude Managed Agents
+  (`anthropic>=0.92.0,<2`, beta `managed-agents-2026-04-01`). Independent of
+  LangChain, CrewAI, OpenAI Agents, and the Claude Agent SDK. Shared JS+Python
+  docs: [`/guards/claude-managed-agents/`](https://docs.arcjet.com/guards/claude-managed-agents/).
 There is deliberately **no `arcjet[crewai]` extra**. `arcjet.guard.crewai`
 works against the `crewai` you install yourself (`>=1.15.3,<2`, where `@on`
 and `HookAborted` landed; CrewAI requires Python `>=3.10,<3.14`). Arcjet does
@@ -1059,7 +1066,7 @@ from arcjet.guard.langchain import (
 )
 ```
 
-**Fail-closed default** — The *checkpoint surfaces* (`guard_action`, `guard_action_sync`, `guard_tool`, `guard_hooks`, `ArcjetMiddleware`, `register_arcjet_hooks`) default to denying when evaluation is unavailable. This is Arcjet's one documented divergence from the platform-wide fail-open convention. Note the scope: the core `guard()` call still fails **open**, returning an ALLOW for which `has_failed_open()` is `True`, as does the request protection API (`arcjet` / `arcjet_sync`). It is the surfaces that wrap a consequential effect which fail closed:
+**Fail-closed default** — The *checkpoint surfaces* (`guard_action`, `guard_action_sync`, `guard_tool`, `guard_hooks`, `guard_custom_tool`, `guard_events`, `ArcjetMiddleware`, `register_arcjet_hooks`) default to denying when evaluation is unavailable. This is Arcjet's one documented divergence from the platform-wide fail-open convention. Note the scope: the core `guard()` call still fails **open**, returning an ALLOW for which `has_failed_open()` is `True`, as does the request protection API (`arcjet` / `arcjet_sync`). It is the surfaces that wrap a consequential effect which fail closed:
 
 - **`on_guard_error="deny"`** (default) — If Guard is unavailable or evaluation fails, the guarded action blocks with `ArcjetUnavailableError`.
 - **`on_guard_error="allow"`** — Opt out: if Guard is unavailable, the action runs anyway. Use this only where availability matters more than enforcement.
@@ -1636,6 +1643,78 @@ caller-owned `session_id=` fallback, then `arcjet_sequence()`. It never
 mints. It never reads `trace_id`. Wrap-time `session_id=` /
 `correlation_id=` (including `inbound["session_id"]`) must be a UUID the
 app already minted — the same value you pass to `query()`.
+
+### Claude Managed Agents (hosted REST+SSE)
+
+`arcjet.guard.claude_managed_agents` needs
+`pip install "arcjet[claude-managed-agents]"` (`anthropic>=0.92.0,<2`).
+This is **not** `arcjet.guard.claude_agent_sdk`. There is no PreToolUse,
+no `guard_tool`, and no `guard_inbound`. Anthropic runs the tool loop
+(beta `managed-agents-2026-04-01`). Shared JS+Python docs:
+[`/guards/claude-managed-agents/`](https://docs.arcjet.com/guards/claude-managed-agents/).
+
+```py
+from arcjet.guard import DetectPromptInjection, launch_arcjet
+from arcjet.guard.claude_managed_agents import (
+    claude_managed_agents_context,
+    guard_custom_tool,
+    guard_events,
+)
+
+aj = launch_arcjet(key=arcjet_key)
+ctx = claude_managed_agents_context({"session_id": app_session_id})
+
+send = guard_events(
+    guard=aj,
+    send=client.beta.sessions.events.send,
+    action="message.received",
+    rules=lambda arguments: [DetectPromptInjection()(arguments["prompt"])],
+    correlation_id=ctx.correlation_id,
+    on_guard_error="deny",  # default
+)
+
+handle = guard_custom_tool(
+    guard=aj,
+    run=send_email,
+    action="email.sent",
+    correlation_id=ctx.correlation_id,
+    on_guard_error="deny",  # default
+)
+
+send(
+    session.id,
+    events=[{"type": "user.message", "content": [{"type": "text", "text": user_text}]}],
+)
+
+# On agent.custom_tool_use:
+await handle(event, send=client.beta.sessions.events.send, session_id=session.id)
+```
+
+On DENY the custom-tool helper does not run the tool. It sends a real
+`user.custom_tool_result` (`custom_tool_use_id`, `content`, `is_error`)
+with JSON `{ arcjetDenied, reason, message, retryable, retryAfterSeconds? }`.
+`guard_events` does not call `sessions.events.send` when inbound
+`user.message` / `initial_events` is denied.
+
+For a self-hosted `EnvironmentWorker`, wrap the custom `@beta_tool` /
+`@beta_async_tool` with the same helper (`tool=`) and put it in the
+worker's `tools` factory. The CLI worker cannot register custom tools.
+
+#### What this extra cannot gate
+
+Default `permission_policy: always_allow` **cannot** be gated —
+Anthropic-cloud bash / read / write run before any customer hook.
+`web_search` / `web_fetch` always run on Anthropic. MCP: Anthropic is
+the client; customer-side Guard is on custom tools and MCP servers
+**they** host. HITL `always_ask` / `user.tool_confirmation` is not
+policy. `protect()` and the request path are fail-open — the caller
+must check `has_failed_open()`. These helpers default to
+`on_guard_error="deny"`.
+
+`claude_managed_agents_context` reads a caller-owned `correlation_id` /
+`session_id`, then `arcjet_sequence()`. It never mints. It never reads
+`trace_id`. It never treats Anthropic session / event ids as if we
+created them.
 
 ### Sync usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ claude-agent-sdk = ["claude-agent-sdk>=0.2.127,<1"]
 # extra — do not reuse that module or `guard_tool` / PreToolUse.
 # The floor is 0.92.0, the first release whose changelog adds
 # `client.beta.agents` / `sessions` / `environments`. EnvironmentWorker
-# landed later (0.103.0); the adapter duck-types `run` so the extra
+# landed later (0.103.0); the adapter duck-types `call` so the extra
 # floor stays at agents/sessions/environments. No chromadb — unlike
 # CrewAI this extra is safe to declare. Like openai-agents it is in no
 # dependency group so the lockfile does not pull its transitive tree

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,19 @@ openai-agents = ["openai-agents>=0.19.0,<1"]
 # openai-agents it is in no dependency group so the lockfile does not
 # pull its transitive tree into every `uv sync`.
 claude-agent-sdk = ["claude-agent-sdk>=0.2.127,<1"]
+# Hosted Claude Managed Agents (REST+SSE, beta managed-agents-2026-04-01).
+# Separate extra so installing `arcjet` never pulls `anthropic`;
+# `arcjet.guard.claude_managed_agents` imports `anthropic` lazily and
+# duck-types `sessions.events.send`. This is NOT the Claude Agent SDK
+# extra — do not reuse that module or `guard_tool` / PreToolUse.
+# The floor is 0.92.0, the first release whose changelog adds
+# `client.beta.agents` / `sessions` / `environments`. EnvironmentWorker
+# landed later (0.103.0); the adapter duck-types `run` so the extra
+# floor stays at agents/sessions/environments. No chromadb — unlike
+# CrewAI this extra is safe to declare. Like openai-agents it is in no
+# dependency group so the lockfile does not pull its transitive tree
+# into every `uv sync`.
+claude-managed-agents = ["anthropic>=0.92.0,<2"]
 # There is deliberately no `crewai` extra, and CrewAI is in no dependency
 # group. `crewai` hard-depends on `chromadb~=1.1.0`, and every chromadb from
 # 1.0.0 to 1.5.9 carries an unpatched critical RCE (CVE-2026-45829 /

--- a/src/arcjet/guard/claude_managed_agents/__init__.py
+++ b/src/arcjet/guard/claude_managed_agents/__init__.py
@@ -1,0 +1,54 @@
+"""Optional Claude Managed Agents (hosted REST+SSE) integration.
+
+Install ``arcjet[claude-managed-agents]`` to use this module. Core Guard
+clients do not import ``anthropic``, and this package does not import
+:mod:`arcjet.guard.langchain`, :mod:`arcjet.guard.crewai`,
+:mod:`arcjet.guard.openai_agents`, or
+:mod:`arcjet.guard.claude_agent_sdk`.
+
+This is **not** the Claude Agent SDK extra. There is no PreToolUse,
+no ``guard_tool``, and no ``guard_inbound``. Anthropic runs the tool
+loop (beta ``managed-agents-2026-04-01``).
+
+Three names:
+
+* :func:`guard_custom_tool` — on ``agent.custom_tool_use``, run Guard
+  **before** the app executes. On DENY the original does not run; the
+  helper sends ``user.custom_tool_result`` with error text via the real
+  events API (``is_error`` is on that schema). Pass ``tool=`` to wrap a
+  self-hosted ``EnvironmentWorker`` / ``@beta_tool`` ``run`` the same
+  way. The CLI worker cannot register custom tools.
+* :func:`guard_events` — inbound: gate ``user.message`` /
+  ``initial_events`` **before** ``sessions.events.send`` (or
+  ``sessions.create(..., initial_events=)``). There is no
+  ``guard_inbound``.
+* :func:`claude_managed_agents_context` — read a caller-owned
+  ``correlation_id`` / ``session_id``. Never mints. Never treats
+  Anthropic session / event ids as if we created them. Never reads
+  ``trace_id``.
+
+Default ``permission_policy: always_allow`` **cannot** be gated —
+Anthropic-cloud bash / read / write run before any customer hook.
+``web_search`` / ``web_fetch`` always run on Anthropic. MCP: Anthropic
+is the client; customer-side Guard is on custom tools and MCP servers
+**they** host. HITL ``always_ask`` / ``user.tool_confirmation`` is not
+policy.
+
+``protect()`` / the request path is fail-open — check
+:meth:`~arcjet.guard.Decision.has_failed_open`. These helpers are
+fail-closed (default ``on_guard_error="deny"``).
+
+See https://docs.arcjet.com/guards/claude-managed-agents/
+"""
+
+from __future__ import annotations
+
+from ._context import claude_managed_agents_context
+from ._events import guard_events
+from ._tool import guard_custom_tool
+
+__all__ = [
+    "guard_custom_tool",
+    "guard_events",
+    "claude_managed_agents_context",
+]

--- a/src/arcjet/guard/claude_managed_agents/__init__.py
+++ b/src/arcjet/guard/claude_managed_agents/__init__.py
@@ -16,12 +16,14 @@ Three names:
   **before** the app executes. On DENY the original does not run; the
   helper sends ``user.custom_tool_result`` with error text via the real
   events API (``is_error`` is on that schema). Pass ``tool=`` to wrap a
-  self-hosted ``EnvironmentWorker`` / ``@beta_tool`` ``run`` the same
-  way. The CLI worker cannot register custom tools.
+  self-hosted ``EnvironmentWorker`` / ``@beta_tool`` ``call`` (what
+  ``SessionToolRunner`` invokes). A worker deny raises ``ToolError`` so
+  the runner posts ``is_error=True``. The CLI worker cannot register
+  custom tools.
 * :func:`guard_events` — inbound: gate ``user.message`` /
   ``initial_events`` **before** ``sessions.events.send`` (or
-  ``sessions.create(..., initial_events=)``). There is no
-  ``guard_inbound``.
+  ``sessions.create(..., initial_events=)``). Always returns an async
+  callable. There is no ``guard_inbound``.
 * :func:`claude_managed_agents_context` — read a caller-owned
   ``correlation_id`` / ``session_id``. Never mints. Never treats
   Anthropic session / event ids as if we created them. Never reads

--- a/src/arcjet/guard/claude_managed_agents/_common.py
+++ b/src/arcjet/guard/claude_managed_agents/_common.py
@@ -1,0 +1,369 @@
+"""Shared checkpoint wiring for the Managed Agents events and tool gates.
+
+``_events`` and ``_tool`` used to copy the resolver / decide / capture loop.
+That is the fail-closed path — keep it in one place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextvars
+import functools
+import inspect
+from collections.abc import Callable, Coroutine, Mapping, Sequence
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Optional, TypeVar, Union, cast
+
+from arcjet._logging import logger
+from arcjet._metadata import Metadata
+
+from .._checkpoint import (
+    ResolvedInputs,
+    _classify_decision,
+    _emit_capture,
+    _guard_async,
+    _guard_sync,
+    _outcome_for_completed_action,
+    _resolve_correlation_id,
+)
+from .._errors import ArcjetDeniedError, ArcjetUnavailableError, OnGuardError
+from .._policy_input import PolicyInputMap
+from .._registry import _awaitable
+from .._rules import RuleWithInput
+from ._context import SESSION_METADATA_KEY, claude_managed_agents_context
+
+ActorResolver = Union[str, Callable[[Mapping[str, Any]], Optional[str]], None]
+InputResolver = Union[
+    PolicyInputMap,
+    Callable[[Mapping[str, Any]], Optional[PolicyInputMap]],
+    None,
+]
+RulesResolver = Union[
+    Sequence[RuleWithInput],
+    Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+]
+MetadataResolver = Union[
+    Metadata, Callable[[Mapping[str, Any]], Optional[Metadata]], None
+]
+
+#: Attribute wrappers put on the copy they return, so a second wrap of the
+#: same object does not evaluate the same call twice.
+_GUARD_BRAND = "_arcjet_guarded"
+
+PHASE_METADATA_KEY = "claude-managed-agents.phase"
+TOOL_METADATA_KEY = "claude-managed-agents.tool"
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class CheckpointOutcome:
+    """Shared result of one Guard evaluation. Surfaces interpret *failure*."""
+
+    decision: Any
+    failure: Optional[BaseException]
+    prepared: ResolvedInputs
+    correlation_id: Optional[str]
+    metadata: Optional[Metadata]
+    proceeded_open: bool
+
+
+def _read(source: Any, name: str) -> Any:
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        return source.get(name)
+    return getattr(source, name, None)
+
+
+def _resolve(source: Any, arguments: Mapping[str, Any]) -> Any:
+    if source is None or not callable(source):
+        return source
+    return source(arguments)
+
+
+def prepared_inputs(
+    actor: ActorResolver, inputs: InputResolver, arguments: Mapping[str, Any]
+) -> ResolvedInputs:
+    degraded: Optional[BaseException] = None
+    resolved_actor: Optional[str] = None
+    resolved_inputs: Optional[PolicyInputMap] = None
+    try:
+        resolved_actor = _resolve(actor, arguments)
+    except Exception as exc:
+        degraded = exc
+    try:
+        resolved_inputs = _resolve(inputs, arguments)
+    except Exception as exc:
+        degraded = degraded or exc
+    return ResolvedInputs(
+        actor=resolved_actor, inputs=resolved_inputs, degraded=degraded
+    )
+
+
+def resolved_rules(
+    rules: RulesResolver, arguments: Mapping[str, Any]
+) -> Sequence[RuleWithInput]:
+    if not callable(rules):
+        return rules
+    return cast(
+        Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+        rules,
+    )(arguments)
+
+
+def resolve_metadata_value(
+    metadata: MetadataResolver, arguments: Mapping[str, Any]
+) -> Optional[Metadata]:
+    if callable(metadata):
+        return cast(
+            Callable[[Mapping[str, Any]], Optional[Metadata]],
+            metadata,
+        )(arguments)
+    return metadata
+
+
+def merge_metadata(
+    *,
+    correlation_id: Optional[str],
+    session_id: Optional[str],
+    extra: Optional[Metadata],
+    reserved: Mapping[str, Any],
+) -> Optional[Metadata]:
+    """User metadata, then reserved keys so phase / session / tool cannot be forged."""
+    derived = claude_managed_agents_context(
+        correlation_id=correlation_id,
+        session_id=session_id,
+    )
+    merged: dict[str, Any] = {}
+    if derived.metadata:
+        merged.update(derived.metadata)
+    if extra:
+        merged.update(extra)
+    owned = None
+    if derived.metadata:
+        owned = derived.metadata.get(SESSION_METADATA_KEY)
+    if owned is not None:
+        merged[SESSION_METADATA_KEY] = owned
+    merged.update(reserved)
+    return merged or None
+
+
+def correlation_id_for(
+    *,
+    correlation_id: Optional[str],
+    session_id: Optional[str],
+) -> Optional[str]:
+    derived = claude_managed_agents_context(
+        correlation_id=correlation_id,
+        session_id=session_id,
+    )
+    return _resolve_correlation_id(derived.correlation_id)
+
+
+def unavailable_error(action: str, cause: Optional[BaseException]) -> BaseException:
+    return ArcjetUnavailableError(action, cause=cause)
+
+
+async def decide(
+    guard: Any,
+    *,
+    action: str,
+    correlation_id: Optional[str],
+    metadata: Optional[Metadata],
+    prepared: ResolvedInputs,
+    rules: Sequence[RuleWithInput],
+) -> Any:
+    kwargs = {
+        "rules": rules,
+        "label": action,
+        "metadata": metadata,
+        "correlation_id": correlation_id,
+        "actor": prepared.actor,
+        "inputs": prepared.inputs,
+    }
+    if _awaitable(guard, "guard") is not None or guard is None:
+        return await _guard_async(guard, **kwargs)
+    return await asyncio.to_thread(partial(_guard_sync, guard, **kwargs))
+
+
+async def evaluate_checkpoint(
+    *,
+    guard: Any,
+    action: str,
+    actor: ActorResolver,
+    inputs: InputResolver,
+    rules: RulesResolver,
+    metadata: MetadataResolver,
+    correlation_id: Optional[str],
+    session_id: Optional[str],
+    on_guard_error: OnGuardError,
+    arguments: Mapping[str, Any],
+    reserved_metadata: Mapping[str, Any],
+) -> CheckpointOutcome:
+    """Evaluate one checkpoint. Never raises an Arcjet error."""
+    resolved_correlation = _resolve_correlation_id(None)
+    resolved_metadata: Optional[Metadata] = None
+    decision: Any = None
+    prepared = ResolvedInputs()
+
+    try:
+        resolved_correlation = correlation_id_for(
+            correlation_id=correlation_id, session_id=session_id
+        )
+        extra = resolve_metadata_value(metadata, arguments)
+        resolved_metadata = merge_metadata(
+            correlation_id=correlation_id,
+            session_id=session_id,
+            extra=extra,
+            reserved=reserved_metadata,
+        )
+        prepared = prepared_inputs(actor, inputs, arguments)
+        resolved_rules_list = resolved_rules(rules, arguments)
+        decision = await decide(
+            guard,
+            action=action,
+            correlation_id=resolved_correlation,
+            metadata=resolved_metadata,
+            prepared=prepared,
+            rules=resolved_rules_list,
+        )
+        failure = _classify_decision(
+            decision,
+            action=action,
+            on_guard_error=on_guard_error,
+            denied_error=ArcjetDeniedError,
+            unavailable_error=unavailable_error,
+            degraded=prepared.degraded,
+        )
+    except Exception:
+        if on_guard_error == "allow":
+            logger.warning(
+                "arcjet: policy for action %r could not be evaluated; proceeding "
+                "because on_guard_error is 'allow'",
+                action,
+            )
+            return CheckpointOutcome(
+                decision=None,
+                failure=None,
+                prepared=prepared,
+                correlation_id=resolved_correlation,
+                metadata=resolved_metadata,
+                proceeded_open=True,
+            )
+        _emit_capture(
+            client=guard,
+            action=action,
+            outcome="unavailable",
+            correlation_id=resolved_correlation,
+            decision=None,
+            metadata=resolved_metadata,
+        )
+        return CheckpointOutcome(
+            decision=None,
+            failure=unavailable_error(action, None),
+            prepared=prepared,
+            correlation_id=resolved_correlation,
+            metadata=resolved_metadata,
+            proceeded_open=False,
+        )
+
+    if failure is not None:
+        denied = getattr(decision, "conclusion", None) == "DENY"
+        _emit_capture(
+            client=guard,
+            action=action,
+            outcome="denied" if denied else "unavailable",
+            correlation_id=resolved_correlation,
+            decision=decision,
+            metadata=resolved_metadata,
+        )
+    else:
+        _emit_capture(
+            client=guard,
+            action=action,
+            outcome=_outcome_for_completed_action(decision, degraded=prepared.degraded),
+            correlation_id=resolved_correlation,
+            decision=decision,
+            metadata=resolved_metadata,
+        )
+    return CheckpointOutcome(
+        decision=decision,
+        failure=failure,
+        prepared=prepared,
+        correlation_id=resolved_correlation,
+        metadata=resolved_metadata,
+        proceeded_open=False,
+    )
+
+
+async def maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def looks_async(fn: Any) -> bool:
+    """True when *fn* should be awaited.
+
+    Covers ``async def`` functions, bound coroutine methods (the real
+    ``AsyncAnthropic`` ``sessions.events.send`` / ``BetaAsyncFunctionTool.call``),
+    and instances whose ``__call__`` is async.
+    """
+    if inspect.iscoroutinefunction(fn):
+        return True
+    call = getattr(fn, "__call__", None)
+    if inspect.iscoroutinefunction(call):
+        return True
+    unwrapped = inspect.unwrap(fn)
+    if inspect.iscoroutinefunction(unwrapped):
+        return True
+    unwrapped_call = getattr(unwrapped, "__call__", None)
+    return inspect.iscoroutinefunction(unwrapped_call)
+
+
+def run_coroutine_sync(coro: Coroutine[Any, Any, T]) -> T:
+    """Run *coro* from sync code, including when a loop is already running.
+
+    ``asyncio.run`` cannot be called from a running loop. A coroutine that
+    has not been scheduled yet can be driven on a side thread with its own
+    loop. Contextvars (Sequence correlation) are copied onto that thread.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    def _runner() -> T:
+        return asyncio.run(coro)
+
+    copied = contextvars.copy_context()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(copied.run, _runner).result()
+
+
+def adopt_wrapper(wrapper: Any, wrapped: Any) -> Any:
+    """``functools.update_wrapper`` that tolerates instances without ``__name__``."""
+    try:
+        functools.update_wrapper(wrapper, wrapped)
+    except AttributeError:
+        pass
+    return wrapper
+
+
+def is_already_guarded(value: Any) -> bool:
+    return bool(getattr(value, _GUARD_BRAND, False))
+
+
+def brand(value: Any) -> None:
+    try:
+        object.__setattr__(value, _GUARD_BRAND, True)
+    except AttributeError as exc:
+        raise TypeError(
+            "could not brand the wrapped copy with "
+            f"{_GUARD_BRAND!r}; the type likely uses __slots__ "
+            "without space for this attribute. The wrap cannot proceed "
+            "without the brand — a second wrap would double-call Guard."
+        ) from exc

--- a/src/arcjet/guard/claude_managed_agents/_common.py
+++ b/src/arcjet/guard/claude_managed_agents/_common.py
@@ -340,8 +340,12 @@ def run_coroutine_sync(coro: Coroutine[Any, Any, T]) -> T:
         return asyncio.run(coro)
 
     copied = contextvars.copy_context()
+
+    def _in_copied_context() -> T:
+        return copied.run(_runner)
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-        return pool.submit(copied.run, _runner).result()
+        return pool.submit(_in_copied_context).result()
 
 
 def adopt_wrapper(wrapper: Any, wrapped: Any) -> Any:

--- a/src/arcjet/guard/claude_managed_agents/_common.py
+++ b/src/arcjet/guard/claude_managed_agents/_common.py
@@ -349,6 +349,8 @@ def adopt_wrapper(wrapper: Any, wrapped: Any) -> Any:
     try:
         functools.update_wrapper(wrapper, wrapped)
     except AttributeError:
+        # Instances used as callables often lack ``__name__`` / ``__doc__``.
+        # Copying wrapper metadata is best-effort and must not fail the wrap.
         pass
     return wrapper
 

--- a/src/arcjet/guard/claude_managed_agents/_context.py
+++ b/src/arcjet/guard/claude_managed_agents/_context.py
@@ -18,6 +18,10 @@ from arcjet._metadata import Metadata
 
 from .._context import _validated, current_correlation_id
 
+#: Capture metadata key for the caller-owned session id. Reserved — adapters
+#: re-apply it after user metadata so a caller cannot wipe or forge it.
+SESSION_METADATA_KEY = "claude-managed-agents.session"
+
 #: Names read off a caller-owned app object, in preference order. Each
 #: slot lists the Python spelling first and the JS camelCase alias second.
 #: Anthropic-minted ``id`` / ``event_id`` are not in this list.
@@ -158,7 +162,7 @@ def claude_managed_agents_context(
     if owned_session is None:
         owned_session = _valid_id(session_id)
     if owned_session is not None:
-        derived["claude-managed-agents.session"] = owned_session
+        derived[SESSION_METADATA_KEY] = owned_session
 
     merged: dict[str, Any] = {**derived}
     if metadata:

--- a/src/arcjet/guard/claude_managed_agents/_context.py
+++ b/src/arcjet/guard/claude_managed_agents/_context.py
@@ -1,0 +1,167 @@
+"""Caller-owned correlation for a Claude Managed Agents session.
+
+Anthropic mints session ids (``ses_...``) and event ids (``sevt_...``).
+This helper never treats those as ids we created. It reads a caller-owned
+``correlation_id`` / ``session_id`` the application already has. It never
+mints. It never reads ``trace_id``. It never reads ``id`` / ``event_id``
+off an Anthropic session or event object.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from arcjet._logging import logger
+from arcjet._metadata import Metadata
+
+from .._context import _validated, current_correlation_id
+
+#: Names read off a caller-owned app object, in preference order. Each
+#: slot lists the Python spelling first and the JS camelCase alias second.
+#: Anthropic-minted ``id`` / ``event_id`` are not in this list.
+_APP_ID_SLOTS: tuple[tuple[str, ...], ...] = (
+    ("correlation_id", "correlationId"),
+    ("session_id", "sessionId"),
+)
+
+#: Never read as correlation. The SDK / API mint a session and event id;
+#: joining a Sequence on a generated id is one nobody can look up. ``id``
+#: and ``event_id`` on an Anthropic object are theirs, not ours.
+_NEVER_READ = frozenset(
+    {
+        "trace_id",
+        "traceId",
+        "id",
+        "event_id",
+        "eventId",
+        "event_ids",
+        "eventIds",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ClaudeManagedAgentsContext:
+    """What :func:`claude_managed_agents_context` derived.
+
+    ``correlation_id`` is ``None`` when nothing valid was present — this
+    helper never mints one.
+    """
+
+    correlation_id: Optional[str] = None
+    metadata: Optional[Metadata] = None
+
+
+def _readable(value: Any) -> Any:
+    """*value* if named fields can be read off it, else ``None``."""
+    if value is None or isinstance(
+        value, (str, bytes, bytearray, list, tuple, set, frozenset)
+    ):
+        return None
+    return value
+
+
+def _read(source: Any, name: str) -> Any:
+    """*name* off a mapping or an object, whichever *source* is."""
+    if source is None or name in _NEVER_READ:
+        return None
+    if isinstance(source, Mapping):
+        return source.get(name)
+    return getattr(source, name, None)
+
+
+def _valid_id(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    try:
+        return _validated(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def claude_managed_agents_context(
+    source: Any = None,
+    *,
+    correlation_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    metadata: Optional[Metadata] = None,
+) -> ClaudeManagedAgentsContext:
+    """Read a caller-owned correlation id for a Managed Agents run.
+
+    Preference order:
+
+    1. Fields the integrator put on *source*: ``correlation_id``, then
+       ``session_id`` (Python or JS camelCase)
+    2. ``correlation_id=`` / ``session_id=`` passed here
+    3. The enclosing :func:`~arcjet.guard.arcjet_sequence`, if any
+
+    Anthropic session / event ``id`` values are never read. ``trace_id``
+    is never read. An invalid candidate is skipped. If nothing valid
+    remains, ``correlation_id`` is ``None`` and the decision is
+    uncorrelated rather than joined to a generated id nobody has.
+
+    This function never constructs a session and never resolves one's id.
+
+    Args:
+        source: A caller-owned mapping / object. An Anthropic Session or
+            event object is safe to pass — ``id`` is ignored.
+        correlation_id: Caller-owned fallback, used only if *source*
+            carries nothing valid.
+        session_id: Same, for an id the application calls a session. This
+            is the application's id, not Anthropic's ``ses_...``.
+        metadata: Merged over the session metadata derived from *source*.
+
+    Returns:
+        The correlation id and metadata to pass to ``guard()``.
+    """
+    envelope = _readable(source)
+
+    candidates: list[tuple[Any, str]] = []
+    if envelope is not None:
+        for names in _APP_ID_SLOTS:
+            for name in names:
+                value = _read(envelope, name)
+                if value is not None:
+                    candidates.append((value, name))
+    if correlation_id is not None:
+        candidates.append((correlation_id, "correlation_id"))
+    if session_id is not None:
+        candidates.append((session_id, "session_id"))
+
+    resolved: Optional[str] = None
+    rejected: Optional[str] = None
+    for value, label in candidates:
+        valid = _valid_id(value)
+        if valid is not None:
+            resolved = valid
+            break
+        if isinstance(value, str):
+            rejected = label
+
+    if resolved is None:
+        resolved = current_correlation_id()
+
+    if rejected is not None and resolved is None:
+        logger.warning(
+            "arcjet: Claude Managed Agents %s rejected; no valid "
+            "caller-owned correlation / session id, leaving the call "
+            "uncorrelated",
+            rejected,
+        )
+
+    derived: dict[str, Any] = {}
+    owned_session = _valid_id(_read(envelope, "session_id")) or _valid_id(
+        _read(envelope, "sessionId")
+    )
+    if owned_session is None:
+        owned_session = _valid_id(session_id)
+    if owned_session is not None:
+        derived["claude-managed-agents.session"] = owned_session
+
+    merged: dict[str, Any] = {**derived}
+    if metadata:
+        merged.update(metadata)
+
+    return ClaudeManagedAgentsContext(correlation_id=resolved, metadata=merged or None)

--- a/src/arcjet/guard/claude_managed_agents/_denial.py
+++ b/src/arcjet/guard/claude_managed_agents/_denial.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 import json
 import math
 import time
-from typing import Any, Optional, TypedDict
+from typing import Any, NoReturn, Optional, TypedDict
 
 from .._types import Decision
+from ._import import load_tool_error
 
 UNAVAILABLE_RETRY_AFTER_SECONDS: int = 5
 
@@ -147,3 +148,30 @@ def custom_tool_result_event(
     if session_thread_id:
         event["session_thread_id"] = session_thread_id
     return event
+
+
+class WorkerToolDenied(Exception):
+    """Raised from a wrapped worker ``call`` when Guard denies.
+
+    Used when ``anthropic.ToolError`` is not importable (unit tests /
+    extra absent). ``SessionToolRunner`` maps any exception to
+    ``is_error=True``; prefer ``ToolError`` so the model sees the
+    envelope as ``content`` rather than ``repr(exc)``.
+    """
+
+    def __init__(self, content: str) -> None:
+        super().__init__(content)
+        self.content = content
+
+
+def raise_worker_denial(payload: ArcjetDenialResult) -> NoReturn:
+    """Fail a worker ``call`` so the runner posts ``is_error=True``.
+
+    Raises Anthropic's ``ToolError`` when the extra is installed, otherwise
+    :class:`WorkerToolDenied`. Both carry the denial JSON as ``content``.
+    """
+    text = dumps_denial(payload)
+    tool_error = load_tool_error()
+    if tool_error is not None:
+        raise tool_error(text)
+    raise WorkerToolDenied(text)

--- a/src/arcjet/guard/claude_managed_agents/_denial.py
+++ b/src/arcjet/guard/claude_managed_agents/_denial.py
@@ -1,0 +1,149 @@
+"""Model-visible denial payload for a Managed Agents custom-tool result.
+
+LangChain and CrewAI raise typed errors from their checkpoints. Claude
+Managed Agents cannot: the session is idle on ``agent.custom_tool_use``
+until the client sends ``user.custom_tool_result``. The honest deny is
+that event, with error text the model can read. The events schema
+includes optional ``is_error`` — use it; do not invent a second field.
+
+The envelope is the one every JS adapter already uses. Python has no
+second shape for a model-facing tool result — do not invent one.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from typing import Any, Optional, TypedDict
+
+from .._types import Decision
+
+UNAVAILABLE_RETRY_AFTER_SECONDS: int = 5
+
+
+class _ArcjetDenialRequired(TypedDict):
+    """Required fields of the model-visible denial envelope."""
+
+    arcjetDenied: bool
+    reason: str
+    message: str
+    retryable: bool
+
+
+class ArcjetDenialResult(_ArcjetDenialRequired, total=False):
+    """JSON object the model reads from the custom-tool result text block.
+
+    Keys stay camelCase so a model (and a shared Sequence reader) sees the
+    same envelope the JS adapters already emit.
+    """
+
+    retryAfterSeconds: int
+
+
+def retry_after_seconds(decision: Decision) -> Optional[int]:
+    """Seconds until a rate-limited call may be retried.
+
+    Only meaningful for a ``RATE_LIMIT`` denial. A co-occurring rule that
+    allowed can still leave a ``reset_at_unix_seconds`` in ``decision.results``;
+    ignore it when the denying reason is not a rate limit — same rule as JS
+    ``denial.ts``.
+    """
+    if decision.reason != "RATE_LIMIT":
+        return None
+    now = time.time()
+    found: Optional[int] = None
+    for result in decision.results:
+        if getattr(result, "conclusion", None) != "DENY":
+            continue
+        if getattr(result, "reason", None) != "RATE_LIMIT":
+            continue
+        reset = getattr(result, "reset_at_unix_seconds", None)
+        if isinstance(reset, int) and reset > 0:
+            seconds = max(0, math.ceil(reset - now))
+            if found is None or seconds < found:
+                found = seconds
+    return found
+
+
+def denied_message(decision: Decision) -> str:
+    """Human- and model-readable explanation of a real DENY."""
+    if decision.reason == "RATE_LIMIT":
+        retry_after = retry_after_seconds(decision)
+        suffix = " later." if retry_after is None else f" after {retry_after} seconds."
+        return f"Arcjet denied this call ({decision.reason}). It may be retried{suffix}"
+    return (
+        f"Arcjet denied this call ({decision.reason}). Do not retry; explain "
+        f"the denial to the user or try a different approach."
+    )
+
+
+def unavailable_message() -> str:
+    return "Arcjet security check could not be completed; please retry later."
+
+
+def denial_result(decision: Decision) -> ArcjetDenialResult:
+    """Structured payload for an evaluated DENY."""
+    is_rate_limit = decision.reason == "RATE_LIMIT"
+    payload: ArcjetDenialResult = {
+        "arcjetDenied": True,
+        "reason": decision.reason,
+        "message": denied_message(decision),
+        "retryable": is_rate_limit,
+    }
+    if is_rate_limit:
+        retry_after = retry_after_seconds(decision)
+        if retry_after is not None:
+            payload["retryAfterSeconds"] = retry_after
+    return payload
+
+
+def unavailable_result() -> ArcjetDenialResult:
+    """Structured payload when policy could not be evaluated and we fail closed."""
+    return {
+        "arcjetDenied": True,
+        "reason": "ERROR",
+        "message": unavailable_message(),
+        "retryable": True,
+        "retryAfterSeconds": UNAVAILABLE_RETRY_AFTER_SECONDS,
+    }
+
+
+def dumps_denial(payload: ArcjetDenialResult) -> str:
+    """JSON the model receives in a ``user.custom_tool_result`` text block."""
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def payload_from_block(decision: Optional[Decision]) -> ArcjetDenialResult:
+    """DENY uses the decision; everything else is an unavailability envelope.
+
+    Action is kept on the capture, not in this envelope: the model-facing
+    shape is shared with JS and has no action field.
+    """
+    if decision is not None and getattr(decision, "conclusion", None) == "DENY":
+        return denial_result(decision)
+    return unavailable_result()
+
+
+def custom_tool_result_event(
+    *,
+    custom_tool_use_id: str,
+    payload: ArcjetDenialResult,
+    session_thread_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """A real ``user.custom_tool_result`` body for ``sessions.events.send``.
+
+    Field names match the Managed Agents events schema
+    (``BetaManagedAgentsUserCustomToolResultEventParams``): ``type``,
+    ``custom_tool_use_id``, ``content``, optional ``is_error``, optional
+    ``session_thread_id``. ``is_error`` is on the schema — include it.
+    """
+    event: dict[str, Any] = {
+        "type": "user.custom_tool_result",
+        "custom_tool_use_id": custom_tool_use_id,
+        "content": [{"type": "text", "text": dumps_denial(payload)}],
+        "is_error": True,
+    }
+    if session_thread_id:
+        event["session_thread_id"] = session_thread_id
+    return event

--- a/src/arcjet/guard/claude_managed_agents/_events.py
+++ b/src/arcjet/guard/claude_managed_agents/_events.py
@@ -1,0 +1,482 @@
+"""Inbound gate for ``sessions.events.send`` / ``initial_events``.
+
+``guard_events`` wraps a send callable (the real
+``client.beta.sessions.events.send``, or ``sessions.create`` when the
+caller is seeding ``initial_events``). ``user.message`` events are
+evaluated **before** the original send runs. On DENY the original is
+not called.
+
+This is not ``guard_inbound``. There is no PreToolUse. Built-in tools
+under default ``always_allow`` cannot be gated here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Optional, Union, cast
+
+from arcjet._errors import ArcjetMisconfiguration
+from arcjet._logging import logger
+from arcjet._metadata import Metadata
+
+from .._checkpoint import (
+    ResolvedInputs,
+    _classify_decision,
+    _emit_capture,
+    _guard_async,
+    _guard_sync,
+    _outcome_for_completed_action,
+    _resolve_correlation_id,
+)
+from .._context import _validated
+from .._errors import ArcjetDeniedError, ArcjetUnavailableError, OnGuardError
+from .._policy_input import PolicyInputMap
+from .._registry import _awaitable
+from .._rules import RuleWithInput
+from .._types import Decision
+from ._context import claude_managed_agents_context
+from ._denial import payload_from_block, unavailable_message
+from ._import import _require_anthropic
+
+ActorResolver = Union[str, Callable[[Mapping[str, Any]], Optional[str]], None]
+InputResolver = Union[
+    PolicyInputMap,
+    Callable[[Mapping[str, Any]], Optional[PolicyInputMap]],
+    None,
+]
+RulesResolver = Union[
+    Sequence[RuleWithInput],
+    Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+]
+MetadataResolver = Union[
+    Metadata, Callable[[Mapping[str, Any]], Optional[Metadata]], None
+]
+
+_USER_MESSAGE = "user.message"
+
+
+@dataclass(frozen=True, slots=True)
+class _EventsConfig:
+    guard: Any
+    action: str
+    actor: ActorResolver
+    inputs: InputResolver
+    rules: RulesResolver
+    metadata: MetadataResolver
+    correlation_id: Optional[str]
+    session_id: Optional[str]
+    on_guard_error: OnGuardError
+
+
+@dataclass(frozen=True, slots=True)
+class InboundVerdict:
+    """What the send wrapper should do. Unit tests call this without a client."""
+
+    deny: bool
+    reason: Optional[str] = None
+    decision: Optional[Decision] = None
+
+
+def _read(source: Any, name: str) -> Any:
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        return source.get(name)
+    return getattr(source, name, None)
+
+
+def _event_type(event: Any) -> str:
+    value = _read(event, "type")
+    return value if isinstance(value, str) else ""
+
+
+def _is_user_message(event: Any) -> bool:
+    return _event_type(event) == _USER_MESSAGE
+
+
+def _as_event_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return [value]
+    if isinstance(value, Sequence):
+        return list(value)
+    return [value]
+
+
+def inbound_events(*groups: Any) -> list[Any]:
+    """``user.message`` events from ``events`` / ``initial_events`` groups."""
+    found: list[Any] = []
+    for group in groups:
+        for event in _as_event_list(group):
+            if _is_user_message(event):
+                found.append(event)
+    return found
+
+
+def _content_text(content: Any) -> str:
+    """Flatten Managed Agents message content to a single prompt string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Mapping):
+        text = content.get("text")
+        return text if isinstance(text, str) else ""
+    if isinstance(content, Sequence) and not isinstance(
+        content, (str, bytes, bytearray)
+    ):
+        parts: list[str] = []
+        for block in content:
+            piece = _content_text(block)
+            if piece:
+                parts.append(piece)
+        return "\n".join(parts)
+    text = getattr(content, "text", None)
+    return text if isinstance(text, str) else ""
+
+
+def message_arguments(event: Any) -> dict[str, Any]:
+    """What inbound resolvers see for one ``user.message``."""
+    content = _read(event, "content")
+    prompt = _content_text(content)
+    return {"prompt": prompt, "content": content, "type": _USER_MESSAGE}
+
+
+def _resolve(source: Any, arguments: Mapping[str, Any]) -> Any:
+    if source is None or not callable(source):
+        return source
+    return source(arguments)
+
+
+def _prepared(config: _EventsConfig, arguments: Mapping[str, Any]) -> ResolvedInputs:
+    degraded: Optional[BaseException] = None
+    resolved_actor: Optional[str] = None
+    resolved_inputs: Optional[PolicyInputMap] = None
+    try:
+        resolved_actor = _resolve(config.actor, arguments)
+    except Exception as exc:
+        degraded = exc
+    try:
+        resolved_inputs = _resolve(config.inputs, arguments)
+    except Exception as exc:
+        degraded = degraded or exc
+    return ResolvedInputs(
+        actor=resolved_actor, inputs=resolved_inputs, degraded=degraded
+    )
+
+
+def _resolved_rules(
+    config: _EventsConfig, arguments: Mapping[str, Any]
+) -> Sequence[RuleWithInput]:
+    rules = config.rules
+    if not callable(rules):
+        return rules
+    return cast(
+        Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+        rules,
+    )(arguments)
+
+
+def _resolved_metadata(
+    config: _EventsConfig, arguments: Mapping[str, Any]
+) -> Optional[Metadata]:
+    metadata = config.metadata
+    if callable(metadata):
+        return cast(
+            Callable[[Mapping[str, Any]], Optional[Metadata]],
+            metadata,
+        )(arguments)
+    return metadata
+
+
+def _correlation(config: _EventsConfig) -> Optional[str]:
+    derived = claude_managed_agents_context(
+        correlation_id=config.correlation_id,
+        session_id=config.session_id,
+    )
+    return _resolve_correlation_id(derived.correlation_id)
+
+
+def _merged_metadata(
+    config: _EventsConfig, extra: Optional[Metadata]
+) -> Optional[Metadata]:
+    derived = claude_managed_agents_context(
+        correlation_id=config.correlation_id,
+        session_id=config.session_id,
+    )
+    merged: dict[str, Any] = {}
+    if derived.metadata:
+        merged.update(derived.metadata)
+    merged["claude-managed-agents.phase"] = "inbound"
+    if extra:
+        merged.update(extra)
+    return merged or None
+
+
+def _unavailable(action: str, cause: Optional[BaseException]) -> BaseException:
+    return ArcjetUnavailableError(action, cause=cause)
+
+
+async def _decide(
+    config: _EventsConfig,
+    *,
+    action: str,
+    correlation_id: Optional[str],
+    metadata: Optional[Metadata],
+    prepared: ResolvedInputs,
+    rules: Sequence[RuleWithInput],
+) -> Any:
+    kwargs = {
+        "rules": rules,
+        "label": action,
+        "metadata": metadata,
+        "correlation_id": correlation_id,
+        "actor": prepared.actor,
+        "inputs": prepared.inputs,
+    }
+    if _awaitable(config.guard, "guard") is not None or config.guard is None:
+        return await _guard_async(config.guard, **kwargs)
+    return await asyncio.to_thread(partial(_guard_sync, config.guard, **kwargs))
+
+
+async def evaluate_user_message(event: Any, config: _EventsConfig) -> InboundVerdict:
+    """Evaluate policy for one inbound ``user.message``. Never raises Arcjet."""
+    action = config.action
+    correlation_id = _resolve_correlation_id(None)
+    metadata: Optional[Metadata] = None
+    decision: Any = None
+
+    try:
+        arguments = message_arguments(event)
+        correlation_id = _correlation(config)
+        extra = _resolved_metadata(config, arguments)
+        metadata = _merged_metadata(config, extra)
+        prepared = _prepared(config, arguments)
+        rules = _resolved_rules(config, arguments)
+        decision = await _decide(
+            config,
+            action=action,
+            correlation_id=correlation_id,
+            metadata=metadata,
+            prepared=prepared,
+            rules=rules,
+        )
+        failure = _classify_decision(
+            decision,
+            action=action,
+            on_guard_error=config.on_guard_error,
+            denied_error=ArcjetDeniedError,
+            unavailable_error=_unavailable,
+            degraded=prepared.degraded,
+        )
+    except Exception:
+        if config.on_guard_error == "allow":
+            logger.warning(
+                "arcjet: policy for action %r could not be evaluated; proceeding "
+                "because on_guard_error is 'allow'",
+                action,
+            )
+            return InboundVerdict(deny=False)
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="unavailable",
+            correlation_id=correlation_id,
+            decision=None,
+            metadata=metadata,
+        )
+        return InboundVerdict(deny=True, reason=unavailable_message())
+
+    if failure is not None:
+        denied = getattr(decision, "conclusion", None) == "DENY"
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="denied" if denied else "unavailable",
+            correlation_id=correlation_id,
+            decision=decision,
+            metadata=metadata,
+        )
+        payload = payload_from_block(decision)
+        return InboundVerdict(deny=True, reason=payload["message"], decision=decision)
+
+    _emit_capture(
+        client=config.guard,
+        action=action,
+        outcome=_outcome_for_completed_action(decision, degraded=prepared.degraded),
+        correlation_id=correlation_id,
+        decision=decision,
+        metadata=metadata,
+    )
+    return InboundVerdict(deny=False)
+
+
+def _extract_inbound(args: tuple[Any, ...], kwargs: dict[str, Any]) -> list[Any]:
+    """``user.message`` values from a send / create call.
+
+    Real SDK shapes:
+
+    * ``sessions.events.send(session_id, events=[...])``
+    * ``sessions.create(..., initial_events=[...])``
+    """
+    events = kwargs.get("events")
+    initial = kwargs.get("initial_events")
+    if events is None and args:
+        # Positional ``events`` after session_id on some call styles.
+        if len(args) >= 2 and not isinstance(args[1], (str, bytes, bytearray)):
+            events = args[1]
+    return inbound_events(events, initial)
+
+
+async def _gate_inbound(
+    config: _EventsConfig, inbound: Sequence[Any]
+) -> InboundVerdict:
+    for event in inbound:
+        verdict = await evaluate_user_message(event, config)
+        if verdict.deny:
+            return verdict
+    return InboundVerdict(deny=False)
+
+
+def _looks_async(fn: Any) -> bool:
+    """True when *fn* should be awaited.
+
+    Covers ``async def`` functions, bound coroutine methods (the real
+    ``AsyncAnthropic`` ``sessions.events.send``), and instances whose
+    ``__call__`` is async.
+    """
+    if inspect.iscoroutinefunction(fn):
+        return True
+    call = getattr(fn, "__call__", None)
+    if inspect.iscoroutinefunction(call):
+        return True
+    unwrapped = inspect.unwrap(fn)
+    if inspect.iscoroutinefunction(unwrapped):
+        return True
+    unwrapped_call = getattr(unwrapped, "__call__", None)
+    return inspect.iscoroutinefunction(unwrapped_call)
+
+
+def guard_events(
+    *,
+    guard: Any,
+    send: Any,
+    action: str,
+    actor: ActorResolver = None,
+    inputs: InputResolver = None,
+    rules: RulesResolver = (),
+    metadata: MetadataResolver = None,
+    correlation_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    on_guard_error: OnGuardError = "deny",
+) -> Callable[..., Any]:
+    """Wrap ``sessions.events.send`` so inbound ``user.message`` is gated first.
+
+    Also gates ``initial_events`` when the wrapped callable is
+    ``sessions.create`` (or any send-shaped function that takes that
+    kwarg). Non-``user.message`` events (``user.custom_tool_result``,
+    ``user.interrupt``, ``user.tool_confirmation``, …) pass through
+    without an inbound check.
+
+    On DENY (or unevaluated policy under the default
+    ``on_guard_error="deny"``) the original *send* is not called and
+    :class:`~arcjet.guard.ArcjetDeniedError` /
+    :class:`~arcjet.guard.ArcjetUnavailableError` is raised. The
+    Anthropic session id passed to *send* is never used as correlation.
+
+    There is no ``guard_inbound``. ``permission_policy: always_allow``
+    (the default) cannot be gated. HITL ``always_ask`` is not policy.
+
+    Args:
+        guard: The Arcjet client. An async client is preferred; a blocking
+            client is accepted.
+        send: ``client.beta.sessions.events.send``, or another callable
+            with the same ``events=`` / ``initial_events=`` kwargs.
+        action: Checkpoint label, e.g. ``"message.received"``.
+        actor: Who is acting, or a callable of the message arguments.
+        inputs: Policy inputs, or a callable of the message arguments.
+        rules: Local rules, or a callable of the message arguments.
+        metadata: Capture metadata, or a callable of the message arguments.
+        correlation_id: Caller-owned Sequence id. Never minted. Never an
+            Anthropic session / event id we treated as ours.
+        session_id: Same, for an id the application calls a session.
+        on_guard_error: ``"deny"`` (default) or ``"allow"``.
+
+    Raises:
+        ArcjetMisconfiguration: *on_guard_error* is not ``"allow"`` or
+            ``"deny"``, or the installed ``anthropic`` is below 0.92.0.
+        TypeError: *send* is not callable.
+        ValueError: *correlation_id* / *session_id* is not printable ASCII
+            within 256 bytes.
+    """
+    _require_anthropic()
+    if on_guard_error not in ("allow", "deny"):
+        raise ArcjetMisconfiguration(
+            f"on_guard_error must be 'allow' or 'deny', got {on_guard_error!r}. "
+            f"It decides whether a call runs when policy could not be "
+            f"evaluated, so there is no safe value to guess."
+        )
+    if not callable(send):
+        raise TypeError(
+            f"guard_events() wraps a send callable "
+            f"(client.beta.sessions.events.send), got {type(send).__name__}"
+        )
+    if correlation_id is not None:
+        _validated(correlation_id)
+    if session_id is not None:
+        _validated(session_id)
+    if not isinstance(action, str) or not action:
+        raise ArcjetMisconfiguration(
+            "guard_events() needs a non-empty action string "
+            "(there is no guard_inbound helper; user.message is this path)"
+        )
+
+    config = _EventsConfig(
+        guard=guard,
+        action=action,
+        actor=actor,
+        inputs=inputs,
+        rules=rules,
+        metadata=metadata,
+        correlation_id=correlation_id,
+        session_id=session_id,
+        on_guard_error=on_guard_error,
+    )
+
+    def _raise_for(verdict: InboundVerdict) -> None:
+        if not verdict.deny:
+            return
+        if (
+            verdict.decision is not None
+            and getattr(verdict.decision, "conclusion", None) == "DENY"
+        ):
+            raise ArcjetDeniedError(config.action, verdict.decision)
+        raise ArcjetUnavailableError(config.action)
+
+    if _looks_async(send):
+
+        async def wrapped_async(*args: Any, **kwargs: Any) -> Any:
+            inbound = _extract_inbound(args, kwargs)
+            if inbound:
+                verdict = await _gate_inbound(config, inbound)
+                _raise_for(verdict)
+            result = send(*args, **kwargs)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+
+        return wrapped_async
+
+    def wrapped_sync(*args: Any, **kwargs: Any) -> Any:
+        inbound = _extract_inbound(args, kwargs)
+        if inbound:
+            verdict = asyncio.run(_gate_inbound(config, inbound))
+            _raise_for(verdict)
+        return send(*args, **kwargs)
+
+    return wrapped_sync

--- a/src/arcjet/guard/claude_managed_agents/_events.py
+++ b/src/arcjet/guard/claude_managed_agents/_events.py
@@ -6,55 +6,39 @@ caller is seeding ``initial_events``). ``user.message`` events are
 evaluated **before** the original send runs. On DENY the original is
 not called.
 
+The wrapper is always async so it is safe to ``await`` from an already
+running loop (``AsyncAnthropic``, FastAPI). A sync ``send`` is invoked
+directly after the gate; its return value is returned as-is.
+
 This is not ``guard_inbound``. There is no PreToolUse. Built-in tools
 under default ``always_allow`` cannot be gated here.
 """
 
 from __future__ import annotations
 
-import asyncio
-import inspect
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from functools import partial
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional
 
 from arcjet._errors import ArcjetMisconfiguration
-from arcjet._logging import logger
-from arcjet._metadata import Metadata
 
-from .._checkpoint import (
-    ResolvedInputs,
-    _classify_decision,
-    _emit_capture,
-    _guard_async,
-    _guard_sync,
-    _outcome_for_completed_action,
-    _resolve_correlation_id,
-)
 from .._context import _validated
 from .._errors import ArcjetDeniedError, ArcjetUnavailableError, OnGuardError
-from .._policy_input import PolicyInputMap
-from .._registry import _awaitable
-from .._rules import RuleWithInput
-from .._types import Decision
-from ._context import claude_managed_agents_context
-from ._denial import payload_from_block, unavailable_message
+from ._common import (
+    PHASE_METADATA_KEY,
+    ActorResolver,
+    InputResolver,
+    MetadataResolver,
+    RulesResolver,
+    _read,
+    adopt_wrapper,
+    brand,
+    evaluate_checkpoint,
+    is_already_guarded,
+    maybe_await,
+)
+from ._denial import payload_from_block
 from ._import import _require_anthropic
-
-ActorResolver = Union[str, Callable[[Mapping[str, Any]], Optional[str]], None]
-InputResolver = Union[
-    PolicyInputMap,
-    Callable[[Mapping[str, Any]], Optional[PolicyInputMap]],
-    None,
-]
-RulesResolver = Union[
-    Sequence[RuleWithInput],
-    Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
-]
-MetadataResolver = Union[
-    Metadata, Callable[[Mapping[str, Any]], Optional[Metadata]], None
-]
 
 _USER_MESSAGE = "user.message"
 
@@ -78,15 +62,7 @@ class InboundVerdict:
 
     deny: bool
     reason: Optional[str] = None
-    decision: Optional[Decision] = None
-
-
-def _read(source: Any, name: str) -> Any:
-    if source is None:
-        return None
-    if isinstance(source, Mapping):
-        return source.get(name)
-    return getattr(source, name, None)
+    decision: Optional[Any] = None
 
 
 def _event_type(event: Any) -> str:
@@ -147,187 +123,40 @@ def message_arguments(event: Any) -> dict[str, Any]:
     return {"prompt": prompt, "content": content, "type": _USER_MESSAGE}
 
 
-def _resolve(source: Any, arguments: Mapping[str, Any]) -> Any:
-    if source is None or not callable(source):
-        return source
-    return source(arguments)
-
-
-def _prepared(config: _EventsConfig, arguments: Mapping[str, Any]) -> ResolvedInputs:
-    degraded: Optional[BaseException] = None
-    resolved_actor: Optional[str] = None
-    resolved_inputs: Optional[PolicyInputMap] = None
-    try:
-        resolved_actor = _resolve(config.actor, arguments)
-    except Exception as exc:
-        degraded = exc
-    try:
-        resolved_inputs = _resolve(config.inputs, arguments)
-    except Exception as exc:
-        degraded = degraded or exc
-    return ResolvedInputs(
-        actor=resolved_actor, inputs=resolved_inputs, degraded=degraded
-    )
-
-
-def _resolved_rules(
-    config: _EventsConfig, arguments: Mapping[str, Any]
-) -> Sequence[RuleWithInput]:
-    rules = config.rules
-    if not callable(rules):
-        return rules
-    return cast(
-        Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
-        rules,
-    )(arguments)
-
-
-def _resolved_metadata(
-    config: _EventsConfig, arguments: Mapping[str, Any]
-) -> Optional[Metadata]:
-    metadata = config.metadata
-    if callable(metadata):
-        return cast(
-            Callable[[Mapping[str, Any]], Optional[Metadata]],
-            metadata,
-        )(arguments)
-    return metadata
-
-
-def _correlation(config: _EventsConfig) -> Optional[str]:
-    derived = claude_managed_agents_context(
-        correlation_id=config.correlation_id,
-        session_id=config.session_id,
-    )
-    return _resolve_correlation_id(derived.correlation_id)
-
-
-def _merged_metadata(
-    config: _EventsConfig, extra: Optional[Metadata]
-) -> Optional[Metadata]:
-    derived = claude_managed_agents_context(
-        correlation_id=config.correlation_id,
-        session_id=config.session_id,
-    )
-    merged: dict[str, Any] = {}
-    if derived.metadata:
-        merged.update(derived.metadata)
-    merged["claude-managed-agents.phase"] = "inbound"
-    if extra:
-        merged.update(extra)
-    return merged or None
-
-
-def _unavailable(action: str, cause: Optional[BaseException]) -> BaseException:
-    return ArcjetUnavailableError(action, cause=cause)
-
-
-async def _decide(
-    config: _EventsConfig,
-    *,
-    action: str,
-    correlation_id: Optional[str],
-    metadata: Optional[Metadata],
-    prepared: ResolvedInputs,
-    rules: Sequence[RuleWithInput],
-) -> Any:
-    kwargs = {
-        "rules": rules,
-        "label": action,
-        "metadata": metadata,
-        "correlation_id": correlation_id,
-        "actor": prepared.actor,
-        "inputs": prepared.inputs,
-    }
-    if _awaitable(config.guard, "guard") is not None or config.guard is None:
-        return await _guard_async(config.guard, **kwargs)
-    return await asyncio.to_thread(partial(_guard_sync, config.guard, **kwargs))
-
-
 async def evaluate_user_message(event: Any, config: _EventsConfig) -> InboundVerdict:
     """Evaluate policy for one inbound ``user.message``. Never raises Arcjet."""
-    action = config.action
-    correlation_id = _resolve_correlation_id(None)
-    metadata: Optional[Metadata] = None
-    decision: Any = None
-
-    try:
-        arguments = message_arguments(event)
-        correlation_id = _correlation(config)
-        extra = _resolved_metadata(config, arguments)
-        metadata = _merged_metadata(config, extra)
-        prepared = _prepared(config, arguments)
-        rules = _resolved_rules(config, arguments)
-        decision = await _decide(
-            config,
-            action=action,
-            correlation_id=correlation_id,
-            metadata=metadata,
-            prepared=prepared,
-            rules=rules,
-        )
-        failure = _classify_decision(
-            decision,
-            action=action,
-            on_guard_error=config.on_guard_error,
-            denied_error=ArcjetDeniedError,
-            unavailable_error=_unavailable,
-            degraded=prepared.degraded,
-        )
-    except Exception:
-        if config.on_guard_error == "allow":
-            logger.warning(
-                "arcjet: policy for action %r could not be evaluated; proceeding "
-                "because on_guard_error is 'allow'",
-                action,
-            )
-            return InboundVerdict(deny=False)
-        _emit_capture(
-            client=config.guard,
-            action=action,
-            outcome="unavailable",
-            correlation_id=correlation_id,
-            decision=None,
-            metadata=metadata,
-        )
-        return InboundVerdict(deny=True, reason=unavailable_message())
-
-    if failure is not None:
-        denied = getattr(decision, "conclusion", None) == "DENY"
-        _emit_capture(
-            client=config.guard,
-            action=action,
-            outcome="denied" if denied else "unavailable",
-            correlation_id=correlation_id,
-            decision=decision,
-            metadata=metadata,
-        )
-        payload = payload_from_block(decision)
-        return InboundVerdict(deny=True, reason=payload["message"], decision=decision)
-
-    _emit_capture(
-        client=config.guard,
-        action=action,
-        outcome=_outcome_for_completed_action(decision, degraded=prepared.degraded),
-        correlation_id=correlation_id,
-        decision=decision,
-        metadata=metadata,
+    outcome = await evaluate_checkpoint(
+        guard=config.guard,
+        action=config.action,
+        actor=config.actor,
+        inputs=config.inputs,
+        rules=config.rules,
+        metadata=config.metadata,
+        correlation_id=config.correlation_id,
+        session_id=config.session_id,
+        on_guard_error=config.on_guard_error,
+        arguments=message_arguments(event),
+        reserved_metadata={PHASE_METADATA_KEY: "inbound"},
     )
+    if outcome.proceeded_open:
+        return InboundVerdict(deny=False)
+    if outcome.failure is not None:
+        payload = payload_from_block(outcome.decision)
+        return InboundVerdict(
+            deny=True, reason=payload["message"], decision=outcome.decision
+        )
     return InboundVerdict(deny=False)
 
 
 def _extract_inbound(args: tuple[Any, ...], kwargs: dict[str, Any]) -> list[Any]:
     """``user.message`` values from a send / create call.
 
-    Real SDK shapes:
-
-    * ``sessions.events.send(session_id, events=[...])``
-    * ``sessions.create(..., initial_events=[...])``
+    Real SDK shape is keyword-only ``events=`` / ``initial_events=``. A
+    positional second argument is accepted for duck-typed send callables.
     """
     events = kwargs.get("events")
     initial = kwargs.get("initial_events")
     if events is None and args:
-        # Positional ``events`` after session_id on some call styles.
         if len(args) >= 2 and not isinstance(args[1], (str, bytes, bytearray)):
             events = args[1]
     return inbound_events(events, initial)
@@ -341,25 +170,6 @@ async def _gate_inbound(
         if verdict.deny:
             return verdict
     return InboundVerdict(deny=False)
-
-
-def _looks_async(fn: Any) -> bool:
-    """True when *fn* should be awaited.
-
-    Covers ``async def`` functions, bound coroutine methods (the real
-    ``AsyncAnthropic`` ``sessions.events.send``), and instances whose
-    ``__call__`` is async.
-    """
-    if inspect.iscoroutinefunction(fn):
-        return True
-    call = getattr(fn, "__call__", None)
-    if inspect.iscoroutinefunction(call):
-        return True
-    unwrapped = inspect.unwrap(fn)
-    if inspect.iscoroutinefunction(unwrapped):
-        return True
-    unwrapped_call = getattr(unwrapped, "__call__", None)
-    return inspect.iscoroutinefunction(unwrapped_call)
 
 
 def guard_events(
@@ -377,17 +187,20 @@ def guard_events(
 ) -> Callable[..., Any]:
     """Wrap ``sessions.events.send`` so inbound ``user.message`` is gated first.
 
+    Always returns an async callable. ``await`` it — including when *send*
+    itself is the sync ``Anthropic`` client method. On DENY (or unevaluated
+    policy under the default ``on_guard_error="deny"``) the original *send*
+    is not called and :class:`~arcjet.guard.ArcjetDeniedError` /
+    :class:`~arcjet.guard.ArcjetUnavailableError` is raised.
+
     Also gates ``initial_events`` when the wrapped callable is
     ``sessions.create`` (or any send-shaped function that takes that
     kwarg). Non-``user.message`` events (``user.custom_tool_result``,
     ``user.interrupt``, ``user.tool_confirmation``, …) pass through
     without an inbound check.
 
-    On DENY (or unevaluated policy under the default
-    ``on_guard_error="deny"``) the original *send* is not called and
-    :class:`~arcjet.guard.ArcjetDeniedError` /
-    :class:`~arcjet.guard.ArcjetUnavailableError` is raised. The
-    Anthropic session id passed to *send* is never used as correlation.
+    The Anthropic session id passed to *send* is never used as
+    correlation. Already-branded wrappers are returned unchanged.
 
     There is no ``guard_inbound``. ``permission_policy: always_allow``
     (the default) cannot be gated. HITL ``always_ask`` is not policy.
@@ -426,6 +239,8 @@ def guard_events(
             f"guard_events() wraps a send callable "
             f"(client.beta.sessions.events.send), got {type(send).__name__}"
         )
+    if is_already_guarded(send):
+        return send
     if correlation_id is not None:
         _validated(correlation_id)
     if session_id is not None:
@@ -458,25 +273,13 @@ def guard_events(
             raise ArcjetDeniedError(config.action, verdict.decision)
         raise ArcjetUnavailableError(config.action)
 
-    if _looks_async(send):
-
-        async def wrapped_async(*args: Any, **kwargs: Any) -> Any:
-            inbound = _extract_inbound(args, kwargs)
-            if inbound:
-                verdict = await _gate_inbound(config, inbound)
-                _raise_for(verdict)
-            result = send(*args, **kwargs)
-            if inspect.isawaitable(result):
-                return await result
-            return result
-
-        return wrapped_async
-
-    def wrapped_sync(*args: Any, **kwargs: Any) -> Any:
+    async def wrapped(*args: Any, **kwargs: Any) -> Any:
         inbound = _extract_inbound(args, kwargs)
         if inbound:
-            verdict = asyncio.run(_gate_inbound(config, inbound))
+            verdict = await _gate_inbound(config, inbound)
             _raise_for(verdict)
-        return send(*args, **kwargs)
+        return await maybe_await(send(*args, **kwargs))
 
-    return wrapped_sync
+    adopt_wrapper(wrapped, send)
+    brand(wrapped)
+    return wrapped

--- a/src/arcjet/guard/claude_managed_agents/_events.py
+++ b/src/arcjet/guard/claude_managed_agents/_events.py
@@ -148,18 +148,14 @@ async def evaluate_user_message(event: Any, config: _EventsConfig) -> InboundVer
     return InboundVerdict(deny=False)
 
 
-def _extract_inbound(args: tuple[Any, ...], kwargs: dict[str, Any]) -> list[Any]:
+def _extract_inbound(_args: tuple[Any, ...], kwargs: dict[str, Any]) -> list[Any]:
     """``user.message`` values from a send / create call.
 
-    Real SDK shape is keyword-only ``events=`` / ``initial_events=``. A
-    positional second argument is accepted for duck-typed send callables.
+    Matches the real SDK: ``events=`` / ``initial_events=`` are
+    keyword-only. A positional second argument is not treated as events
+    — ``send(session_id, *, events=...)`` would reject that shape.
     """
-    events = kwargs.get("events")
-    initial = kwargs.get("initial_events")
-    if events is None and args:
-        if len(args) >= 2 and not isinstance(args[1], (str, bytes, bytearray)):
-            events = args[1]
-    return inbound_events(events, initial)
+    return inbound_events(kwargs.get("events"), kwargs.get("initial_events"))
 
 
 async def _gate_inbound(

--- a/src/arcjet/guard/claude_managed_agents/_import.py
+++ b/src/arcjet/guard/claude_managed_agents/_import.py
@@ -119,6 +119,30 @@ _TOOL_ERROR_MODULES: Final[tuple[str, ...]] = (
 )
 
 
+#: Transient SDK errors a hosted deny ``send`` may retry. ``APIError`` is
+#: omitted — a 4xx is not transient.
+_RETRYABLE_API_ERROR_NAMES: Final[tuple[str, ...]] = (
+    "APIConnectionError",
+    "APITimeoutError",
+)
+
+
+def load_retryable_api_errors() -> tuple[type[BaseException], ...]:
+    """Anthropic connection / timeout error types, if the extra is installed."""
+    if not anthropic_present():
+        return ()
+    try:
+        module = importlib.import_module("anthropic")
+    except ImportError:
+        return ()
+    found: list[type[BaseException]] = []
+    for name in _RETRYABLE_API_ERROR_NAMES:
+        candidate = getattr(module, name, None)
+        if isinstance(candidate, type) and issubclass(candidate, BaseException):
+            found.append(candidate)
+    return tuple(found)
+
+
 def load_tool_error() -> Optional[type[BaseException]]:
     """Anthropic's ``ToolError``, if the extra is installed.
 

--- a/src/arcjet/guard/claude_managed_agents/_import.py
+++ b/src/arcjet/guard/claude_managed_agents/_import.py
@@ -1,0 +1,111 @@
+"""Lazy Anthropic imports, so this package works without the extra.
+
+The public module is importable without ``anthropic``: unit tests and
+``import arcjet.guard`` must keep working. The helpers duck-type the
+events API (``sessions.events.send``, ``agent.custom_tool_use``) so a
+missing extra does not fail the wrap. The floor is checked when the
+peer *is* installed, so a too-old SDK is refused at wrap time rather
+than as an ``AttributeError`` from inside a tool call.
+
+The floor is 0.92.0 — the first release whose changelog adds Claude
+Managed Agents (``client.beta.agents``, ``client.beta.sessions``,
+``client.beta.environments``, beta ``managed-agents-2026-04-01``).
+``EnvironmentWorker`` landed later (0.103.0); this adapter duck-types
+a worker tool's ``run`` so the extra floor stays at agents / sessions
+/ environments, not the worker helper.
+
+``importlib`` is used rather than static imports so type checkers do not
+need the extra installed either.
+"""
+
+from __future__ import annotations
+
+import importlib
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Final, Optional
+
+from arcjet._errors import ArcjetMisconfiguration
+
+#: First release that ships ``client.beta.agents`` / ``sessions`` /
+#: ``environments`` (changelog: "add support for Claude Managed Agents").
+MINIMUM_ANTHROPIC: Final[tuple[int, int, int]] = (0, 92, 0)
+
+_INSTALL_HINT: Final[str] = (
+    'Install it with: pip install "arcjet[claude-managed-agents]" '
+    "(anthropic>=0.92.0,<2)"
+)
+
+
+def _release(raw: str) -> tuple[int, ...]:
+    """The numeric release segment of *raw*, e.g. ``"0.92.0rc1"`` → ``(0, 92, 0)``.
+
+    Local parsing rather than ``packaging.version``: that is not an Arcjet
+    dependency, and a three-part release is all this comparison needs. Pre-
+    release suffixes (``rc1``) are stripped; post-releases (``0.92.0.post1``)
+    also compare as ``(0, 92, 0)`` because only the leading digit run is kept.
+    A short or non-numeric release such as ``"0.92"`` or ``"0.92.post1"``
+    collapses to ``(0, 92)``, which compares less than the three-part floor
+    and is refused — not treated as unknown and skipped. An empty parse
+    (``"weird"``) is the skip path.
+    """
+    parts: list[int] = []
+    for chunk in raw.split(".")[:3]:
+        digits = ""
+        for char in chunk:
+            if not char.isdigit():
+                break
+            digits += char
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def _installed_version() -> Optional[str]:
+    try:
+        return version("anthropic")
+    except PackageNotFoundError:  # pragma: no cover - depends on the install
+        return None
+
+
+def _require_anthropic() -> None:
+    """Refuse a peer too old to expose beta agents / sessions / environments.
+
+    Below 0.92.0 there is no ``client.beta.agents`` namespace this adapter
+    can honestly use. Reported at wrap time. A missing install is left to
+    the import path — the helpers duck-type ``send`` / ``run``.
+    """
+    installed = _installed_version()
+    if installed is None:
+        return
+    release = _release(installed)
+    if release and release < MINIMUM_ANTHROPIC:
+        floor = ".".join(str(part) for part in MINIMUM_ANTHROPIC)
+        raise ArcjetMisconfiguration(
+            f"arcjet.guard.claude_managed_agents needs anthropic >= {floor}, "
+            f"but {installed} is installed. Below {floor} there is no "
+            f"client.beta.agents / sessions / environments API (beta "
+            f"managed-agents-2026-04-01). Upgrade with: "
+            f'pip install "anthropic>={floor},<2"'
+        )
+
+
+def load_anthropic() -> Any:
+    """The ``anthropic`` package, or an error naming what to install."""
+    _require_anthropic()
+    try:
+        return importlib.import_module("anthropic")
+    except ImportError as exc:  # pragma: no cover - depends on the install
+        raise ImportError(
+            f"arcjet.guard.claude_managed_agents needs the Anthropic SDK. "
+            f"{_INSTALL_HINT}"
+        ) from exc
+
+
+def anthropic_present() -> bool:
+    """Whether ``anthropic`` is importable in this process."""
+    try:
+        importlib.import_module("anthropic")
+    except ImportError:
+        return False
+    return True

--- a/src/arcjet/guard/claude_managed_agents/_import.py
+++ b/src/arcjet/guard/claude_managed_agents/_import.py
@@ -11,7 +11,7 @@ The floor is 0.92.0 — the first release whose changelog adds Claude
 Managed Agents (``client.beta.agents``, ``client.beta.sessions``,
 ``client.beta.environments``, beta ``managed-agents-2026-04-01``).
 ``EnvironmentWorker`` landed later (0.103.0); this adapter duck-types
-a worker tool's ``run`` so the extra floor stays at agents / sessions
+a worker tool's ``call`` so the extra floor stays at agents / sessions
 / environments, not the worker helper.
 
 ``importlib`` is used rather than static imports so type checkers do not
@@ -73,7 +73,7 @@ def _require_anthropic() -> None:
 
     Below 0.92.0 there is no ``client.beta.agents`` namespace this adapter
     can honestly use. Reported at wrap time. A missing install is left to
-    the import path — the helpers duck-type ``send`` / ``run``.
+    the import path — the helpers duck-type ``send`` / ``call``.
     """
     installed = _installed_version()
     if installed is None:
@@ -109,3 +109,32 @@ def anthropic_present() -> bool:
     except ImportError:
         return False
     return True
+
+
+#: Where the SDK has exported ``ToolError``. Checked in order; the public
+#: ``anthropic.lib.tools`` path is preferred over the private module.
+_TOOL_ERROR_MODULES: Final[tuple[str, ...]] = (
+    "anthropic.lib.tools",
+    "anthropic.lib.tools._beta_functions",
+)
+
+
+def load_tool_error() -> Optional[type[BaseException]]:
+    """Anthropic's ``ToolError``, if the extra is installed.
+
+    ``SessionToolRunner`` sets ``is_error`` on ``user.custom_tool_result``
+    only when the local tool raises. ``ToolError`` keeps the denial JSON as
+    ``content`` instead of ``repr(exc)``.
+    """
+    if not anthropic_present():
+        return None
+    _require_anthropic()
+    for name in _TOOL_ERROR_MODULES:
+        try:
+            module = importlib.import_module(name)
+        except ImportError:
+            continue
+        candidate = getattr(module, "ToolError", None)
+        if isinstance(candidate, type) and issubclass(candidate, BaseException):
+            return candidate
+    return None

--- a/src/arcjet/guard/claude_managed_agents/_tool.py
+++ b/src/arcjet/guard/claude_managed_agents/_tool.py
@@ -47,7 +47,7 @@ from ._denial import (
     payload_from_block,
     raise_worker_denial,
 )
-from ._import import _require_anthropic
+from ._import import _require_anthropic, load_retryable_api_errors
 
 #: How many times a hosted deny ``send`` is attempted before giving up.
 DENIAL_SEND_ATTEMPTS = 3
@@ -194,9 +194,9 @@ async def _send_denial(
         try:
             return await maybe_await(send(anthropic_session_id, events=[body]))
         except Exception as exc:
-            last_error = exc
-            if attempt + 1 >= attempts:
+            if not _is_retryable_send_error(exc) or attempt + 1 >= attempts:
                 raise
+            last_error = exc
             delay_index = min(attempt, len(DENIAL_SEND_BACKOFF_SECONDS) - 1)
             if delay_index >= 0 and DENIAL_SEND_BACKOFF_SECONDS:
                 await asyncio.sleep(DENIAL_SEND_BACKOFF_SECONDS[delay_index])
@@ -205,12 +205,15 @@ async def _send_denial(
     return None
 
 
-def _positional_param_names(fn: Any) -> Optional[list[str]]:
-    """Positional / named-positional parameter names, or ``None`` if unknown."""
+def _signature(fn: Any) -> Optional[inspect.Signature]:
     try:
-        signature = inspect.signature(fn)
+        return inspect.signature(fn)
     except (TypeError, ValueError):
         return None
+
+
+def _positional_param_names(signature: inspect.Signature) -> list[str]:
+    """Positional / named-positional parameter names."""
     names: list[str] = []
     for param in signature.parameters.values():
         if param.kind in (
@@ -228,22 +231,47 @@ def _positional_param_names(fn: Any) -> Optional[list[str]]:
     return names
 
 
+def _binds(signature: inspect.Signature, *args: Any) -> bool:
+    try:
+        signature.bind(*args)
+    except TypeError:
+        return False
+    return True
+
+
+def _is_retryable_send_error(exc: BaseException) -> bool:
+    """True for transient transport failures, not programmer errors."""
+    if isinstance(exc, (OSError, TimeoutError, asyncio.TimeoutError)):
+        return True
+    retryable = load_retryable_api_errors()
+    return bool(retryable) and isinstance(exc, retryable)
+
+
 def _invoke_run(run: Any, event: Any) -> Any:
     """Call a hosted ``run`` from its signature. Never catches a body error.
 
-    Contracts, in order:
+    Contracts, in order, each confirmed with ``Signature.bind`` before call:
 
     * ``(name, input)`` / ``(tool_name, arguments)``
     * a single ``input`` / ``arguments`` mapping
     * the ``agent.custom_tool_use`` event (the default)
     """
-    names = _positional_param_names(run)
-    if names is not None and len(names) >= 2:
+    signature = _signature(run)
+    if signature is None:
+        return run(event)
+    names = _positional_param_names(signature)
+    if len(names) >= 2:
         first, second = names[0], names[1]
         if first in {"name", "tool_name"} and second in {"input", "arguments"}:
-            return run(_tool_name(event), _arguments_from_event(event))
-    if names is not None and len(names) == 1 and names[0] in {"input", "arguments"}:
-        return run(_arguments_from_event(event))
+            pair = (_tool_name(event), _arguments_from_event(event))
+            if _binds(signature, *pair):
+                return run(*pair)
+    if len(names) == 1 and names[0] in {"input", "arguments"}:
+        single = (_arguments_from_event(event),)
+        if _binds(signature, *single):
+            return run(*single)
+    if _binds(signature, event):
+        return run(event)
     return run(event)
 
 

--- a/src/arcjet/guard/claude_managed_agents/_tool.py
+++ b/src/arcjet/guard/claude_managed_agents/_tool.py
@@ -1,14 +1,15 @@
 """Custom-tool gate for Claude Managed Agents.
 
-On ``agent.custom_tool_use`` Guard runs **before** the app ``run``. On
+On ``agent.custom_tool_use`` Guard runs **before** the app handler. On
 DENY the original does not run and the wrapper sends a real
 ``user.custom_tool_result`` via ``sessions.events.send``. There is no
 PreToolUse.
 
-A ``tool=`` object with ``run`` (the ``@beta_tool`` /
-``@beta_async_tool`` / ``betaTool({ run })`` shape) is wrapped the same
-way for a self-hosted ``EnvironmentWorker``. The CLI worker cannot
-register custom tools.
+A ``tool=`` object with ``call`` (the Python ``@beta_tool`` /
+``@beta_async_tool`` / ``BetaFunctionTool.call`` shape that
+``SessionToolRunner`` invokes) is wrapped the same way for a
+self-hosted ``EnvironmentWorker``. The CLI worker cannot register
+custom tools.
 """
 
 from __future__ import annotations
@@ -16,62 +17,42 @@ from __future__ import annotations
 import asyncio
 import copy
 import inspect
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from functools import partial
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional
 
 from arcjet._errors import ArcjetMisconfiguration
 from arcjet._logging import logger
-from arcjet._metadata import Metadata
 
-from .._checkpoint import (
-    ResolvedInputs,
-    _classify_decision,
-    _emit_capture,
-    _guard_async,
-    _guard_sync,
-    _outcome_for_completed_action,
-    _resolve_correlation_id,
-)
 from .._context import _validated
-from .._errors import ArcjetDeniedError, ArcjetUnavailableError, OnGuardError
-from .._policy_input import PolicyInputMap
-from .._registry import _awaitable
-from .._rules import RuleWithInput
-from ._context import claude_managed_agents_context
+from .._errors import OnGuardError
+from ._common import (
+    TOOL_METADATA_KEY,
+    ActorResolver,
+    InputResolver,
+    MetadataResolver,
+    RulesResolver,
+    _read,
+    adopt_wrapper,
+    brand,
+    evaluate_checkpoint,
+    is_already_guarded,
+    looks_async,
+    maybe_await,
+    run_coroutine_sync,
+)
 from ._denial import (
     ArcjetDenialResult,
     custom_tool_result_event,
-    dumps_denial,
     payload_from_block,
+    raise_worker_denial,
 )
 from ._import import _require_anthropic
 
-ActorResolver = Union[str, Callable[[Mapping[str, Any]], Optional[str]], None]
-InputResolver = Union[
-    PolicyInputMap,
-    Callable[[Mapping[str, Any]], Optional[PolicyInputMap]],
-    None,
-]
-RulesResolver = Union[
-    Sequence[RuleWithInput],
-    Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
-]
-MetadataResolver = Union[
-    Metadata, Callable[[Mapping[str, Any]], Optional[Metadata]], None
-]
-
-#: Attribute :func:`guard_custom_tool` puts on the copy it returns, so a
-#: second wrap of the same object does not evaluate the same call twice.
-_GUARD_BRAND = "_arcjet_guarded"
-
-#: Built-in toolset names. ``web_search`` / ``web_fetch`` always run on
-#: Anthropic. Cloud bash/read/write under default ``always_allow`` cannot
-#: be gated. A self-hosted worker *does* execute bash/read/write locally;
-#: wrapping those is the caller's choice via ``tool=``, not an automatic
-#: factory rewrite of the stock toolset.
-_ANTHROPIC_CLOUD_ONLY = frozenset({"web_search", "web_fetch"})
+#: How many times a hosted deny ``send`` is attempted before giving up.
+DENIAL_SEND_ATTEMPTS = 3
+#: Backoff between deny-send retries. Tests monkeypatch this to zeros.
+DENIAL_SEND_BACKOFF_SECONDS: tuple[float, ...] = (0.05, 0.15)
 
 
 @dataclass(frozen=True, slots=True)
@@ -98,12 +79,12 @@ class CustomToolVerdict:
     payload: Optional[ArcjetDenialResult] = None
 
 
-def _read(source: Any, name: str) -> Any:
-    if source is None:
-        return None
-    if isinstance(source, Mapping):
-        return source.get(name)
-    return getattr(source, name, None)
+#: Built-in toolset names. ``web_search`` / ``web_fetch`` always run on
+#: Anthropic. Cloud bash/read/write under default ``always_allow`` cannot
+#: be gated. A self-hosted worker *does* execute bash/read/write locally;
+#: wrapping those is the caller's choice via ``tool=``, not an automatic
+#: factory rewrite of the stock toolset.
+_ANTHROPIC_CLOUD_ONLY = frozenset({"web_search", "web_fetch"})
 
 
 def _event_id(event: Any) -> str:
@@ -145,106 +126,12 @@ def _arguments_from_event(event: Any) -> Mapping[str, Any]:
     return {}
 
 
-def _resolve(source: Any, arguments: Mapping[str, Any]) -> Any:
-    if source is None or not callable(source):
-        return source
-    return source(arguments)
-
-
-def _prepared(config: _ToolConfig, arguments: Mapping[str, Any]) -> ResolvedInputs:
-    degraded: Optional[BaseException] = None
-    resolved_actor: Optional[str] = None
-    resolved_inputs: Optional[PolicyInputMap] = None
-    try:
-        resolved_actor = _resolve(config.actor, arguments)
-    except Exception as exc:
-        degraded = exc
-    try:
-        resolved_inputs = _resolve(config.inputs, arguments)
-    except Exception as exc:
-        degraded = degraded or exc
-    return ResolvedInputs(
-        actor=resolved_actor, inputs=resolved_inputs, degraded=degraded
-    )
-
-
-def _resolved_rules(
-    config: _ToolConfig, arguments: Mapping[str, Any]
-) -> Sequence[RuleWithInput]:
-    rules = config.rules
-    if not callable(rules):
-        return rules
-    return cast(
-        Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
-        rules,
-    )(arguments)
-
-
-def _resolved_metadata(
-    config: _ToolConfig, arguments: Mapping[str, Any]
-) -> Optional[Metadata]:
-    metadata = config.metadata
-    if callable(metadata):
-        return cast(
-            Callable[[Mapping[str, Any]], Optional[Metadata]],
-            metadata,
-        )(arguments)
-    return metadata
-
-
-def _correlation(config: _ToolConfig) -> Optional[str]:
-    derived = claude_managed_agents_context(
-        correlation_id=config.correlation_id,
-        session_id=config.session_id,
-    )
-    return _resolve_correlation_id(derived.correlation_id)
-
-
-def _merged_metadata(
-    config: _ToolConfig,
-    extra: Optional[Metadata],
-    *,
-    event: Any = None,
-) -> Optional[Metadata]:
-    derived = claude_managed_agents_context(
-        correlation_id=config.correlation_id,
-        session_id=config.session_id,
-    )
-    merged: dict[str, Any] = {}
-    if derived.metadata:
-        merged.update(derived.metadata)
+def _reserved_tool_metadata(event: Any, config: _ToolConfig) -> dict[str, Any]:
+    reserved: dict[str, Any] = {}
     name = _tool_name(event, config.tool_name)
     if name:
-        merged["claude-managed-agents.tool"] = name
-    if extra:
-        merged.update(extra)
-    return merged or None
-
-
-def _unavailable(action: str, cause: Optional[BaseException]) -> BaseException:
-    return ArcjetUnavailableError(action, cause=cause)
-
-
-async def _decide(
-    config: _ToolConfig,
-    *,
-    action: str,
-    correlation_id: Optional[str],
-    metadata: Optional[Metadata],
-    prepared: ResolvedInputs,
-    rules: Sequence[RuleWithInput],
-) -> Any:
-    kwargs = {
-        "rules": rules,
-        "label": action,
-        "metadata": metadata,
-        "correlation_id": correlation_id,
-        "actor": prepared.actor,
-        "inputs": prepared.inputs,
-    }
-    if _awaitable(config.guard, "guard") is not None or config.guard is None:
-        return await _guard_async(config.guard, **kwargs)
-    return await asyncio.to_thread(partial(_guard_sync, config.guard, **kwargs))
+        reserved[TOOL_METADATA_KEY] = name
+    return reserved
 
 
 async def evaluate_custom_tool(event: Any, config: _ToolConfig) -> CustomToolVerdict:
@@ -254,72 +141,25 @@ async def evaluate_custom_tool(event: Any, config: _ToolConfig) -> CustomToolVer
     the session is waiting on. The deny envelope is the only shape the
     model can read as a structured ``ArcjetDenialResult``.
     """
-    action = config.action
-    correlation_id = _resolve_correlation_id(None)
-    metadata: Optional[Metadata] = None
-    decision: Any = None
-
-    try:
-        arguments = _arguments_from_event(event)
-        correlation_id = _correlation(config)
-        extra = _resolved_metadata(config, arguments)
-        metadata = _merged_metadata(config, extra, event=event)
-        prepared = _prepared(config, arguments)
-        rules = _resolved_rules(config, arguments)
-        decision = await _decide(
-            config,
-            action=action,
-            correlation_id=correlation_id,
-            metadata=metadata,
-            prepared=prepared,
-            rules=rules,
-        )
-        failure = _classify_decision(
-            decision,
-            action=action,
-            on_guard_error=config.on_guard_error,
-            denied_error=ArcjetDeniedError,
-            unavailable_error=_unavailable,
-            degraded=prepared.degraded,
-        )
-    except Exception:
-        if config.on_guard_error == "allow":
-            logger.warning(
-                "arcjet: policy for action %r could not be evaluated; proceeding "
-                "because on_guard_error is 'allow'",
-                action,
-            )
-            return CustomToolVerdict(deny=False)
-        _emit_capture(
-            client=config.guard,
-            action=action,
-            outcome="unavailable",
-            correlation_id=correlation_id,
-            decision=None,
-            metadata=metadata,
-        )
-        return CustomToolVerdict(deny=True, payload=payload_from_block(None))
-
-    if failure is not None:
-        denied = getattr(decision, "conclusion", None) == "DENY"
-        _emit_capture(
-            client=config.guard,
-            action=action,
-            outcome="denied" if denied else "unavailable",
-            correlation_id=correlation_id,
-            decision=decision,
-            metadata=metadata,
-        )
-        return CustomToolVerdict(deny=True, payload=payload_from_block(decision))
-
-    _emit_capture(
-        client=config.guard,
-        action=action,
-        outcome=_outcome_for_completed_action(decision, degraded=prepared.degraded),
-        correlation_id=correlation_id,
-        decision=decision,
-        metadata=metadata,
+    outcome = await evaluate_checkpoint(
+        guard=config.guard,
+        action=config.action,
+        actor=config.actor,
+        inputs=config.inputs,
+        rules=config.rules,
+        metadata=config.metadata,
+        correlation_id=config.correlation_id,
+        session_id=config.session_id,
+        on_guard_error=config.on_guard_error,
+        arguments=_arguments_from_event(event),
+        reserved_metadata=_reserved_tool_metadata(event, config),
     )
+    if outcome.proceeded_open:
+        return CustomToolVerdict(deny=False)
+    if outcome.failure is not None:
+        return CustomToolVerdict(
+            deny=True, payload=payload_from_block(outcome.decision)
+        )
     return CustomToolVerdict(deny=False)
 
 
@@ -335,52 +175,78 @@ def denial_event(event: Any, verdict: CustomToolVerdict) -> dict[str, Any]:
     )
 
 
-async def _maybe_await(value: Any) -> Any:
-    if inspect.isawaitable(value):
-        return await value
-    return value
-
-
 async def _send_denial(
     *,
     send: Any,
-    session_id: Any,
+    anthropic_session_id: Any,
     event: Any,
     verdict: CustomToolVerdict,
 ) -> Any:
+    """Post the deny result, retrying transient send failures.
+
+    ``SessionToolRunner`` retries result posts; the hosted path must too,
+    or the session stays idle on ``agent.custom_tool_use``.
+    """
     body = denial_event(event, verdict)
-    # Real SDK: ``send(session_id, events=[...])``.
-    result = send(session_id, events=[body])
-    return await _maybe_await(result)
+    last_error: Optional[BaseException] = None
+    attempts = max(1, DENIAL_SEND_ATTEMPTS)
+    for attempt in range(attempts):
+        try:
+            return await maybe_await(
+                send(anthropic_session_id, events=[body])
+            )
+        except Exception as exc:
+            last_error = exc
+            if attempt + 1 >= attempts:
+                raise
+            delay_index = min(attempt, len(DENIAL_SEND_BACKOFF_SECONDS) - 1)
+            if delay_index >= 0 and DENIAL_SEND_BACKOFF_SECONDS:
+                await asyncio.sleep(DENIAL_SEND_BACKOFF_SECONDS[delay_index])
+    if last_error is not None:  # pragma: no cover - loop always raises
+        raise last_error
+    return None
 
 
-def _is_already_guarded(tool: Any) -> bool:
-    return bool(getattr(tool, _GUARD_BRAND, False))
-
-
-def _brand(tool: Any) -> None:
+def _positional_param_names(fn: Any) -> Optional[list[str]]:
+    """Positional / named-positional parameter names, or ``None`` if unknown."""
     try:
-        object.__setattr__(tool, _GUARD_BRAND, True)
-    except AttributeError as exc:
-        raise TypeError(
-            "guard_custom_tool() could not brand the tool copy with "
-            f"{_GUARD_BRAND!r}; the SDK type likely uses __slots__ "
-            "without space for this attribute. The wrap cannot proceed "
-            "without the brand — a second wrap would double-call Guard."
-        ) from exc
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return None
+    names: list[str] = []
+    for param in signature.parameters.values():
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        if param.name in {"self", "cls"}:
+            continue
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            names.append(param.name)
+    return names
 
 
 def _invoke_run(run: Any, event: Any) -> Any:
-    """Call a user ``run`` with the custom-tool event or its input.
+    """Call a hosted ``run`` from its signature. Never catches a body error.
 
-    Hosted handlers typically take ``(name, input)`` or the event. A
-    worker ``@beta_tool`` ``run`` takes the validated input mapping.
-    Try the event first; if that TypeError-s on arity, pass input.
+    Contracts, in order:
+
+    * ``(name, input)`` / ``(tool_name, arguments)``
+    * a single ``input`` / ``arguments`` mapping
+    * the ``agent.custom_tool_use`` event (the default)
     """
-    try:
-        return run(event)
-    except TypeError:
+    names = _positional_param_names(run)
+    if names is not None and len(names) >= 2:
+        first, second = names[0], names[1]
+        if first in {"name", "tool_name"} and second in {"input", "arguments"}:
+            return run(_tool_name(event), _arguments_from_event(event))
+    if names is not None and len(names) == 1 and names[0] in {"input", "arguments"}:
         return run(_arguments_from_event(event))
+    return run(event)
 
 
 def _wrap_run_handler(config: _ToolConfig, run: Any) -> Callable[..., Any]:
@@ -388,7 +254,7 @@ def _wrap_run_handler(config: _ToolConfig, run: Any) -> Callable[..., Any]:
         event: Any,
         *,
         send: Any,
-        session_id: Any,
+        anthropic_session_id: Any,
     ) -> Any:
         try:
             verdict = await evaluate_custom_tool(event, config)
@@ -399,63 +265,43 @@ def _wrap_run_handler(config: _ToolConfig, run: Any) -> Callable[..., Any]:
                     "proceeding because on_guard_error is 'allow'",
                     config.action,
                 )
-                return await _maybe_await(_invoke_run(run, event))
+                return await maybe_await(_invoke_run(run, event))
             await _send_denial(
                 send=send,
-                session_id=session_id,
+                anthropic_session_id=anthropic_session_id,
                 event=event,
                 verdict=CustomToolVerdict(deny=True, payload=payload_from_block(None)),
             )
             return None
         if verdict.deny:
             await _send_denial(
-                send=send, session_id=session_id, event=event, verdict=verdict
+                send=send,
+                anthropic_session_id=anthropic_session_id,
+                event=event,
+                verdict=verdict,
             )
             return None
-        return await _maybe_await(_invoke_run(run, event))
+        return await maybe_await(_invoke_run(run, event))
 
+    adopt_wrapper(handle, run)
     return handle
 
 
-def _wrap_tool_run(config: _ToolConfig, original: Any) -> Any:
-    """Wrap a worker tool ``run`` so DENY never executes the body.
-
-    The EnvironmentWorker / SessionToolRunner posts
-    ``user.custom_tool_result`` from the return value. Returning the
-    denial JSON is the same gate; we do not invent a second send.
-    """
-
-    async def guarded_run(*args: Any, **kwargs: Any) -> Any:
-        event = _event_from_run_args(config.tool_name, args, kwargs)
-        try:
-            verdict = await evaluate_custom_tool(event, config)
-        except Exception:
-            if config.on_guard_error == "allow":
-                return await _maybe_await(original(*args, **kwargs))
-            return dumps_denial(payload_from_block(None))
-        if verdict.deny:
-            payload = (
-                verdict.payload
-                if verdict.payload is not None
-                else payload_from_block(None)
-            )
-            return dumps_denial(payload)
-        return await _maybe_await(original(*args, **kwargs))
-
-    if inspect.iscoroutinefunction(inspect.unwrap(original)):
-        return guarded_run
-
-    def guarded_run_sync(*args: Any, **kwargs: Any) -> Any:
-        return asyncio.run(guarded_run(*args, **kwargs))
-
-    return guarded_run_sync
-
-
-def _event_from_run_args(
+def _event_from_call_args(
     tool_name: str, args: tuple[Any, ...], kwargs: dict[str, Any]
 ) -> dict[str, Any]:
-    """Rebuild an ``agent.custom_tool_use``-shaped mapping from ``run`` args."""
-    if args and isinstance(args[0], Mapping) and "input" in args[0]:
+    """Rebuild an ``agent.custom_tool_use``-shaped mapping from ``call`` args.
+
+    ``SessionToolRunner`` invokes ``tool.call(input)`` with the model input
+    mapping. A mapping is treated as a full event only when it *is* one
+    (``type == agent.custom_tool_use``), not merely because it has an
+    ``input`` key — that is a legal tool-schema field.
+    """
+    if (
+        args
+        and isinstance(args[0], Mapping)
+        and args[0].get("type") == "agent.custom_tool_use"
+    ):
         source = args[0]
         return {
             "type": "agent.custom_tool_use",
@@ -466,6 +312,8 @@ def _event_from_run_args(
     input_map: dict[str, Any] = {}
     if args and isinstance(args[0], Mapping):
         input_map = dict(args[0])
+    elif "input" in kwargs and isinstance(kwargs["input"], Mapping):
+        input_map = dict(kwargs["input"])
     elif kwargs:
         input_map = dict(kwargs)
     return {
@@ -476,26 +324,65 @@ def _event_from_run_args(
     }
 
 
-def _has_run(tool: Any) -> bool:
-    return callable(getattr(tool, "run", None))
+def _wrap_tool_call(config: _ToolConfig, original: Any) -> Any:
+    """Wrap a worker tool ``call`` so DENY never executes the body.
+
+    ``SessionToolRunner`` posts ``user.custom_tool_result`` from the
+    return value and sets ``is_error`` only when ``call`` raises.
+    Returning denial JSON would look like success. Raising
+    ``ToolError`` (or :class:`~._denial.WorkerToolDenied` without the
+    extra) is the honest deny.
+    """
+
+    async def guarded_call(*args: Any, **kwargs: Any) -> Any:
+        event = _event_from_call_args(config.tool_name, args, kwargs)
+        try:
+            verdict = await evaluate_custom_tool(event, config)
+        except Exception:
+            if config.on_guard_error == "allow":
+                return await maybe_await(original(*args, **kwargs))
+            raise_worker_denial(payload_from_block(None))
+        if verdict.deny:
+            payload = (
+                verdict.payload
+                if verdict.payload is not None
+                else payload_from_block(None)
+            )
+            raise_worker_denial(payload)
+        return await maybe_await(original(*args, **kwargs))
+
+    if looks_async(original):
+        adopt_wrapper(guarded_call, original)
+        return guarded_call
+
+    def guarded_call_sync(*args: Any, **kwargs: Any) -> Any:
+        return run_coroutine_sync(guarded_call(*args, **kwargs))
+
+    adopt_wrapper(guarded_call_sync, original)
+    return guarded_call_sync
+
+
+def _has_call(tool: Any) -> bool:
+    return callable(getattr(tool, "call", None))
 
 
 def _wrap_tool_object(tool: Any, config: _ToolConfig) -> Any:
-    if _is_already_guarded(tool):
+    if is_already_guarded(tool):
         return tool
-    if not _has_run(tool):
+    if not _has_call(tool):
         raise TypeError(
-            "guard_custom_tool(tool=) wraps an object with a callable run "
-            f"(beta_tool / beta_async_tool), got {type(tool).__name__}"
+            "guard_custom_tool(tool=) wraps an object with a callable call "
+            f"(BetaFunctionTool / @beta_tool / @beta_async_tool), got "
+            f"{type(tool).__name__}"
         )
     guarded = copy.copy(tool)
-    original = getattr(tool, "run")
-    wrapped = _wrap_tool_run(config, original)
+    original = getattr(tool, "call")
+    wrapped = _wrap_tool_call(config, original)
     try:
-        object.__setattr__(guarded, "run", wrapped)
+        object.__setattr__(guarded, "call", wrapped)
     except AttributeError:
-        guarded.run = wrapped
-    _brand(guarded)
+        guarded.call = wrapped
+    brand(guarded)
     return guarded
 
 
@@ -541,17 +428,26 @@ def guard_custom_tool(
 
     Pass ``run=`` for the hosted REST+SSE path. The returned handler is::
 
-        await handler(event, send=client.beta.sessions.events.send, session_id=...)
+        await handler(
+            event,
+            send=client.beta.sessions.events.send,
+            anthropic_session_id=session.id,
+        )
+
+    ``anthropic_session_id`` is Anthropic's ``ses_...``, used only to post
+    ``user.custom_tool_result``. Wrap-time ``session_id=`` is a
+    caller-owned correlation id and is never read off that value.
 
     On DENY (or unevaluated policy under the default
     ``on_guard_error="deny"``) the original ``run`` is not called and
     ``user.custom_tool_result`` is sent with error text (schema field
-    ``is_error`` is set). On ALLOW, ``run`` executes and the caller
-    sends the success result.
+    ``is_error`` is set). Transient send failures are retried. On ALLOW,
+    ``run`` executes and the caller sends the success result.
 
     Pass ``tool=`` for a self-hosted ``EnvironmentWorker`` /
-    ``@beta_tool`` object. The returned copy has ``run`` wrapped the
-    same way; the worker posts the denial JSON as the tool result.
+    ``@beta_tool`` object. The returned copy has ``call`` wrapped — that
+    is what ``SessionToolRunner`` invokes, not ``run``. On DENY the
+    wrapper raises ``ToolError`` so the runner posts ``is_error=True``.
     Already-branded tools are returned unchanged. The ``ant`` CLI
     worker cannot register custom tools.
 
@@ -565,9 +461,10 @@ def guard_custom_tool(
             client is accepted.
         action: Checkpoint label, e.g. ``"email.sent"``.
         run: Hosted custom-tool body. Called with the
-            ``agent.custom_tool_use`` event (or its ``input`` mapping).
-        tool: A worker tool with ``run`` (``@beta_tool`` /
-            ``@beta_async_tool``).
+            ``agent.custom_tool_use`` event, its ``input`` mapping, or
+            ``(name, input)`` — chosen from the callable's signature.
+        tool: A worker tool with ``call`` (``@beta_tool`` /
+            ``@beta_async_tool`` / ``BetaFunctionTool``).
         actor: Who is acting, or a callable of the tool arguments.
         inputs: Policy inputs, or a callable of the tool arguments.
         rules: Local rules, or a callable of the tool arguments.
@@ -575,13 +472,14 @@ def guard_custom_tool(
         correlation_id: Caller-owned Sequence id. Never minted. Never an
             Anthropic session / event id we treated as ours.
         session_id: Same, for an id the application calls a session.
+            Not Anthropic's ``ses_...``.
         on_guard_error: ``"deny"`` (default) or ``"allow"``.
 
     Raises:
         ArcjetMisconfiguration: *on_guard_error* is not ``"allow"`` or
             ``"deny"``, or the installed ``anthropic`` is below 0.92.0.
         TypeError: neither ``run`` nor ``tool`` was provided, or *tool*
-            has no callable ``run``.
+            has no callable ``call``.
         ValueError: *correlation_id* / *session_id* is not printable ASCII
             within 256 bytes.
     """
@@ -604,7 +502,7 @@ def guard_custom_tool(
         if tool_name in _ANTHROPIC_CLOUD_ONLY:
             logger.warning(
                 "arcjet: %s always runs on Anthropic; wrapping its local "
-                "run does not gate the cloud tool",
+                "call does not gate the cloud tool",
                 tool_name,
             )
 

--- a/src/arcjet/guard/claude_managed_agents/_tool.py
+++ b/src/arcjet/guard/claude_managed_agents/_tool.py
@@ -192,9 +192,7 @@ async def _send_denial(
     attempts = max(1, DENIAL_SEND_ATTEMPTS)
     for attempt in range(attempts):
         try:
-            return await maybe_await(
-                send(anthropic_session_id, events=[body])
-            )
+            return await maybe_await(send(anthropic_session_id, events=[body]))
         except Exception as exc:
             last_error = exc
             if attempt + 1 >= attempts:

--- a/src/arcjet/guard/claude_managed_agents/_tool.py
+++ b/src/arcjet/guard/claude_managed_agents/_tool.py
@@ -1,0 +1,631 @@
+"""Custom-tool gate for Claude Managed Agents.
+
+On ``agent.custom_tool_use`` Guard runs **before** the app ``run``. On
+DENY the original does not run and the wrapper sends a real
+``user.custom_tool_result`` via ``sessions.events.send``. There is no
+PreToolUse.
+
+A ``tool=`` object with ``run`` (the ``@beta_tool`` /
+``@beta_async_tool`` / ``betaTool({ run })`` shape) is wrapped the same
+way for a self-hosted ``EnvironmentWorker``. The CLI worker cannot
+register custom tools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import inspect
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Optional, Union, cast
+
+from arcjet._errors import ArcjetMisconfiguration
+from arcjet._logging import logger
+from arcjet._metadata import Metadata
+
+from .._checkpoint import (
+    ResolvedInputs,
+    _classify_decision,
+    _emit_capture,
+    _guard_async,
+    _guard_sync,
+    _outcome_for_completed_action,
+    _resolve_correlation_id,
+)
+from .._context import _validated
+from .._errors import ArcjetDeniedError, ArcjetUnavailableError, OnGuardError
+from .._policy_input import PolicyInputMap
+from .._registry import _awaitable
+from .._rules import RuleWithInput
+from ._context import claude_managed_agents_context
+from ._denial import (
+    ArcjetDenialResult,
+    custom_tool_result_event,
+    dumps_denial,
+    payload_from_block,
+)
+from ._import import _require_anthropic
+
+ActorResolver = Union[str, Callable[[Mapping[str, Any]], Optional[str]], None]
+InputResolver = Union[
+    PolicyInputMap,
+    Callable[[Mapping[str, Any]], Optional[PolicyInputMap]],
+    None,
+]
+RulesResolver = Union[
+    Sequence[RuleWithInput],
+    Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+]
+MetadataResolver = Union[
+    Metadata, Callable[[Mapping[str, Any]], Optional[Metadata]], None
+]
+
+#: Attribute :func:`guard_custom_tool` puts on the copy it returns, so a
+#: second wrap of the same object does not evaluate the same call twice.
+_GUARD_BRAND = "_arcjet_guarded"
+
+#: Built-in toolset names. ``web_search`` / ``web_fetch`` always run on
+#: Anthropic. Cloud bash/read/write under default ``always_allow`` cannot
+#: be gated. A self-hosted worker *does* execute bash/read/write locally;
+#: wrapping those is the caller's choice via ``tool=``, not an automatic
+#: factory rewrite of the stock toolset.
+_ANTHROPIC_CLOUD_ONLY = frozenset({"web_search", "web_fetch"})
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolConfig:
+    guard: Any
+    action: str
+    actor: ActorResolver
+    inputs: InputResolver
+    rules: RulesResolver
+    metadata: MetadataResolver
+    correlation_id: Optional[str]
+    session_id: Optional[str]
+    on_guard_error: OnGuardError
+    tool_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class CustomToolVerdict:
+    """What the custom-tool wrapper should do. Unit tests call this
+    without constructing a real Anthropic client.
+    """
+
+    deny: bool
+    payload: Optional[ArcjetDenialResult] = None
+
+
+def _read(source: Any, name: str) -> Any:
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        return source.get(name)
+    return getattr(source, name, None)
+
+
+def _event_id(event: Any) -> str:
+    """Anthropic's event id — used only as ``custom_tool_use_id``, never
+    as a Sequence correlation we minted.
+    """
+    for name in ("id", "event_id", "eventId"):
+        value = _read(event, name)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _session_thread_id(event: Any) -> Optional[str]:
+    value = _read(event, "session_thread_id")
+    if value is None:
+        value = _read(event, "sessionThreadId")
+    return value if isinstance(value, str) and value else None
+
+
+def _tool_name(event: Any, fallback: str = "") -> str:
+    value = _read(event, "name")
+    if value is None:
+        value = _read(event, "tool_name")
+    if value is None:
+        value = _read(event, "toolName")
+    if isinstance(value, str) and value:
+        return value
+    return fallback
+
+
+def _arguments_from_event(event: Any) -> Mapping[str, Any]:
+    """Model-produced input from ``agent.custom_tool_use``."""
+    raw = _read(event, "input")
+    if raw is None:
+        raw = _read(event, "arguments")
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    return {}
+
+
+def _resolve(source: Any, arguments: Mapping[str, Any]) -> Any:
+    if source is None or not callable(source):
+        return source
+    return source(arguments)
+
+
+def _prepared(config: _ToolConfig, arguments: Mapping[str, Any]) -> ResolvedInputs:
+    degraded: Optional[BaseException] = None
+    resolved_actor: Optional[str] = None
+    resolved_inputs: Optional[PolicyInputMap] = None
+    try:
+        resolved_actor = _resolve(config.actor, arguments)
+    except Exception as exc:
+        degraded = exc
+    try:
+        resolved_inputs = _resolve(config.inputs, arguments)
+    except Exception as exc:
+        degraded = degraded or exc
+    return ResolvedInputs(
+        actor=resolved_actor, inputs=resolved_inputs, degraded=degraded
+    )
+
+
+def _resolved_rules(
+    config: _ToolConfig, arguments: Mapping[str, Any]
+) -> Sequence[RuleWithInput]:
+    rules = config.rules
+    if not callable(rules):
+        return rules
+    return cast(
+        Callable[[Mapping[str, Any]], Sequence[RuleWithInput]],
+        rules,
+    )(arguments)
+
+
+def _resolved_metadata(
+    config: _ToolConfig, arguments: Mapping[str, Any]
+) -> Optional[Metadata]:
+    metadata = config.metadata
+    if callable(metadata):
+        return cast(
+            Callable[[Mapping[str, Any]], Optional[Metadata]],
+            metadata,
+        )(arguments)
+    return metadata
+
+
+def _correlation(config: _ToolConfig) -> Optional[str]:
+    derived = claude_managed_agents_context(
+        correlation_id=config.correlation_id,
+        session_id=config.session_id,
+    )
+    return _resolve_correlation_id(derived.correlation_id)
+
+
+def _merged_metadata(
+    config: _ToolConfig,
+    extra: Optional[Metadata],
+    *,
+    event: Any = None,
+) -> Optional[Metadata]:
+    derived = claude_managed_agents_context(
+        correlation_id=config.correlation_id,
+        session_id=config.session_id,
+    )
+    merged: dict[str, Any] = {}
+    if derived.metadata:
+        merged.update(derived.metadata)
+    name = _tool_name(event, config.tool_name)
+    if name:
+        merged["claude-managed-agents.tool"] = name
+    if extra:
+        merged.update(extra)
+    return merged or None
+
+
+def _unavailable(action: str, cause: Optional[BaseException]) -> BaseException:
+    return ArcjetUnavailableError(action, cause=cause)
+
+
+async def _decide(
+    config: _ToolConfig,
+    *,
+    action: str,
+    correlation_id: Optional[str],
+    metadata: Optional[Metadata],
+    prepared: ResolvedInputs,
+    rules: Sequence[RuleWithInput],
+) -> Any:
+    kwargs = {
+        "rules": rules,
+        "label": action,
+        "metadata": metadata,
+        "correlation_id": correlation_id,
+        "actor": prepared.actor,
+        "inputs": prepared.inputs,
+    }
+    if _awaitable(config.guard, "guard") is not None or config.guard is None:
+        return await _guard_async(config.guard, **kwargs)
+    return await asyncio.to_thread(partial(_guard_sync, config.guard, **kwargs))
+
+
+async def evaluate_custom_tool(event: Any, config: _ToolConfig) -> CustomToolVerdict:
+    """Evaluate policy for one ``agent.custom_tool_use``. Never raises Arcjet.
+
+    A raise from this function would skip the ``user.custom_tool_result``
+    the session is waiting on. The deny envelope is the only shape the
+    model can read as a structured ``ArcjetDenialResult``.
+    """
+    action = config.action
+    correlation_id = _resolve_correlation_id(None)
+    metadata: Optional[Metadata] = None
+    decision: Any = None
+
+    try:
+        arguments = _arguments_from_event(event)
+        correlation_id = _correlation(config)
+        extra = _resolved_metadata(config, arguments)
+        metadata = _merged_metadata(config, extra, event=event)
+        prepared = _prepared(config, arguments)
+        rules = _resolved_rules(config, arguments)
+        decision = await _decide(
+            config,
+            action=action,
+            correlation_id=correlation_id,
+            metadata=metadata,
+            prepared=prepared,
+            rules=rules,
+        )
+        failure = _classify_decision(
+            decision,
+            action=action,
+            on_guard_error=config.on_guard_error,
+            denied_error=ArcjetDeniedError,
+            unavailable_error=_unavailable,
+            degraded=prepared.degraded,
+        )
+    except Exception:
+        if config.on_guard_error == "allow":
+            logger.warning(
+                "arcjet: policy for action %r could not be evaluated; proceeding "
+                "because on_guard_error is 'allow'",
+                action,
+            )
+            return CustomToolVerdict(deny=False)
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="unavailable",
+            correlation_id=correlation_id,
+            decision=None,
+            metadata=metadata,
+        )
+        return CustomToolVerdict(deny=True, payload=payload_from_block(None))
+
+    if failure is not None:
+        denied = getattr(decision, "conclusion", None) == "DENY"
+        _emit_capture(
+            client=config.guard,
+            action=action,
+            outcome="denied" if denied else "unavailable",
+            correlation_id=correlation_id,
+            decision=decision,
+            metadata=metadata,
+        )
+        return CustomToolVerdict(deny=True, payload=payload_from_block(decision))
+
+    _emit_capture(
+        client=config.guard,
+        action=action,
+        outcome=_outcome_for_completed_action(decision, degraded=prepared.degraded),
+        correlation_id=correlation_id,
+        decision=decision,
+        metadata=metadata,
+    )
+    return CustomToolVerdict(deny=False)
+
+
+def denial_event(event: Any, verdict: CustomToolVerdict) -> dict[str, Any]:
+    """The real ``user.custom_tool_result`` a DENY must send."""
+    payload = (
+        verdict.payload if verdict.payload is not None else payload_from_block(None)
+    )
+    return custom_tool_result_event(
+        custom_tool_use_id=_event_id(event),
+        payload=payload,
+        session_thread_id=_session_thread_id(event),
+    )
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def _send_denial(
+    *,
+    send: Any,
+    session_id: Any,
+    event: Any,
+    verdict: CustomToolVerdict,
+) -> Any:
+    body = denial_event(event, verdict)
+    # Real SDK: ``send(session_id, events=[...])``.
+    result = send(session_id, events=[body])
+    return await _maybe_await(result)
+
+
+def _is_already_guarded(tool: Any) -> bool:
+    return bool(getattr(tool, _GUARD_BRAND, False))
+
+
+def _brand(tool: Any) -> None:
+    try:
+        object.__setattr__(tool, _GUARD_BRAND, True)
+    except AttributeError as exc:
+        raise TypeError(
+            "guard_custom_tool() could not brand the tool copy with "
+            f"{_GUARD_BRAND!r}; the SDK type likely uses __slots__ "
+            "without space for this attribute. The wrap cannot proceed "
+            "without the brand — a second wrap would double-call Guard."
+        ) from exc
+
+
+def _invoke_run(run: Any, event: Any) -> Any:
+    """Call a user ``run`` with the custom-tool event or its input.
+
+    Hosted handlers typically take ``(name, input)`` or the event. A
+    worker ``@beta_tool`` ``run`` takes the validated input mapping.
+    Try the event first; if that TypeError-s on arity, pass input.
+    """
+    try:
+        return run(event)
+    except TypeError:
+        return run(_arguments_from_event(event))
+
+
+def _wrap_run_handler(config: _ToolConfig, run: Any) -> Callable[..., Any]:
+    async def handle(
+        event: Any,
+        *,
+        send: Any,
+        session_id: Any,
+    ) -> Any:
+        try:
+            verdict = await evaluate_custom_tool(event, config)
+        except Exception:
+            if config.on_guard_error == "allow":
+                logger.warning(
+                    "arcjet: policy for action %r could not be evaluated; "
+                    "proceeding because on_guard_error is 'allow'",
+                    config.action,
+                )
+                return await _maybe_await(_invoke_run(run, event))
+            await _send_denial(
+                send=send,
+                session_id=session_id,
+                event=event,
+                verdict=CustomToolVerdict(deny=True, payload=payload_from_block(None)),
+            )
+            return None
+        if verdict.deny:
+            await _send_denial(
+                send=send, session_id=session_id, event=event, verdict=verdict
+            )
+            return None
+        return await _maybe_await(_invoke_run(run, event))
+
+    return handle
+
+
+def _wrap_tool_run(config: _ToolConfig, original: Any) -> Any:
+    """Wrap a worker tool ``run`` so DENY never executes the body.
+
+    The EnvironmentWorker / SessionToolRunner posts
+    ``user.custom_tool_result`` from the return value. Returning the
+    denial JSON is the same gate; we do not invent a second send.
+    """
+
+    async def guarded_run(*args: Any, **kwargs: Any) -> Any:
+        event = _event_from_run_args(config.tool_name, args, kwargs)
+        try:
+            verdict = await evaluate_custom_tool(event, config)
+        except Exception:
+            if config.on_guard_error == "allow":
+                return await _maybe_await(original(*args, **kwargs))
+            return dumps_denial(payload_from_block(None))
+        if verdict.deny:
+            payload = (
+                verdict.payload
+                if verdict.payload is not None
+                else payload_from_block(None)
+            )
+            return dumps_denial(payload)
+        return await _maybe_await(original(*args, **kwargs))
+
+    if inspect.iscoroutinefunction(inspect.unwrap(original)):
+        return guarded_run
+
+    def guarded_run_sync(*args: Any, **kwargs: Any) -> Any:
+        return asyncio.run(guarded_run(*args, **kwargs))
+
+    return guarded_run_sync
+
+
+def _event_from_run_args(
+    tool_name: str, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    """Rebuild an ``agent.custom_tool_use``-shaped mapping from ``run`` args."""
+    if args and isinstance(args[0], Mapping) and "input" in args[0]:
+        source = args[0]
+        return {
+            "type": "agent.custom_tool_use",
+            "id": _event_id(source),
+            "name": _tool_name(source, tool_name),
+            "input": _arguments_from_event(source),
+        }
+    input_map: dict[str, Any] = {}
+    if args and isinstance(args[0], Mapping):
+        input_map = dict(args[0])
+    elif kwargs:
+        input_map = dict(kwargs)
+    return {
+        "type": "agent.custom_tool_use",
+        "id": "",
+        "name": tool_name,
+        "input": input_map,
+    }
+
+
+def _has_run(tool: Any) -> bool:
+    return callable(getattr(tool, "run", None))
+
+
+def _wrap_tool_object(tool: Any, config: _ToolConfig) -> Any:
+    if _is_already_guarded(tool):
+        return tool
+    if not _has_run(tool):
+        raise TypeError(
+            "guard_custom_tool(tool=) wraps an object with a callable run "
+            f"(beta_tool / beta_async_tool), got {type(tool).__name__}"
+        )
+    guarded = copy.copy(tool)
+    original = getattr(tool, "run")
+    wrapped = _wrap_tool_run(config, original)
+    try:
+        object.__setattr__(guarded, "run", wrapped)
+    except AttributeError:
+        guarded.run = wrapped
+    _brand(guarded)
+    return guarded
+
+
+def _validate_common(
+    *,
+    on_guard_error: OnGuardError,
+    correlation_id: Optional[str],
+    session_id: Optional[str],
+    action: str,
+) -> None:
+    _require_anthropic()
+    if on_guard_error not in ("allow", "deny"):
+        raise ArcjetMisconfiguration(
+            f"on_guard_error must be 'allow' or 'deny', got {on_guard_error!r}. "
+            f"It decides whether a call runs when policy could not be "
+            f"evaluated, so there is no safe value to guess."
+        )
+    if correlation_id is not None:
+        _validated(correlation_id)
+    if session_id is not None:
+        _validated(session_id)
+    if not isinstance(action, str) or not action:
+        raise ArcjetMisconfiguration(
+            "guard_custom_tool() needs a non-empty action string"
+        )
+
+
+def guard_custom_tool(
+    *,
+    guard: Any,
+    action: str,
+    run: Any = None,
+    tool: Any = None,
+    actor: ActorResolver = None,
+    inputs: InputResolver = None,
+    rules: RulesResolver = (),
+    metadata: MetadataResolver = None,
+    correlation_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    on_guard_error: OnGuardError = "deny",
+) -> Any:
+    """Gate an ``agent.custom_tool_use`` **before** the app executes.
+
+    Pass ``run=`` for the hosted REST+SSE path. The returned handler is::
+
+        await handler(event, send=client.beta.sessions.events.send, session_id=...)
+
+    On DENY (or unevaluated policy under the default
+    ``on_guard_error="deny"``) the original ``run`` is not called and
+    ``user.custom_tool_result`` is sent with error text (schema field
+    ``is_error`` is set). On ALLOW, ``run`` executes and the caller
+    sends the success result.
+
+    Pass ``tool=`` for a self-hosted ``EnvironmentWorker`` /
+    ``@beta_tool`` object. The returned copy has ``run`` wrapped the
+    same way; the worker posts the denial JSON as the tool result.
+    Already-branded tools are returned unchanged. The ``ant`` CLI
+    worker cannot register custom tools.
+
+    Default ``permission_policy: always_allow`` for built-in / MCP
+    tools on Anthropic's cloud **cannot** be gated. ``web_search`` /
+    ``web_fetch`` always run on Anthropic. HITL ``always_ask`` is not
+    policy.
+
+    Args:
+        guard: The Arcjet client. An async client is preferred; a blocking
+            client is accepted.
+        action: Checkpoint label, e.g. ``"email.sent"``.
+        run: Hosted custom-tool body. Called with the
+            ``agent.custom_tool_use`` event (or its ``input`` mapping).
+        tool: A worker tool with ``run`` (``@beta_tool`` /
+            ``@beta_async_tool``).
+        actor: Who is acting, or a callable of the tool arguments.
+        inputs: Policy inputs, or a callable of the tool arguments.
+        rules: Local rules, or a callable of the tool arguments.
+        metadata: Capture metadata, or a callable of the tool arguments.
+        correlation_id: Caller-owned Sequence id. Never minted. Never an
+            Anthropic session / event id we treated as ours.
+        session_id: Same, for an id the application calls a session.
+        on_guard_error: ``"deny"`` (default) or ``"allow"``.
+
+    Raises:
+        ArcjetMisconfiguration: *on_guard_error* is not ``"allow"`` or
+            ``"deny"``, or the installed ``anthropic`` is below 0.92.0.
+        TypeError: neither ``run`` nor ``tool`` was provided, or *tool*
+            has no callable ``run``.
+        ValueError: *correlation_id* / *session_id* is not printable ASCII
+            within 256 bytes.
+    """
+    _validate_common(
+        on_guard_error=on_guard_error,
+        correlation_id=correlation_id,
+        session_id=session_id,
+        action=action,
+    )
+    if run is None and tool is None:
+        raise TypeError("guard_custom_tool() needs run= or tool=")
+    if run is not None and tool is not None:
+        raise TypeError("guard_custom_tool() takes run= or tool=, not both")
+
+    tool_name = ""
+    if tool is not None:
+        raw_name = getattr(tool, "name", None)
+        if isinstance(raw_name, str):
+            tool_name = raw_name
+        if tool_name in _ANTHROPIC_CLOUD_ONLY:
+            logger.warning(
+                "arcjet: %s always runs on Anthropic; wrapping its local "
+                "run does not gate the cloud tool",
+                tool_name,
+            )
+
+    config = _ToolConfig(
+        guard=guard,
+        action=action,
+        actor=actor,
+        inputs=inputs,
+        rules=rules,
+        metadata=metadata,
+        correlation_id=correlation_id,
+        session_id=session_id,
+        on_guard_error=on_guard_error,
+        tool_name=tool_name,
+    )
+
+    if tool is not None:
+        return _wrap_tool_object(tool, config)
+
+    if not callable(run):
+        raise TypeError(
+            f"guard_custom_tool(run=) needs a callable, got {type(run).__name__}"
+        )
+    return _wrap_run_handler(config, run)

--- a/tests/unit/guard/test_claude_managed_agents.py
+++ b/tests/unit/guard/test_claude_managed_agents.py
@@ -545,7 +545,9 @@ class TestCustomToolGate:
         client = StubGuardClient(decision=make_allow_decision())
         send = RecordingSend()
         handle = guard_custom_tool(guard=client, run=run, action="email.sent")
-        result = asyncio.run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
+        result = asyncio.run(
+            handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1")
+        )
         assert result == "ok"
         assert executed == [{"to": "a@example.com", "body": "hi"}]
         assert send.calls == []
@@ -758,7 +760,9 @@ class TestMissingPeer:
             run=lambda _e: "ok",
             action="x.done",
         )
-        result = asyncio.run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
+        result = asyncio.run(
+            handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1")
+        )
         assert result == "ok"
 
 
@@ -924,9 +928,7 @@ class TestReviewFixes:
             {"to": "a@example.com", "body": "hi"},
         )
 
-    def test_typeerror_in_run_body_is_not_retried(
-        self, reset_sequence_context
-    ) -> None:
+    def test_typeerror_in_run_body_is_not_retried(self, reset_sequence_context) -> None:
         calls: list[int] = []
 
         def run(event: Any) -> str:
@@ -939,7 +941,13 @@ class TestReviewFixes:
             action="email.sent",
         )
         with pytest.raises(TypeError, match="real failure"):
-            _run(handle(_custom_tool_use(), send=RecordingSend(), anthropic_session_id="ses_1"))
+            _run(
+                handle(
+                    _custom_tool_use(),
+                    send=RecordingSend(),
+                    anthropic_session_id="ses_1",
+                )
+            )
         assert calls == [1]
 
     def test_pydantic_shaped_custom_tool_use(self, reset_sequence_context) -> None:
@@ -975,7 +983,9 @@ class TestReviewFixes:
             def __init__(self) -> None:
                 self.n = 0
 
-            def __call__(self, session_id: Any, *, events: Any = None, **kwargs: Any) -> str:
+            def __call__(
+                self, session_id: Any, *, events: Any = None, **kwargs: Any
+            ) -> str:
                 self.n += 1
                 if self.n < 3:
                     raise ConnectionError("blip")
@@ -996,7 +1006,9 @@ class TestReviewFixes:
         monkeypatch.setattr(tool_module, "DENIAL_SEND_BACKOFF_SECONDS", (0, 0))
 
         class DeadSend:
-            def __call__(self, session_id: Any, *, events: Any = None, **kwargs: Any) -> str:
+            def __call__(
+                self, session_id: Any, *, events: Any = None, **kwargs: Any
+            ) -> str:
                 raise ConnectionError("down")
 
         handle = guard_custom_tool(
@@ -1005,7 +1017,11 @@ class TestReviewFixes:
             action="email.sent",
         )
         with pytest.raises(ConnectionError, match="down"):
-            _run(handle(_custom_tool_use(), send=DeadSend(), anthropic_session_id="ses_1"))
+            _run(
+                handle(
+                    _custom_tool_use(), send=DeadSend(), anthropic_session_id="ses_1"
+                )
+            )
 
     def test_worker_denial_prefers_tool_error(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/guard/test_claude_managed_agents.py
+++ b/tests/unit/guard/test_claude_managed_agents.py
@@ -770,7 +770,9 @@ class TestVersionFloor:
     def test_release_parsing(self) -> None:
         assert _release("0.92.0") == (0, 92, 0)
         assert _release("0.92.0rc1") == (0, 92, 0)
+        assert _release("0.92.0.post1") == (0, 92, 0)
         assert _release("0.92") == (0, 92)
+        assert _release("0.92.post1") == (0, 92)
         assert _release("1.3.0") == (1, 3, 0)
         assert _release("weird") == ()
 
@@ -782,7 +784,7 @@ class TestVersionFloor:
     def test_at_or_above_the_floor_is_accepted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        for installed in ("0.92.0", "0.97.0", "1.3.0"):
+        for installed in ("0.92.0", "0.92.0.post1", "0.97.0", "1.3.0"):
             monkeypatch.setattr(
                 import_module, "_installed_version", lambda v=installed: v
             )
@@ -793,6 +795,13 @@ class TestVersionFloor:
     ) -> None:
         monkeypatch.setattr(import_module, "_installed_version", lambda: None)
         import_module._require_anthropic()
+
+    def test_short_post_release_of_the_floor_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(import_module, "_installed_version", lambda: "0.92.post1")
+        with pytest.raises(ArcjetMisconfiguration, match="needs anthropic >= 0.92.0"):
+            import_module._require_anthropic()
 
 
 class TestReviewFixes:
@@ -999,6 +1008,49 @@ class TestReviewFixes:
         )
         _run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
         assert send.n == 3
+
+    def test_denial_send_does_not_retry_programmer_errors(
+        self, reset_sequence_context, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(tool_module, "DENIAL_SEND_BACKOFF_SECONDS", (0, 0))
+
+        class BadSend:
+            def __init__(self) -> None:
+                self.n = 0
+
+            def __call__(
+                self, session_id: Any, *, events: Any = None, **kwargs: Any
+            ) -> str:
+                self.n += 1
+                raise TypeError("send() missing events")
+
+        send = BadSend()
+        handle = guard_custom_tool(
+            guard=StubGuardClient(decision=make_deny_decision()),
+            run=lambda _e: "x",
+            action="email.sent",
+        )
+        with pytest.raises(TypeError, match="missing events"):
+            _run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
+        assert send.n == 1
+
+    def test_positional_second_arg_is_not_treated_as_events(
+        self, reset_sequence_context
+    ) -> None:
+        class LooseSend:
+            def __init__(self) -> None:
+                self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+            def __call__(self, *args: Any, **kwargs: Any) -> str:
+                self.calls.append((args, kwargs))
+                return "sent"
+
+        client = StubGuardClient(decision=make_deny_decision())
+        send = LooseSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        assert _run(wrapped("ses_1", [_user_message("inject")])) == "sent"
+        assert client.guards == []
+        assert len(send.calls) == 1
 
     def test_denial_send_retries_then_raises(
         self, reset_sequence_context, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/guard/test_claude_managed_agents.py
+++ b/tests/unit/guard/test_claude_managed_agents.py
@@ -1,0 +1,770 @@
+"""Claude Managed Agents adapter unit tests that must run with anthropic absent.
+
+The extra is optional. These tests import ``arcjet.guard.claude_managed_agents``
+helpers that do not load the peer. This is not the Claude Agent SDK extra.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from guard_doubles import (
+    StubGuardClient,
+    make_allow_decision,
+    make_deny_decision,
+)
+
+from arcjet._errors import ArcjetMisconfiguration
+from arcjet.guard import arcjet_sequence
+from arcjet.guard._errors import ArcjetDeniedError, ArcjetUnavailableError
+from arcjet.guard._types import RuleResultError, RuleResultTokenBucket
+from arcjet.guard.claude_managed_agents import _import as import_module
+from arcjet.guard.claude_managed_agents import (
+    claude_managed_agents_context,
+    guard_custom_tool,
+    guard_events,
+)
+from arcjet.guard.claude_managed_agents._context import ClaudeManagedAgentsContext
+from arcjet.guard.claude_managed_agents._denial import (
+    UNAVAILABLE_RETRY_AFTER_SECONDS,
+    custom_tool_result_event,
+    denial_result,
+    dumps_denial,
+    payload_from_block,
+    retry_after_seconds,
+    unavailable_result,
+)
+from arcjet.guard.claude_managed_agents._events import (
+    _EventsConfig,
+    evaluate_user_message,
+    inbound_events,
+    message_arguments,
+)
+from arcjet.guard.claude_managed_agents._import import (
+    _release,
+    anthropic_present,
+    load_anthropic,
+)
+from arcjet.guard.claude_managed_agents._tool import (
+    _GUARD_BRAND,
+    _arguments_from_event,
+    _ToolConfig,
+    denial_event,
+    evaluate_custom_tool,
+)
+
+MANAGED_SRC = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "arcjet"
+    / "guard"
+    / "claude_managed_agents"
+)
+
+
+def _events_config(**kwargs: Any) -> _EventsConfig:
+    defaults: dict[str, Any] = {
+        "guard": StubGuardClient(decision=make_allow_decision()),
+        "action": "message.received",
+        "actor": None,
+        "inputs": None,
+        "rules": (),
+        "metadata": None,
+        "correlation_id": None,
+        "session_id": None,
+        "on_guard_error": "deny",
+    }
+    defaults.update(kwargs)
+    return _EventsConfig(**defaults)
+
+
+def _tool_config(**kwargs: Any) -> _ToolConfig:
+    defaults: dict[str, Any] = {
+        "guard": StubGuardClient(decision=make_allow_decision()),
+        "action": "email.sent",
+        "actor": None,
+        "inputs": None,
+        "rules": (),
+        "metadata": None,
+        "correlation_id": None,
+        "session_id": None,
+        "on_guard_error": "deny",
+        "tool_name": "send_email",
+    }
+    defaults.update(kwargs)
+    return _ToolConfig(**defaults)
+
+
+def _user_message(text: str = "hello") -> dict[str, Any]:
+    return {
+        "type": "user.message",
+        "content": [{"type": "text", "text": text}],
+    }
+
+
+def _custom_tool_use(
+    *,
+    event_id: str = "sevt_tool_1",
+    name: str = "send_email",
+    input_data: Mapping[str, Any] | None = None,
+    session_thread_id: str | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "type": "agent.custom_tool_use",
+        "id": event_id,
+        "name": name,
+        "input": dict(input_data or {"to": "a@example.com", "body": "hi"}),
+    }
+    if session_thread_id is not None:
+        event["session_thread_id"] = session_thread_id
+    return event
+
+
+class RecordingSend:
+    """Stand-in for ``client.beta.sessions.events.send``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def __call__(self, session_id: Any, *, events: Any = None, **kwargs: Any) -> str:
+        self.calls.append((session_id, {"events": events, **kwargs}))
+        return "sent"
+
+
+class AsyncRecordingSend:
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+    async def __call__(
+        self, session_id: Any, *, events: Any = None, **kwargs: Any
+    ) -> str:
+        self.calls.append((session_id, {"events": events, **kwargs}))
+        return "sent"
+
+
+class TestSourceIsolation:
+    def test_package_does_not_import_sibling_adapters(self) -> None:
+        for path in MANAGED_SRC.glob("*.py"):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module:
+                    assert "langchain" not in node.module
+                    assert "crewai" not in node.module
+                    assert "openai_agents" not in node.module
+                    assert "claude_agent_sdk" not in node.module
+                    assert node.module != "arcjet.guard.langchain"
+                    assert node.module != "arcjet.guard.crewai"
+                    assert node.module != "arcjet.guard.openai_agents"
+                    assert node.module != "arcjet.guard.claude_agent_sdk"
+                    assert node.module != "claude_agent_sdk"
+                    assert not node.module.startswith("claude_agent_sdk.")
+                    assert node.module != "anthropic"
+                    assert not node.module.startswith("anthropic.")
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        assert "langchain" not in alias.name
+                        assert "crewai" not in alias.name
+                        assert "openai_agents" not in alias.name
+                        assert "claude_agent_sdk" not in alias.name
+                        assert alias.name != "claude_agent_sdk"
+                        assert alias.name != "anthropic"
+                        assert not alias.name.startswith("anthropic.")
+
+    def test_core_guard_imports_with_peer_unimportable(self) -> None:
+        program = """
+import sys
+
+class _Blocked:
+    def find_module(self, name, path=None):
+        return self.find_spec(name, path)
+
+    def find_spec(self, name, path=None, target=None):
+        blocked = (
+            "anthropic",
+            "claude_agent_sdk",
+        )
+        if name in blocked or name.startswith("anthropic.") or name.startswith("claude_agent_sdk."):
+            raise ImportError(name + " is blocked for this test")
+        return None
+
+sys.meta_path.insert(0, _Blocked())
+
+import arcjet.guard
+assert callable(arcjet.guard.guard)
+assert "anthropic" not in sys.modules
+assert "claude_agent_sdk" not in sys.modules
+
+import arcjet.guard.claude_managed_agents as adapter
+assert callable(adapter.guard_custom_tool)
+assert callable(adapter.guard_events)
+assert callable(adapter.claude_managed_agents_context)
+assert adapter.__all__ == [
+    "guard_custom_tool",
+    "guard_events",
+    "claude_managed_agents_context",
+]
+assert not hasattr(adapter, "guard_tool")
+assert not hasattr(adapter, "guard_hooks")
+assert not hasattr(adapter, "guard_inbound")
+print("ok")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", program],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "ok"
+
+
+class TestClaudeManagedAgentsContext:
+    def test_prefers_correlation_id_then_session_id(
+        self, reset_sequence_context
+    ) -> None:
+        ctx = claude_managed_agents_context(
+            {"correlation_id": "corr", "session_id": "sess"}
+        )
+        assert ctx.correlation_id == "corr"
+
+        ctx = claude_managed_agents_context({"session_id": "sess"})
+        assert ctx.correlation_id == "sess"
+
+    def test_accepts_camel_case_aliases(self, reset_sequence_context) -> None:
+        ctx = claude_managed_agents_context({"sessionId": "sess"})
+        assert ctx.correlation_id == "sess"
+
+    def test_never_reads_anthropic_session_or_event_id(
+        self, reset_sequence_context
+    ) -> None:
+        ctx = claude_managed_agents_context(
+            {"id": "ses_anthropic", "event_id": "sevt_1", "eventId": "sevt_2"}
+        )
+        assert ctx.correlation_id is None
+        assert ctx.metadata is None
+
+    def test_never_reads_id_off_an_anthropic_shaped_object(
+        self, reset_sequence_context
+    ) -> None:
+        session = SimpleNamespace(id="ses_01XYZ", status="idle")
+        ctx = claude_managed_agents_context(session)
+        assert ctx.correlation_id is None
+
+    def test_never_reads_trace_id(self, reset_sequence_context) -> None:
+        ctx = claude_managed_agents_context({"trace_id": "tr_minted", "traceId": "tr2"})
+        assert ctx.correlation_id is None
+
+    def test_never_mints_when_nothing_is_present(self, reset_sequence_context) -> None:
+        ctx = claude_managed_agents_context({})
+        assert ctx.correlation_id is None
+        assert isinstance(ctx, ClaudeManagedAgentsContext)
+
+    def test_falls_back_to_ambient_sequence(self, reset_sequence_context) -> None:
+        with arcjet_sequence(correlation_id="from-sequence"):
+            ctx = claude_managed_agents_context({})
+        assert ctx.correlation_id == "from-sequence"
+
+    def test_skips_invalid_then_uses_next(self, reset_sequence_context) -> None:
+        ctx = claude_managed_agents_context(
+            {"correlation_id": "not\nvalid", "session_id": "sess"}
+        )
+        assert ctx.correlation_id == "sess"
+
+    def test_explicit_kwargs_are_last_resort(self, reset_sequence_context) -> None:
+        ctx = claude_managed_agents_context(
+            {"session_id": "from-ctx"},
+            correlation_id="from-kw",
+        )
+        assert ctx.correlation_id == "from-ctx"
+        ctx = claude_managed_agents_context({}, session_id="from-kw")
+        assert ctx.correlation_id == "from-kw"
+
+    def test_caller_session_is_metadata_not_an_anthropic_id(
+        self, reset_sequence_context
+    ) -> None:
+        ctx = claude_managed_agents_context({"session_id": "app-owned"})
+        assert ctx.metadata is not None
+        assert ctx.metadata["claude-managed-agents.session"] == "app-owned"
+
+
+class TestDenialPayload:
+    def test_rate_limit_is_retryable_and_may_include_retry_after(self) -> None:
+        decision = make_deny_decision(
+            reason="RATE_LIMIT",
+            results=(
+                RuleResultTokenBucket(
+                    conclusion="DENY",
+                    reset_at_unix_seconds=2_000_000_000,
+                ),
+            ),
+        )
+        payload = denial_result(decision)
+        assert payload["arcjetDenied"] is True
+        assert payload["reason"] == "RATE_LIMIT"
+        assert payload["retryable"] is True
+        assert "retryAfterSeconds" in payload
+
+    def test_unavailable_is_retryable_with_fixed_backoff(self) -> None:
+        payload = unavailable_result()
+        assert payload == {
+            "arcjetDenied": True,
+            "reason": "ERROR",
+            "message": "Arcjet security check could not be completed; please retry later.",
+            "retryable": True,
+            "retryAfterSeconds": UNAVAILABLE_RETRY_AFTER_SECONDS,
+        }
+
+    def test_custom_tool_result_uses_real_events_schema(self) -> None:
+        event = custom_tool_result_event(
+            custom_tool_use_id="sevt_abc",
+            payload=unavailable_result(),
+            session_thread_id="thr_1",
+        )
+        assert event["type"] == "user.custom_tool_result"
+        assert event["custom_tool_use_id"] == "sevt_abc"
+        assert event["is_error"] is True
+        assert event["session_thread_id"] == "thr_1"
+        assert event["content"][0]["type"] == "text"
+        parsed = json.loads(event["content"][0]["text"])
+        assert parsed["arcjetDenied"] is True
+
+    def test_retry_after_ignores_allow_results_with_reset_at(self) -> None:
+        decision = make_deny_decision(
+            reason="RATE_LIMIT",
+            results=(
+                RuleResultTokenBucket(
+                    conclusion="ALLOW",
+                    reset_at_unix_seconds=9_999_999_999,
+                ),
+                RuleResultTokenBucket(
+                    conclusion="DENY",
+                    reset_at_unix_seconds=2_000_000_000,
+                ),
+            ),
+        )
+        assert retry_after_seconds(decision) is not None
+        payload = denial_result(decision)
+        assert "retryAfterSeconds" in payload
+
+
+class TestInboundGate:
+    def test_user_message_is_selected_from_events_and_initial_events(self) -> None:
+        events = [
+            {"type": "user.interrupt"},
+            _user_message("one"),
+            {"type": "user.custom_tool_result", "custom_tool_use_id": "x"},
+        ]
+        initial = [_user_message("two")]
+        found = inbound_events(events, initial)
+        assert [message_arguments(e)["prompt"] for e in found] == ["one", "two"]
+
+    def test_deny_does_not_call_send(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        send = RecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        with pytest.raises(ArcjetDeniedError):
+            wrapped("ses_anthropic", events=[_user_message("inject")])
+        assert send.calls == []
+        assert client.captures[0]["metadata"]["outcome"] == "denied"
+
+    def test_allow_calls_send(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        send = RecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        result = wrapped("ses_anthropic", events=[_user_message("hello")])
+        assert result == "sent"
+        assert len(send.calls) == 1
+        assert send.calls[0][0] == "ses_anthropic"
+
+    def test_initial_events_are_gated_before_create_shaped_send(
+        self, reset_sequence_context
+    ) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        send = RecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        with pytest.raises(ArcjetDeniedError):
+            wrapped(initial_events=[_user_message("seed")])
+        assert send.calls == []
+
+    def test_non_message_events_pass_through(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        send = RecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        wrapped(
+            "ses_1",
+            events=[
+                {
+                    "type": "user.custom_tool_result",
+                    "custom_tool_use_id": "sevt_1",
+                    "content": [{"type": "text", "text": "ok"}],
+                }
+            ],
+        )
+        assert len(send.calls) == 1
+        assert client.guards == []
+
+    def test_unavailable_fail_closed_does_not_send(
+        self, reset_sequence_context
+    ) -> None:
+        client = StubGuardClient(exception=RuntimeError("down"))
+        send = RecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        with pytest.raises(ArcjetUnavailableError):
+            wrapped("ses_1", events=[_user_message("hello")])
+        assert send.calls == []
+
+    def test_unavailable_allow_proceeds(self, reset_sequence_context) -> None:
+        client = StubGuardClient(exception=RuntimeError("down"))
+        send = RecordingSend()
+        wrapped = guard_events(
+            guard=client,
+            send=send,
+            action="message.received",
+            on_guard_error="allow",
+        )
+        wrapped("ses_1", events=[_user_message("hello")])
+        assert len(send.calls) == 1
+
+    def test_failed_open_fail_closed(self, reset_sequence_context) -> None:
+        decision = make_allow_decision(
+            results=(RuleResultError(code="TIMEOUT", message="deadline"),)
+        )
+        client = StubGuardClient(decision=decision)
+        send = RecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        with pytest.raises(ArcjetUnavailableError):
+            wrapped("ses_1", events=[_user_message("hello")])
+        assert send.calls == []
+
+    def test_never_uses_anthropic_session_id_as_correlation(
+        self, reset_sequence_context
+    ) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        send = RecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        wrapped("ses_01ANTHROPIC", events=[_user_message("hello")])
+        assert client.guards[0]["correlation_id"] is None
+
+    def test_async_send_is_awaited(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        send = AsyncRecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        result = asyncio.run(wrapped("ses_1", events=[_user_message("hello")]))
+        assert result == "sent"
+        assert len(send.calls) == 1
+
+    def test_evaluate_reads_prompt_text(self, reset_sequence_context) -> None:
+        seen: list[Mapping[str, Any]] = []
+
+        def actor(arguments: Mapping[str, Any]) -> str:
+            seen.append(dict(arguments))
+            return "user-1"
+
+        client = StubGuardClient(decision=make_allow_decision())
+        verdict = asyncio.run(
+            evaluate_user_message(
+                _user_message("please help"),
+                _events_config(guard=client, actor=actor),
+            )
+        )
+        assert verdict.deny is False
+        assert seen[0]["prompt"] == "please help"
+        assert client.guards[0]["actor"] == "user-1"
+
+
+class TestCustomToolGate:
+    def test_deny_does_not_execute_and_sends_real_result(
+        self, reset_sequence_context
+    ) -> None:
+        executed: list[Any] = []
+
+        def run(event: Any) -> str:
+            executed.append(event)
+            return "sent-email"
+
+        client = StubGuardClient(decision=make_deny_decision())
+        send = RecordingSend()
+        handle = guard_custom_tool(guard=client, run=run, action="email.sent")
+        event = _custom_tool_use()
+        result = asyncio.run(handle(event, send=send, session_id="ses_1"))
+        assert result is None
+        assert executed == []
+        assert len(send.calls) == 1
+        sent = send.calls[0][1]["events"][0]
+        assert sent["type"] == "user.custom_tool_result"
+        assert sent["custom_tool_use_id"] == "sevt_tool_1"
+        assert sent["is_error"] is True
+        payload = json.loads(sent["content"][0]["text"])
+        assert payload["arcjetDenied"] is True
+        assert payload["reason"] == "RATE_LIMIT"
+
+    def test_allow_executes_and_does_not_send(self, reset_sequence_context) -> None:
+        executed: list[Any] = []
+
+        def run(event: Any) -> str:
+            executed.append(_arguments_from_event(event))
+            return "ok"
+
+        client = StubGuardClient(decision=make_allow_decision())
+        send = RecordingSend()
+        handle = guard_custom_tool(guard=client, run=run, action="email.sent")
+        result = asyncio.run(handle(_custom_tool_use(), send=send, session_id="ses_1"))
+        assert result == "ok"
+        assert executed == [{"to": "a@example.com", "body": "hi"}]
+        assert send.calls == []
+
+    def test_fail_closed_sends_unavailable_and_does_not_run(
+        self, reset_sequence_context
+    ) -> None:
+        executed: list[Any] = []
+
+        def run(event: Any) -> str:
+            executed.append(event)
+            return "ok"
+
+        client = StubGuardClient(exception=RuntimeError("down"))
+        send = RecordingSend()
+        handle = guard_custom_tool(guard=client, run=run, action="email.sent")
+        asyncio.run(handle(_custom_tool_use(), send=send, session_id="ses_1"))
+        assert executed == []
+        sent = send.calls[0][1]["events"][0]
+        assert sent["type"] == "user.custom_tool_result"
+        payload = json.loads(sent["content"][0]["text"])
+        assert payload["reason"] == "ERROR"
+        assert payload["retryable"] is True
+
+    def test_echoes_session_thread_id(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        send = RecordingSend()
+        handle = guard_custom_tool(
+            guard=client, run=lambda _e: "x", action="email.sent"
+        )
+        asyncio.run(
+            handle(
+                _custom_tool_use(session_thread_id="thr_9"),
+                send=send,
+                session_id="ses_1",
+            )
+        )
+        assert send.calls[0][1]["events"][0]["session_thread_id"] == "thr_9"
+
+    def test_never_mints_correlation(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        verdict = asyncio.run(
+            evaluate_custom_tool(_custom_tool_use(), _tool_config(guard=client))
+        )
+        assert verdict.deny is True
+        assert client.guards[0]["correlation_id"] is None
+
+    def test_caller_owned_session_is_used(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        send = RecordingSend()
+        handle = guard_custom_tool(
+            guard=client,
+            run=lambda _e: "x",
+            action="email.sent",
+            session_id="app-owned",
+        )
+        asyncio.run(handle(_custom_tool_use(), send=send, session_id="ses_1"))
+        assert client.guards[0]["correlation_id"] == "app-owned"
+
+    def test_never_reads_anthropic_event_id_as_correlation(
+        self, reset_sequence_context
+    ) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        asyncio.run(
+            evaluate_custom_tool(
+                _custom_tool_use(event_id="sevt_minted"),
+                _tool_config(guard=client),
+            )
+        )
+        assert client.guards[0]["correlation_id"] is None
+
+    def test_worker_tool_run_deny_does_not_execute(
+        self, reset_sequence_context
+    ) -> None:
+        executed: list[Any] = []
+
+        class _Tool:
+            name = "lookup"
+
+            def run(self, arguments: Mapping[str, Any]) -> str:
+                executed.append(dict(arguments))
+                return "ran"
+
+        client = StubGuardClient(decision=make_deny_decision())
+        guarded = guard_custom_tool(
+            guard=client, tool=_Tool(), action="order.looked-up"
+        )
+        assert getattr(guarded, _GUARD_BRAND) is True
+        result = guarded.run({"order_id": "1"})
+        assert executed == []
+        parsed = json.loads(result)
+        assert parsed["arcjetDenied"] is True
+
+    def test_worker_tool_already_branded_is_skipped(
+        self, reset_sequence_context
+    ) -> None:
+        class _Tool:
+            name = "lookup"
+            run = staticmethod(lambda arguments: "ok")
+
+        tool = _Tool()
+        object.__setattr__(tool, _GUARD_BRAND, True)
+        client = StubGuardClient(decision=make_deny_decision())
+        guarded = guard_custom_tool(guard=client, tool=tool, action="order.looked-up")
+        assert guarded is tool
+
+    def test_denial_event_matches_evaluate(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        event = _custom_tool_use()
+        verdict = asyncio.run(evaluate_custom_tool(event, _tool_config(guard=client)))
+        body = denial_event(event, verdict)
+        assert body["type"] == "user.custom_tool_result"
+        assert body["custom_tool_use_id"] == "sevt_tool_1"
+        assert body["is_error"] is True
+
+
+class TestGuardValidation:
+    def test_invalid_on_guard_error_is_refused(self) -> None:
+        with pytest.raises(ArcjetMisconfiguration, match="on_guard_error"):
+            guard_custom_tool(
+                guard=StubGuardClient(),
+                run=lambda _e: None,
+                action="x.done",
+                on_guard_error="maybe",  # type: ignore[arg-type]
+            )
+        with pytest.raises(ArcjetMisconfiguration, match="on_guard_error"):
+            guard_events(
+                guard=StubGuardClient(),
+                send=lambda *_a, **_k: None,
+                action="x.done",
+                on_guard_error="maybe",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_correlation_id_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="printable ASCII"):
+            guard_custom_tool(
+                guard=StubGuardClient(),
+                run=lambda _e: None,
+                action="x.done",
+                correlation_id="not\nvalid",
+            )
+
+    def test_run_or_tool_is_required(self) -> None:
+        with pytest.raises(TypeError, match="run= or tool="):
+            guard_custom_tool(guard=StubGuardClient(), action="x.done")
+
+    def test_send_must_be_callable(self) -> None:
+        with pytest.raises(TypeError, match="send callable"):
+            guard_events(
+                guard=StubGuardClient(),
+                send=object(),
+                action="x.done",
+            )
+
+    def test_empty_action_is_refused(self) -> None:
+        with pytest.raises(ArcjetMisconfiguration, match="non-empty action"):
+            guard_events(
+                guard=StubGuardClient(),
+                send=lambda *_a, **_k: None,
+                action="",
+            )
+        with pytest.raises(ArcjetMisconfiguration, match="non-empty action"):
+            guard_custom_tool(
+                guard=StubGuardClient(),
+                run=lambda _e: None,
+                action="",
+            )
+
+    def test_object_shaped_user_message_is_gated(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_deny_decision())
+        send = RecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+        event = SimpleNamespace(
+            type="user.message",
+            content=[SimpleNamespace(type="text", text="hello")],
+        )
+        with pytest.raises(ArcjetDeniedError):
+            wrapped("ses_1", events=[event])
+        assert send.calls == []
+
+
+class TestMissingPeer:
+    def test_load_anthropic_names_what_to_install(self) -> None:
+        if anthropic_present():
+            pytest.skip("anthropic is installed in this environment")
+        with pytest.raises(ImportError, match=r"arcjet\[claude-managed-agents\]"):
+            load_anthropic()
+
+    def test_wrap_does_not_require_the_peer(self) -> None:
+        if anthropic_present():
+            pytest.skip("anthropic is installed in this environment")
+        send = RecordingSend()
+        handle = guard_custom_tool(
+            guard=StubGuardClient(decision=make_allow_decision()),
+            run=lambda _e: "ok",
+            action="x.done",
+        )
+        result = asyncio.run(handle(_custom_tool_use(), send=send, session_id="ses_1"))
+        assert result == "ok"
+
+
+class TestVersionFloor:
+    def test_release_parsing(self) -> None:
+        assert _release("0.92.0") == (0, 92, 0)
+        assert _release("0.92.0rc1") == (0, 92, 0)
+        assert _release("1.3.0") == (1, 3, 0)
+        assert _release("weird") == ()
+
+    def test_below_the_floor_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(import_module, "_installed_version", lambda: "0.91.0")
+        with pytest.raises(ArcjetMisconfiguration, match="needs anthropic >= 0.92.0"):
+            import_module._require_anthropic()
+
+    def test_at_or_above_the_floor_is_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for installed in ("0.92.0", "0.97.0", "1.3.0"):
+            monkeypatch.setattr(
+                import_module, "_installed_version", lambda v=installed: v
+            )
+            import_module._require_anthropic()
+
+    def test_absent_peer_is_left_to_the_import(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(import_module, "_installed_version", lambda: None)
+        import_module._require_anthropic()
+
+
+def test_public_exports_are_only_the_locked_names() -> None:
+    from arcjet.guard import claude_managed_agents as adapter
+
+    assert adapter.__all__ == [
+        "guard_custom_tool",
+        "guard_events",
+        "claude_managed_agents_context",
+    ]
+    assert not hasattr(adapter, "guard_tool")
+    assert not hasattr(adapter, "guard_hooks")
+    assert not hasattr(adapter, "guard_inbound")
+
+
+def test_brand_constant_is_stable() -> None:
+    assert _GUARD_BRAND == "_arcjet_guarded"
+
+
+def test_payload_from_block_uses_deny_or_unavailable() -> None:
+    deny = payload_from_block(make_deny_decision())
+    assert deny["reason"] == "RATE_LIMIT"
+    assert payload_from_block(None)["reason"] == "ERROR"
+    assert dumps_denial(deny).startswith("{")

--- a/tests/unit/guard/test_claude_managed_agents.py
+++ b/tests/unit/guard/test_claude_managed_agents.py
@@ -27,19 +27,31 @@ from arcjet._errors import ArcjetMisconfiguration
 from arcjet.guard import arcjet_sequence
 from arcjet.guard._errors import ArcjetDeniedError, ArcjetUnavailableError
 from arcjet.guard._types import RuleResultError, RuleResultTokenBucket
+from arcjet.guard.claude_managed_agents import _denial as denial_module
 from arcjet.guard.claude_managed_agents import _import as import_module
+from arcjet.guard.claude_managed_agents import _tool as tool_module
 from arcjet.guard.claude_managed_agents import (
     claude_managed_agents_context,
     guard_custom_tool,
     guard_events,
 )
-from arcjet.guard.claude_managed_agents._context import ClaudeManagedAgentsContext
+from arcjet.guard.claude_managed_agents._common import (
+    _GUARD_BRAND,
+    PHASE_METADATA_KEY,
+    TOOL_METADATA_KEY,
+)
+from arcjet.guard.claude_managed_agents._context import (
+    SESSION_METADATA_KEY,
+    ClaudeManagedAgentsContext,
+)
 from arcjet.guard.claude_managed_agents._denial import (
     UNAVAILABLE_RETRY_AFTER_SECONDS,
+    WorkerToolDenied,
     custom_tool_result_event,
     denial_result,
     dumps_denial,
     payload_from_block,
+    raise_worker_denial,
     retry_after_seconds,
     unavailable_result,
 )
@@ -55,8 +67,8 @@ from arcjet.guard.claude_managed_agents._import import (
     load_anthropic,
 )
 from arcjet.guard.claude_managed_agents._tool import (
-    _GUARD_BRAND,
     _arguments_from_event,
+    _invoke_run,
     _ToolConfig,
     denial_event,
     evaluate_custom_tool,
@@ -149,6 +161,21 @@ class AsyncRecordingSend:
     ) -> str:
         self.calls.append((session_id, {"events": events, **kwargs}))
         return "sent"
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _worker_denial_type() -> type[BaseException]:
+    return import_module.load_tool_error() or WorkerToolDenied
+
+
+def _denial_content(exc: BaseException) -> str:
+    content = getattr(exc, "content", None)
+    if isinstance(content, str):
+        return content
+    return str(exc)
 
 
 class TestSourceIsolation:
@@ -371,7 +398,7 @@ class TestInboundGate:
         send = RecordingSend()
         wrapped = guard_events(guard=client, send=send, action="message.received")
         with pytest.raises(ArcjetDeniedError):
-            wrapped("ses_anthropic", events=[_user_message("inject")])
+            _run(wrapped("ses_anthropic", events=[_user_message("inject")]))
         assert send.calls == []
         assert client.captures[0]["metadata"]["outcome"] == "denied"
 
@@ -379,7 +406,7 @@ class TestInboundGate:
         client = StubGuardClient(decision=make_allow_decision())
         send = RecordingSend()
         wrapped = guard_events(guard=client, send=send, action="message.received")
-        result = wrapped("ses_anthropic", events=[_user_message("hello")])
+        result = _run(wrapped("ses_anthropic", events=[_user_message("hello")]))
         assert result == "sent"
         assert len(send.calls) == 1
         assert send.calls[0][0] == "ses_anthropic"
@@ -391,22 +418,24 @@ class TestInboundGate:
         send = RecordingSend()
         wrapped = guard_events(guard=client, send=send, action="message.received")
         with pytest.raises(ArcjetDeniedError):
-            wrapped(initial_events=[_user_message("seed")])
+            _run(wrapped(initial_events=[_user_message("seed")]))
         assert send.calls == []
 
     def test_non_message_events_pass_through(self, reset_sequence_context) -> None:
         client = StubGuardClient(decision=make_deny_decision())
         send = RecordingSend()
         wrapped = guard_events(guard=client, send=send, action="message.received")
-        wrapped(
-            "ses_1",
-            events=[
-                {
-                    "type": "user.custom_tool_result",
-                    "custom_tool_use_id": "sevt_1",
-                    "content": [{"type": "text", "text": "ok"}],
-                }
-            ],
+        _run(
+            wrapped(
+                "ses_1",
+                events=[
+                    {
+                        "type": "user.custom_tool_result",
+                        "custom_tool_use_id": "sevt_1",
+                        "content": [{"type": "text", "text": "ok"}],
+                    }
+                ],
+            )
         )
         assert len(send.calls) == 1
         assert client.guards == []
@@ -418,7 +447,7 @@ class TestInboundGate:
         send = RecordingSend()
         wrapped = guard_events(guard=client, send=send, action="message.received")
         with pytest.raises(ArcjetUnavailableError):
-            wrapped("ses_1", events=[_user_message("hello")])
+            _run(wrapped("ses_1", events=[_user_message("hello")]))
         assert send.calls == []
 
     def test_unavailable_allow_proceeds(self, reset_sequence_context) -> None:
@@ -430,7 +459,7 @@ class TestInboundGate:
             action="message.received",
             on_guard_error="allow",
         )
-        wrapped("ses_1", events=[_user_message("hello")])
+        _run(wrapped("ses_1", events=[_user_message("hello")]))
         assert len(send.calls) == 1
 
     def test_failed_open_fail_closed(self, reset_sequence_context) -> None:
@@ -441,7 +470,7 @@ class TestInboundGate:
         send = RecordingSend()
         wrapped = guard_events(guard=client, send=send, action="message.received")
         with pytest.raises(ArcjetUnavailableError):
-            wrapped("ses_1", events=[_user_message("hello")])
+            _run(wrapped("ses_1", events=[_user_message("hello")]))
         assert send.calls == []
 
     def test_never_uses_anthropic_session_id_as_correlation(
@@ -450,7 +479,7 @@ class TestInboundGate:
         client = StubGuardClient(decision=make_allow_decision())
         send = RecordingSend()
         wrapped = guard_events(guard=client, send=send, action="message.received")
-        wrapped("ses_01ANTHROPIC", events=[_user_message("hello")])
+        _run(wrapped("ses_01ANTHROPIC", events=[_user_message("hello")]))
         assert client.guards[0]["correlation_id"] is None
 
     def test_async_send_is_awaited(self, reset_sequence_context) -> None:
@@ -494,7 +523,7 @@ class TestCustomToolGate:
         send = RecordingSend()
         handle = guard_custom_tool(guard=client, run=run, action="email.sent")
         event = _custom_tool_use()
-        result = asyncio.run(handle(event, send=send, session_id="ses_1"))
+        result = asyncio.run(handle(event, send=send, anthropic_session_id="ses_1"))
         assert result is None
         assert executed == []
         assert len(send.calls) == 1
@@ -516,7 +545,7 @@ class TestCustomToolGate:
         client = StubGuardClient(decision=make_allow_decision())
         send = RecordingSend()
         handle = guard_custom_tool(guard=client, run=run, action="email.sent")
-        result = asyncio.run(handle(_custom_tool_use(), send=send, session_id="ses_1"))
+        result = asyncio.run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
         assert result == "ok"
         assert executed == [{"to": "a@example.com", "body": "hi"}]
         assert send.calls == []
@@ -533,7 +562,7 @@ class TestCustomToolGate:
         client = StubGuardClient(exception=RuntimeError("down"))
         send = RecordingSend()
         handle = guard_custom_tool(guard=client, run=run, action="email.sent")
-        asyncio.run(handle(_custom_tool_use(), send=send, session_id="ses_1"))
+        asyncio.run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
         assert executed == []
         sent = send.calls[0][1]["events"][0]
         assert sent["type"] == "user.custom_tool_result"
@@ -551,7 +580,7 @@ class TestCustomToolGate:
             handle(
                 _custom_tool_use(session_thread_id="thr_9"),
                 send=send,
-                session_id="ses_1",
+                anthropic_session_id="ses_1",
             )
         )
         assert send.calls[0][1]["events"][0]["session_thread_id"] == "thr_9"
@@ -573,7 +602,7 @@ class TestCustomToolGate:
             action="email.sent",
             session_id="app-owned",
         )
-        asyncio.run(handle(_custom_tool_use(), send=send, session_id="ses_1"))
+        asyncio.run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
         assert client.guards[0]["correlation_id"] == "app-owned"
 
     def test_never_reads_anthropic_event_id_as_correlation(
@@ -588,7 +617,7 @@ class TestCustomToolGate:
         )
         assert client.guards[0]["correlation_id"] is None
 
-    def test_worker_tool_run_deny_does_not_execute(
+    def test_worker_tool_call_deny_does_not_execute(
         self, reset_sequence_context
     ) -> None:
         executed: list[Any] = []
@@ -596,8 +625,8 @@ class TestCustomToolGate:
         class _Tool:
             name = "lookup"
 
-            def run(self, arguments: Mapping[str, Any]) -> str:
-                executed.append(dict(arguments))
+            def call(self, input: object) -> str:
+                executed.append(dict(input))  # type: ignore[arg-type]
                 return "ran"
 
         client = StubGuardClient(decision=make_deny_decision())
@@ -605,17 +634,32 @@ class TestCustomToolGate:
             guard=client, tool=_Tool(), action="order.looked-up"
         )
         assert getattr(guarded, _GUARD_BRAND) is True
-        result = guarded.run({"order_id": "1"})
+        with pytest.raises(_worker_denial_type()) as raised:
+            guarded.call({"order_id": "1"})
         assert executed == []
-        parsed = json.loads(result)
+        parsed = json.loads(_denial_content(raised.value))
         assert parsed["arcjetDenied"] is True
+
+    def test_worker_tool_without_call_is_refused(self) -> None:
+        class _JsShaped:
+            name = "lookup"
+
+            def run(self, arguments: Mapping[str, Any]) -> str:
+                return "ran"
+
+        with pytest.raises(TypeError, match="callable call"):
+            guard_custom_tool(
+                guard=StubGuardClient(),
+                tool=_JsShaped(),
+                action="order.looked-up",
+            )
 
     def test_worker_tool_already_branded_is_skipped(
         self, reset_sequence_context
     ) -> None:
         class _Tool:
             name = "lookup"
-            run = staticmethod(lambda arguments: "ok")
+            call = staticmethod(lambda arguments: "ok")
 
         tool = _Tool()
         object.__setattr__(tool, _GUARD_BRAND, True)
@@ -694,7 +738,7 @@ class TestGuardValidation:
             content=[SimpleNamespace(type="text", text="hello")],
         )
         with pytest.raises(ArcjetDeniedError):
-            wrapped("ses_1", events=[event])
+            _run(wrapped("ses_1", events=[event]))
         assert send.calls == []
 
 
@@ -714,7 +758,7 @@ class TestMissingPeer:
             run=lambda _e: "ok",
             action="x.done",
         )
-        result = asyncio.run(handle(_custom_tool_use(), send=send, session_id="ses_1"))
+        result = asyncio.run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
         assert result == "ok"
 
 
@@ -722,6 +766,7 @@ class TestVersionFloor:
     def test_release_parsing(self) -> None:
         assert _release("0.92.0") == (0, 92, 0)
         assert _release("0.92.0rc1") == (0, 92, 0)
+        assert _release("0.92") == (0, 92)
         assert _release("1.3.0") == (1, 3, 0)
         assert _release("weird") == ()
 
@@ -744,6 +789,282 @@ class TestVersionFloor:
     ) -> None:
         monkeypatch.setattr(import_module, "_installed_version", lambda: None)
         import_module._require_anthropic()
+
+
+class TestReviewFixes:
+    def test_sync_send_from_running_loop(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        send = RecordingSend()
+        wrapped = guard_events(guard=client, send=send, action="message.received")
+
+        async def inner() -> str:
+            return await wrapped("ses_1", events=[_user_message("hello")])
+
+        assert _run(inner()) == "sent"
+        assert len(send.calls) == 1
+
+    def test_second_events_wrap_is_skipped(self, reset_sequence_context) -> None:
+        send = RecordingSend()
+        first = guard_events(
+            guard=StubGuardClient(decision=make_allow_decision()),
+            send=send,
+            action="message.received",
+        )
+        second = guard_events(
+            guard=StubGuardClient(decision=make_deny_decision()),
+            send=first,
+            action="message.received",
+        )
+        assert second is first
+        _run(second("ses_1", events=[_user_message("hello")]))
+        assert len(send.calls) == 1
+
+    def test_reserved_metadata_is_not_overwritten(self, reset_sequence_context) -> None:
+        client = StubGuardClient(decision=make_allow_decision())
+        wrapped = guard_events(
+            guard=client,
+            send=RecordingSend(),
+            action="message.received",
+            session_id="app-owned",
+            metadata={
+                PHASE_METADATA_KEY: "forged",
+                SESSION_METADATA_KEY: "forged",
+            },
+        )
+        _run(wrapped("ses_1", events=[_user_message("hello")]))
+        meta = client.guards[0]["metadata"]
+        assert meta[PHASE_METADATA_KEY] == "inbound"
+        assert meta[SESSION_METADATA_KEY] == "app-owned"
+
+    def test_worker_tool_allow_runs_body(self, reset_sequence_context) -> None:
+        executed: list[Any] = []
+
+        class _Tool:
+            name = "lookup"
+
+            def call(self, input: object) -> str:
+                executed.append(dict(input))  # type: ignore[arg-type]
+                return "ran"
+
+        client = StubGuardClient(decision=make_allow_decision())
+        guarded = guard_custom_tool(
+            guard=client, tool=_Tool(), action="order.looked-up"
+        )
+        assert guarded.call({"order_id": "1"}) == "ran"
+        assert executed == [{"order_id": "1"}]
+
+    def test_worker_tool_allow_on_guard_error(self, reset_sequence_context) -> None:
+        executed: list[Any] = []
+
+        class _Tool:
+            name = "lookup"
+
+            def call(self, input: object) -> str:
+                executed.append(1)
+                return "ran"
+
+        client = StubGuardClient(exception=RuntimeError("down"))
+        guarded = guard_custom_tool(
+            guard=client,
+            tool=_Tool(),
+            action="order.looked-up",
+            on_guard_error="allow",
+        )
+        assert guarded.call({"order_id": "1"}) == "ran"
+        assert executed == [1]
+
+    def test_hosted_allow_on_guard_error(self, reset_sequence_context) -> None:
+        executed: list[Any] = []
+
+        def run(event: Any) -> str:
+            executed.append(event)
+            return "ok"
+
+        client = StubGuardClient(exception=RuntimeError("down"))
+        send = RecordingSend()
+        handle = guard_custom_tool(
+            guard=client,
+            run=run,
+            action="email.sent",
+            on_guard_error="allow",
+        )
+        assert (
+            _run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
+            == "ok"
+        )
+        assert executed
+        assert send.calls == []
+
+    def test_invoke_run_uses_signature_not_typeerror(
+        self, reset_sequence_context
+    ) -> None:
+        seen: list[Any] = []
+
+        def by_event(event: Any) -> str:
+            seen.append(("event", _arguments_from_event(event)))
+            return "e"
+
+        def by_input(input: Mapping[str, Any]) -> str:
+            seen.append(("input", dict(input)))
+            return "i"
+
+        def by_name_input(name: str, input: Mapping[str, Any]) -> str:
+            seen.append(("name_input", name, dict(input)))
+            return "n"
+
+        event = _custom_tool_use()
+        assert _invoke_run(by_event, event) == "e"
+        assert _invoke_run(by_input, event) == "i"
+        assert _invoke_run(by_name_input, event) == "n"
+        assert seen[0][0] == "event"
+        assert seen[1] == ("input", {"to": "a@example.com", "body": "hi"})
+        assert seen[2] == (
+            "name_input",
+            "send_email",
+            {"to": "a@example.com", "body": "hi"},
+        )
+
+    def test_typeerror_in_run_body_is_not_retried(
+        self, reset_sequence_context
+    ) -> None:
+        calls: list[int] = []
+
+        def run(event: Any) -> str:
+            calls.append(1)
+            raise TypeError("real failure")
+
+        handle = guard_custom_tool(
+            guard=StubGuardClient(decision=make_allow_decision()),
+            run=run,
+            action="email.sent",
+        )
+        with pytest.raises(TypeError, match="real failure"):
+            _run(handle(_custom_tool_use(), send=RecordingSend(), anthropic_session_id="ses_1"))
+        assert calls == [1]
+
+    def test_pydantic_shaped_custom_tool_use(self, reset_sequence_context) -> None:
+        executed: list[Any] = []
+
+        def run(event: Any) -> str:
+            executed.append(_arguments_from_event(event))
+            return "ok"
+
+        client = StubGuardClient(decision=make_allow_decision())
+        handle = guard_custom_tool(guard=client, run=run, action="email.sent")
+        event = SimpleNamespace(
+            type="agent.custom_tool_use",
+            id="sevt_obj",
+            name="send_email",
+            input={"to": "a@example.com"},
+            session_thread_id=None,
+        )
+        assert (
+            _run(handle(event, send=RecordingSend(), anthropic_session_id="ses_1"))
+            == "ok"
+        )
+        assert executed == [{"to": "a@example.com"}]
+        assert client.guards[0]["inputs"] is None
+        assert client.guards[0]["metadata"][TOOL_METADATA_KEY] == "send_email"
+
+    def test_denial_send_retries_then_succeeds(
+        self, reset_sequence_context, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(tool_module, "DENIAL_SEND_BACKOFF_SECONDS", (0, 0))
+
+        class FlakySend:
+            def __init__(self) -> None:
+                self.n = 0
+
+            def __call__(self, session_id: Any, *, events: Any = None, **kwargs: Any) -> str:
+                self.n += 1
+                if self.n < 3:
+                    raise ConnectionError("blip")
+                return "sent"
+
+        send = FlakySend()
+        handle = guard_custom_tool(
+            guard=StubGuardClient(decision=make_deny_decision()),
+            run=lambda _e: "x",
+            action="email.sent",
+        )
+        _run(handle(_custom_tool_use(), send=send, anthropic_session_id="ses_1"))
+        assert send.n == 3
+
+    def test_denial_send_retries_then_raises(
+        self, reset_sequence_context, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(tool_module, "DENIAL_SEND_BACKOFF_SECONDS", (0, 0))
+
+        class DeadSend:
+            def __call__(self, session_id: Any, *, events: Any = None, **kwargs: Any) -> str:
+                raise ConnectionError("down")
+
+        handle = guard_custom_tool(
+            guard=StubGuardClient(decision=make_deny_decision()),
+            run=lambda _e: "x",
+            action="email.sent",
+        )
+        with pytest.raises(ConnectionError, match="down"):
+            _run(handle(_custom_tool_use(), send=DeadSend(), anthropic_session_id="ses_1"))
+
+    def test_worker_denial_prefers_tool_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeToolError(Exception):
+            def __init__(self, content: str) -> None:
+                super().__init__(content)
+                self.content = content
+
+        monkeypatch.setattr(denial_module, "load_tool_error", lambda: FakeToolError)
+        with pytest.raises(FakeToolError) as raised:
+            raise_worker_denial(unavailable_result())
+        assert json.loads(raised.value.content)["arcjetDenied"] is True
+
+    def test_web_search_wrap_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        class _Search:
+            name = "web_search"
+
+            def call(self, input: object) -> str:
+                return "x"
+
+        with caplog.at_level("WARNING", logger="arcjet"):
+            guard_custom_tool(
+                guard=StubGuardClient(),
+                tool=_Search(),
+                action="search.ran",
+            )
+        assert any("web_search" in rec.message for rec in caplog.records)
+
+    def test_run_and_tool_together_are_refused(self) -> None:
+        class _Tool:
+            def call(self, input: object) -> str:
+                return "x"
+
+        with pytest.raises(TypeError, match="not both"):
+            guard_custom_tool(
+                guard=StubGuardClient(),
+                run=lambda _e: None,
+                tool=_Tool(),
+                action="x.done",
+            )
+
+    def test_async_worker_call_is_awaited(self, reset_sequence_context) -> None:
+        executed: list[Any] = []
+
+        class _Tool:
+            name = "lookup"
+
+            async def call(self, input: object) -> str:
+                executed.append(dict(input))  # type: ignore[arg-type]
+                return "ran"
+
+        guarded = guard_custom_tool(
+            guard=StubGuardClient(decision=make_allow_decision()),
+            tool=_Tool(),
+            action="order.looked-up",
+        )
+        assert _run(guarded.call({"order_id": "2"})) == "ran"
+        assert executed == [{"order_id": "2"}]
 
 
 def test_public_exports_are_only_the_locked_names() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,24 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "docstring-parser" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/40/8249e272c9bba8b4b5802f90717fcdb55996da243a712dca449f2d81c95b/anthropic-1.1.0.tar.gz", hash = "sha256:03d180143ca61177772a35350c78e6ff975b636fd226d221b122b1595f284f3e", size = 1132609, upload-time = "2026-08-26T17:14:53.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/9a/37a5d1913434913ed89bef960693870a1dd9478e76fd12e7b9f2c066270a/anthropic-1.1.0-py3-none-any.whl", hash = "sha256:babf7b217a6f289059a25ba4871c167411c747bbf233a4f1fb8ececc8a22f875", size = 1289646, upload-time = "2026-08-26T17:14:51.773Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -63,6 +81,9 @@ dependencies = [
 [package.optional-dependencies]
 claude-agent-sdk = [
     { name = "claude-agent-sdk" },
+]
+claude-managed-agents = [
+    { name = "anthropic" },
 ]
 langchain = [
     { name = "langchain-core" },
@@ -101,6 +122,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", marker = "extra == 'claude-managed-agents'", specifier = ">=0.92.0,<2" },
     { name = "arcjet-sensitive-info-rampart", marker = "extra == 'sensitive-info-rampart'", editable = "sensitive-info-rampart" },
     { name = "claude-agent-sdk", marker = "extra == 'claude-agent-sdk'", specifier = ">=0.2.127,<1" },
     { name = "connect-python", specifier = ">=0.8.1" },
@@ -112,7 +134,7 @@ requires-dist = [
     { name = "pyqwest", specifier = ">=0.9.0,<0.10.0" },
     { name = "wasmtime", specifier = ">=47.0.1,<47.1.0" },
 ]
-provides-extras = ["sensitive-info-rampart", "langchain", "langchain-agents", "openai-agents", "claude-agent-sdk"]
+provides-extras = ["sensitive-info-rampart", "langchain", "langchain-agents", "openai-agents", "claude-agent-sdk", "claude-managed-agents"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -398,6 +420,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/bd/ba760bd6c7bae939105e50df983eea65ec0cba86f748c4abbedb8abbd8eb/claude_agent_sdk-0.2.144-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e685e624f598249a215a2db57c3a2fbbea5a7f7078a4cc632e099dedca303a69", size = 97959616, upload-time = "2026-08-21T20:12:11.838Z" },
     { url = "https://files.pythonhosted.org/packages/0e/5a/946d37a573b52be868dbcac349fcdd2090b43ea31273d2ff7e71cfd6fd99/claude_agent_sdk-0.2.144-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:8fb664212f3eca5b0e4081f71ff8ccdf72b15e57609ff0c93e626bfea914360a", size = 102347684, upload-time = "2026-08-21T20:12:17.582Z" },
     { url = "https://files.pythonhosted.org/packages/00/bc/b3b859736291b73d3065a0eb69149f39fbbe61cd800087b085690f944df0/claude_agent_sdk-0.2.144-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:8aa83aa3ea4f51ca6db113a5fe27c10db25e2af99ba0eed140738141d99a0837", size = 103339972, upload-time = "2026-08-21T20:12:25.705Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/15/484ffc9205ff9e947f819e0e2204e377da37f87bf3526f37433c9f72027c/claude_agent_sdk-0.2.144-py3-none-win_amd64.whl", hash = "sha256:c6ecd3e8d4ae756c244513388f09f220734ea300395b9744779c96bb94b80a13", size = 103521738, upload-time = "2026-08-25T22:46:28.021Z" },
 ]
 
 [[package]]
@@ -628,6 +651,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `arcjet[claude-managed-agents]` for hosted Claude Managed Agents (REST+SSE, beta `managed-agents-2026-04-01`). This is **not** `arcjet.guard.claude_agent_sdk`: there is no PreToolUse, no `guard_tool`, and no `guard_inbound`.

Peer: `anthropic>=0.92.0,<2`. Public names: `guard_events`, `guard_custom_tool`, `claude_managed_agents_context`.

**Inbound** — gate `user.message` / `initial_events` before `sessions.events.send`. Always `await` the wrapper (including the sync client).

```python
from arcjet.guard import DetectPromptInjection, launch_arcjet
from arcjet.guard.claude_managed_agents import (
    claude_managed_agents_context,
    guard_custom_tool,
    guard_events,
)

aj = launch_arcjet(key=arcjet_key)
ctx = claude_managed_agents_context({"session_id": app_session_id})

send = guard_events(
    guard=aj,
    send=client.beta.sessions.events.send,
    action="message.received",
    rules=lambda arguments: [DetectPromptInjection()(arguments["prompt"])],
    correlation_id=ctx.correlation_id,
)

await send(
    session.id,
    events=[{"type": "user.message", "content": [{"type": "text", "text": user_text}]}],
)
```

**Hosted custom tool** — Guard runs before your `run`. On DENY the tool does not execute; the helper posts `user.custom_tool_result` with `is_error=True`. Wrap-time `session_id=` is caller-owned correlation. `anthropic_session_id=` is Anthropic's `ses_...`.

```python
handle = guard_custom_tool(
    guard=aj,
    run=send_email,
    action="email.sent",
    correlation_id=ctx.correlation_id,
)

# On agent.custom_tool_use:
await handle(event, send=send, anthropic_session_id=session.id)
```

**Self-hosted worker** — wrap `@beta_tool` `.call` (what `SessionToolRunner` invokes). On DENY the wrapper raises `ToolError` so the runner posts `is_error=True`.

```python
guarded = guard_custom_tool(guard=aj, tool=lookup, action="order.looked-up")
worker = client.beta.environments.work.worker(
    workdir="/workspace",
    tools=lambda env: [*beta_agent_toolset_20260401(env), guarded],
)
```

Cannot gate default `always_allow` cloud bash/read/write, or Anthropic-hosted `web_search` / `web_fetch`. HITL `always_ask` is not policy. Helpers default to `on_guard_error="deny"`. Context never mints and never uses Anthropic session/event ids as correlation.

Docs: https://docs.arcjet.com/guards/claude-managed-agents/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03d62a8c-783b-45a3-9cd2-fffd28ff73c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03d62a8c-783b-45a3-9cd2-fffd28ff73c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

