### PR TITLE
fix(analyze): report sensitive-info offsets as string indices

### DIFF
--- a/src/arcjet/_local.py
+++ b/src/arcjet/_local.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import importlib.resources as _res
 import json
 import threading
+from dataclasses import replace
 from typing import Callable, Iterable
 
 from arcjet._analyze import (
@@ -383,6 +384,52 @@ def _to_proto_entities(
     ]
 
 
+def _to_code_point_offsets(
+    value: str,
+    entities: list[DetectedSensitiveInfoEntity],
+) -> list[DetectedSensitiveInfoEntity]:
+    """Convert the UTF-8 byte offsets WASM reports into ``str`` indices.
+
+    ``DetectedSensitiveInfoEntity.start``/``end`` are documented as indices
+    into the value, and Python strings are indexed by code point. The component
+    counts bytes, so without this ``value[entity.start : entity.end]`` returns
+    the wrong substring for any value containing a non-ASCII character.
+
+    A span is only ever widened, never narrowed, so it still covers the whole
+    entity when an offset lands inside a character.
+    """
+    if not entities:
+        return []
+
+    # One pass over the value, recording the code point index that each byte
+    # offset corresponds to.
+    floors: dict[int, int] = {0: 0}
+    ceilings: dict[int, int] = {0: 0}
+    byte_offset = 0
+    for index, character in enumerate(value):
+        width = len(character.encode("utf-8"))
+        for inner in range(1, width):
+            # Inside a character: widen outwards in both directions.
+            floors[byte_offset + inner] = index
+            ceilings[byte_offset + inner] = index + 1
+        byte_offset += width
+        floors[byte_offset] = index + 1
+        ceilings[byte_offset] = index + 1
+
+    def resolve(offset: int, table: dict[int, int]) -> int:
+        # Offsets past the end clamp to it, so a span is always sliceable.
+        return table.get(offset, len(value))
+
+    return [
+        replace(
+            entity,
+            start=resolve(entity.start, floors),
+            end=max(resolve(entity.start, floors), resolve(entity.end, ceilings)),
+        )
+        for entity in entities
+    ]
+
+
 class WasmSensitiveInfoBackend:
     """Default sensitive-info backend backed by the arcjet-analyze WASM engine.
 
@@ -430,7 +477,14 @@ class WasmSensitiveInfoBackend:
 
             wasm_detect = _wrapped_detect
 
-        return component.detect_sensitive_info(value, config, detect=wasm_detect)
+        result = component.detect_sensitive_info(value, config, detect=wasm_detect)
+        # WASM reports UTF-8 byte offsets; the public dataclass is documented in
+        # string indices.
+        return replace(
+            result,
+            allowed=_to_code_point_offsets(value, result.allowed),
+            denied=_to_code_point_offsets(value, result.denied),
+        )
 
 
 # Module-level default backend instance, reused across evaluations.

--- a/tests/test_sensitive_info.py
+++ b/tests/test_sensitive_info.py
@@ -1063,3 +1063,36 @@ class TestWasmBackendSeparatorRuns:
         )
 
         assert len(result.denied) == 1
+
+
+class TestWasmBackendOffsets:
+    """The WASM component reports UTF-8 byte offsets.
+
+    ``DetectedSensitiveInfoEntity.start``/``end`` are documented as indices
+    into the value, and Python indexes strings by code point, so the backend
+    converts them. Without that, ``value[entity.start : entity.end]`` returns
+    the wrong substring as soon as the value contains a non-ASCII character.
+
+    Reserved test data only (RFC 2606 domain).
+    """
+
+    @pytest.mark.parametrize(
+        "prefix",
+        ["", "hello ", "Здравствуйте, ", "您好 ", "🙂🙂🙂🙂 ", "é" * 4 + " "],
+    )
+    def test_offsets_index_the_value_as_a_python_string(self, prefix: str) -> None:
+        from arcjet._local import WasmSensitiveInfoBackend
+
+        email = "victim@example.com"
+        value = f"{prefix}mail {email} end"
+
+        backend = WasmSensitiveInfoBackend()
+        result = backend.detect(
+            SensitiveInfoBackendContext(log=logging.getLogger(__name__)),
+            value,
+            SensitiveInfoEntitiesDeny([SensitiveInfoEntityEmail()]),
+        )
+
+        assert len(result.denied) == 1
+        entity = result.denied[0]
+        assert value[entity.start : entity.end] == email


### PR DESCRIPTION
`DetectedSensitiveInfoEntity.start`/`end` are documented as indices into the value, and Python indexes strings by code point — but the WASM component reports UTF-8 byte offsets and they were passed through unchanged. For any value containing a non-ASCII character, `value[entity.start : entity.end]` returned the wrong substring.

The WASM backend now converts them. A span is only ever widened, never narrowed, so it still covers the whole entity when an offset lands inside a character.

```python
# "你你 bob@a.io TAIL" — before
start=7, end=15   # value[7:15] == "o TAIL"
# after
start=3, end=11   # value[3:11] == "bob@a.io"
```

**This is a behaviour change** for reported offsets on non-ASCII values — from wrong-per-the-docs to correct. ASCII values are unaffected, which is most of them. These offsets are diagnostic: nothing in the SDK slices with them, so the change is limited to what callers see on the returned dataclass.

The JavaScript SDK has the equivalent change in arcjet/arcjet-js#6273. The Go SDK needs none — Go slices strings by byte, so the offsets are already the right unit there.
