### PR TITLE
test(analyze): cover allowed entity offsets as well as denied

### DIFF
--- a/tests/test_sensitive_info.py
+++ b/tests/test_sensitive_info.py
@@ -1096,3 +1096,32 @@ class TestWasmBackendOffsets:
         assert len(result.denied) == 1
         entity = result.denied[0]
         assert value[entity.start : entity.end] == email
+
+    @pytest.mark.parametrize(
+        "prefix",
+        ["", "hello ", "Здравствуйте, ", "您好 ", "🙂🙂🙂🙂 ", "é" * 4 + " "],
+    )
+    def test_allowed_offsets_index_the_value_as_a_python_string(
+        self, prefix: str
+    ) -> None:
+        """The conversion applies to ``allowed``, not just ``denied``.
+
+        An allow-list rule reports matching entities on ``allowed``, so
+        asserting only ``denied`` leaves half the conversion uncovered.
+        """
+        from arcjet._local import WasmSensitiveInfoBackend
+
+        email = "victim@example.com"
+        value = f"{prefix}mail {email} end"
+
+        backend = WasmSensitiveInfoBackend()
+        result = backend.detect(
+            SensitiveInfoBackendContext(log=logging.getLogger(__name__)),
+            value,
+            SensitiveInfoEntitiesAllow([SensitiveInfoEntityEmail()]),
+        )
+
+        assert len(result.allowed) == 1
+        assert not result.denied
+        entity = result.allowed[0]
+        assert value[entity.start : entity.end] == email


### PR DESCRIPTION
The byte-offset to string-index conversion in `WasmSensitiveInfoBackend.detect` is applied to both `allowed` and `denied`, but the regression test added in #241 only asserted `denied` — so half the conversion was untested.

An allow-list rule reports matching entities on `allowed` rather than `denied`, so the new case uses `SensitiveInfoEntitiesAllow`.

Verified non-vacuous: reverting just the `allowed` line and leaving `denied` converted fails the new test on every non-ASCII prefix.

This was raised in review on #241 and I pushed it too late to make the merge, hence the follow-up.
